### PR TITLE
Redact Redis and MongoDB credentials from logs (#15)

### DIFF
--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -1,3 +1,113 @@
 pub mod clickhouse;
 pub mod mongo;
 pub mod redis;
+
+/// Redacts URL userinfo (credentials) from every URL-like substring.
+///
+/// For each occurrence of a `scheme://user:password@` or `scheme://user@`
+/// section, the credentials are replaced with `***`, yielding `scheme://***@`.
+/// URLs without userinfo (`scheme://host...`) are left untouched, and so is any
+/// `@` that appears after the authority (for example inside a path).
+///
+/// This is intentionally implemented with plain string scanning (no regex, no
+/// extra dependencies): for every `://`, the authority section runs up to the
+/// next `/`, whitespace, or end of string; if it contains an `@`, everything
+/// between `://` and that `@` is treated as credentials and redacted.
+pub(crate) fn redact_userinfo(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut i = 0;
+
+    while i < s.len() {
+        match s[i..].find("://") {
+            Some(pos) => {
+                // Byte index just past the "://" scheme separator.
+                let sep = i + pos + 3;
+                result.push_str(&s[i..sep]);
+
+                // The authority section ends at the first '/', whitespace, or
+                // the end of the string.
+                let rest = &s[sep..];
+                let authority_end = rest
+                    .find(|c: char| c == '/' || c.is_whitespace())
+                    .map(|p| sep + p)
+                    .unwrap_or_else(|| s.len());
+
+                // If the authority contains an '@', everything before it is
+                // userinfo (credentials) and must be redacted.
+                match s[sep..authority_end].find('@') {
+                    Some(at_rel) => {
+                        let at = sep + at_rel;
+                        result.push_str("***@");
+                        i = at + 1;
+                    }
+                    None => {
+                        i = sep;
+                    }
+                }
+            }
+            None => {
+                result.push_str(&s[i..]);
+                break;
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_userinfo_user_and_password() {
+        assert_eq!(
+            redact_userinfo("mongodb://admin:s3cret@localhost:27017"),
+            "mongodb://***@localhost:27017"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_username_only() {
+        assert_eq!(
+            redact_userinfo("redis://user@localhost:6379"),
+            "redis://***@localhost:6379"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_password_only() {
+        assert_eq!(
+            redact_userinfo("redis://:s3cret@localhost:6379"),
+            "redis://***@localhost:6379"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_no_userinfo_unchanged() {
+        let input = "redis://localhost:6379/3";
+        assert_eq!(redact_userinfo(input), input);
+    }
+
+    #[test]
+    fn test_redact_userinfo_multiple_urls() {
+        assert_eq!(
+            redact_userinfo("redis://u:p@h1:6379 and mongodb://a:b@h2:27017"),
+            "redis://***@h1:6379 and mongodb://***@h2:27017"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_at_in_path_not_redacted() {
+        // The '@' appears after the authority (inside the path); it must not be
+        // treated as userinfo.
+        let input = "redis://localhost:6379/some@path";
+        assert_eq!(redact_userinfo(input), input);
+    }
+
+    #[test]
+    fn test_redact_userinfo_plain_text_unchanged() {
+        let input = "no url here";
+        assert_eq!(redact_userinfo(input), input);
+    }
+}

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -12,7 +12,9 @@ pub mod redis;
 /// This is intentionally implemented with plain string scanning (no regex, no
 /// extra dependencies): for every `://`, the authority section runs up to the
 /// next `/`, whitespace, or end of string; if it contains an `@`, everything
-/// between `://` and that `@` is treated as credentials and redacted.
+/// between `://` and its LAST `@` is treated as credentials and redacted, so
+/// an unencoded `@` inside a password cannot leak a fragment. Credentials
+/// containing whitespace are not supported (invalid in a URL authority).
 pub(crate) fn redact_userinfo(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut i = 0;
@@ -32,9 +34,10 @@ pub(crate) fn redact_userinfo(s: &str) -> String {
                     .map(|p| sep + p)
                     .unwrap_or_else(|| s.len());
 
-                // If the authority contains an '@', everything before it is
-                // userinfo (credentials) and must be redacted.
-                match s[sep..authority_end].find('@') {
+                // If the authority contains an '@', everything before the
+                // LAST one is userinfo (credentials) and must be redacted —
+                // rfind so an unencoded '@' inside a password is covered too.
+                match s[sep..authority_end].rfind('@') {
                     Some(at_rel) => {
                         let at = sep + at_rel;
                         result.push_str("***@");
@@ -103,6 +106,16 @@ mod tests {
         // treated as userinfo.
         let input = "redis://localhost:6379/some@path";
         assert_eq!(redact_userinfo(input), input);
+    }
+
+    #[test]
+    fn test_redact_userinfo_unencoded_at_in_password() {
+        // An unencoded '@' inside the password must not leak a fragment: the
+        // LAST '@' in the authority bounds the userinfo.
+        assert_eq!(
+            redact_userinfo("redis://user:p@ss@localhost:6379"),
+            "redis://***@localhost:6379"
+        );
     }
 
     #[test]

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -2,19 +2,18 @@ pub mod clickhouse;
 pub mod mongo;
 pub mod redis;
 
-/// Redacts URL userinfo (credentials) from every URL-like substring.
+/// Redacts URL userinfo (credentials) from every URL-like substring inside a
+/// larger text (log lines, driver error messages).
 ///
-/// For each occurrence of a `scheme://user:password@` or `scheme://user@`
-/// section, the credentials are replaced with `***`, yielding `scheme://***@`.
-/// URLs without userinfo (`scheme://host...`) are left untouched, and so is any
-/// `@` that appears after the authority (for example inside a path).
-///
-/// This is intentionally implemented with plain string scanning (no regex, no
-/// extra dependencies): for every `://`, the authority section runs up to the
-/// next `/`, whitespace, or end of string; if it contains an `@`, everything
-/// between `://` and its LAST `@` is treated as credentials and redacted, so
-/// an unencoded `@` inside a password cannot leak a fragment. Credentials
-/// containing whitespace are not supported (invalid in a URL authority).
+/// For each occurrence of `scheme://`, the candidate section runs up to the
+/// next whitespace (or end of string); if it contains an `@`, everything
+/// between `://` and its LAST `@` is treated as credentials and replaced with
+/// `***`. Bounding by the last `@` is deliberately CONSERVATIVE: a raw
+/// credential may contain `/`, `:`, or `@` (RedisConfig::url and env-provided
+/// URIs embed them verbatim), so the scan prefers over-redacting a legitimate
+/// path `@` (`scheme://host/some@path` → `scheme://***@path`) to ever leaking
+/// a password fragment. Credentials containing whitespace cannot be recovered
+/// from mid-text scanning; whole-string values should use [`redact_uri`].
 pub(crate) fn redact_userinfo(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut i = 0;
@@ -26,18 +25,16 @@ pub(crate) fn redact_userinfo(s: &str) -> String {
                 let sep = i + pos + 3;
                 result.push_str(&s[i..sep]);
 
-                // The authority section ends at the first '/', whitespace, or
-                // the end of the string.
+                // The candidate section runs to the next whitespace (or end).
+                // NOT stopping at '/' is intentional — see the doc comment.
                 let rest = &s[sep..];
-                let authority_end = rest
-                    .find(|c: char| c == '/' || c.is_whitespace())
+                let section_end = rest
+                    .find(|c: char| c.is_whitespace())
                     .map(|p| sep + p)
                     .unwrap_or_else(|| s.len());
 
-                // If the authority contains an '@', everything before the
-                // LAST one is userinfo (credentials) and must be redacted —
-                // rfind so an unencoded '@' inside a password is covered too.
-                match s[sep..authority_end].rfind('@') {
+                // Everything before the LAST '@' is treated as credentials.
+                match s[sep..section_end].rfind('@') {
                     Some(at_rel) => {
                         let at = sep + at_rel;
                         result.push_str("***@");
@@ -56,6 +53,29 @@ pub(crate) fn redact_userinfo(s: &str) -> String {
     }
 
     result
+}
+
+/// Redacts the userinfo of a value that IS a single URI (not text containing
+/// one), e.g. `MongoDBConfig::uri` taken verbatim from the environment.
+///
+/// Scans the WHOLE string after `://` for the last `@`, so credentials
+/// containing `/`, `:`, `@`, or even whitespace are fully covered — anything
+/// before the last `@` is replaced with `***`. URIs without an `@` are
+/// returned unchanged.
+pub(crate) fn redact_uri(uri: &str) -> String {
+    match uri.find("://") {
+        Some(pos) => {
+            let sep = pos + 3;
+            match uri[sep..].rfind('@') {
+                Some(at_rel) => {
+                    let at = sep + at_rel;
+                    format!("{}***@{}", &uri[..sep], &uri[at + 1..])
+                }
+                None => uri.to_string(),
+            }
+        }
+        None => uri.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -101,11 +121,51 @@ mod tests {
     }
 
     #[test]
-    fn test_redact_userinfo_at_in_path_not_redacted() {
-        // The '@' appears after the authority (inside the path); it must not be
-        // treated as userinfo.
-        let input = "redis://localhost:6379/some@path";
-        assert_eq!(redact_userinfo(input), input);
+    fn test_redact_userinfo_at_in_path_over_redacts_conservatively() {
+        // A path '@' cannot be distinguished from an unencoded credential
+        // containing '/' without parsing knowledge we don't have; the scan
+        // deliberately over-redacts rather than risk leaking a password.
+        assert_eq!(
+            redact_userinfo("redis://localhost:6379/some@path"),
+            "redis://***@path"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_slash_in_password() {
+        // A raw '/' inside a credential must not defeat the redaction.
+        let out = redact_userinfo("connect failed: redis://user:p/secret@localhost:6379 timeout");
+        assert!(!out.contains("p/secret"));
+        assert_eq!(out, "connect failed: redis://***@localhost:6379 timeout");
+    }
+
+    #[test]
+    fn test_redact_uri_slash_in_password() {
+        assert_eq!(
+            redact_uri("mongodb://admin:p/secret@localhost:27017"),
+            "mongodb://***@localhost:27017"
+        );
+    }
+
+    #[test]
+    fn test_redact_uri_whitespace_in_password() {
+        // Whole-string scanning covers credentials containing whitespace too.
+        assert_eq!(
+            redact_uri("mongodb://admin:p secret@localhost:27017"),
+            "mongodb://***@localhost:27017"
+        );
+    }
+
+    #[test]
+    fn test_redact_uri_no_userinfo_unchanged() {
+        let input = "mongodb://localhost:27017";
+        assert_eq!(redact_uri(input), input);
+    }
+
+    #[test]
+    fn test_redact_uri_plain_text_unchanged() {
+        let input = "no uri here";
+        assert_eq!(redact_uri(input), input);
     }
 
     #[test]

--- a/src/infrastructure/config/mongo.rs
+++ b/src/infrastructure/config/mongo.rs
@@ -1,8 +1,11 @@
-use mongodb::bson::doc;
-use serde::{Deserialize, Serialize};
-
 /// Configuration for MongoDB connection
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// The `uri` may embed credentials, so `Debug` is implemented manually (not
+/// derived) and, together with `Display`, renders the userinfo redacted so the
+/// URI is never leaked through logs. `Serialize`/`Deserialize` are intentionally
+/// not implemented: nothing in the crate persists this config, and deriving them
+/// would risk writing the raw URI to disk or logs.
+#[derive(Clone)]
 pub struct MongoDBConfig {
     /// MongoDB connection URI
     pub uri: String,
@@ -37,11 +40,20 @@ impl Default for MongoDBConfig {
 
 impl std::fmt::Display for MongoDBConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact any credentials embedded in the connection URI before writing.
+        let uri = super::redact_userinfo(&self.uri);
         write!(
             f,
             "{}/{} steps={}, events={} (timeout: {}s)",
-            self.uri, self.database, self.steps_collection, self.events_collection, self.timeout,
+            uri, self.database, self.steps_collection, self.events_collection, self.timeout,
         )
+    }
+}
+
+impl std::fmt::Debug for MongoDBConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never leak credentials through `{:?}`; render the redacted form.
+        write!(f, "MongoDBConfig({})", self)
     }
 }
 
@@ -199,34 +211,27 @@ mod tests {
     }
 
     #[test]
-    fn test_serialization_deserialization() {
+    fn test_display_and_debug_redact_credentials() {
         let config = MongoDBConfig {
-            uri: "mongodb://localhost:27017".to_string(),
+            uri: "mongodb://admin:s3ntinel-pw@localhost:27017".to_string(),
             database: "testdb".to_string(),
-            steps_collection: "steps_collection".to_string(),
-            events_collection: "events_collection".to_string(),
-            timeout: 45,
+            steps_collection: "steps".to_string(),
+            events_collection: "events".to_string(),
+            timeout: 30,
         };
 
-        // Serialize to JSON
-        let serialized = serde_json::to_string(&config).expect("Failed to serialize config");
+        let display = format!("{}", config);
+        let debug = format!("{:?}", config);
 
-        // Validate JSON contains expected fields
-        assert!(serialized.contains("mongodb://localhost:27017"));
-        assert!(serialized.contains("testdb"));
-        assert!(serialized.contains("steps_collection"));
-        assert!(serialized.contains("events_collection"));
-        assert!(serialized.contains("45"));
+        // Neither Display nor Debug may leak the password or the username.
+        assert!(!display.contains("s3ntinel-pw"));
+        assert!(!display.contains("admin"));
+        assert!(display.contains("***"));
+        assert!(!debug.contains("s3ntinel-pw"));
+        assert!(!debug.contains("admin"));
+        assert!(debug.contains("***"));
 
-        // Deserialize back to object
-        let deserialized: MongoDBConfig =
-            serde_json::from_str(&serialized).expect("Failed to deserialize");
-
-        // Check all fields match
-        assert_eq!(deserialized.uri, config.uri);
-        assert_eq!(deserialized.database, config.database);
-        assert_eq!(deserialized.steps_collection, config.steps_collection);
-        assert_eq!(deserialized.events_collection, config.events_collection);
-        assert_eq!(deserialized.timeout, config.timeout);
+        // The raw URI (used to connect) must still carry the real credentials.
+        assert!(config.uri.contains("s3ntinel-pw"));
     }
 }

--- a/src/infrastructure/config/mongo.rs
+++ b/src/infrastructure/config/mongo.rs
@@ -41,7 +41,7 @@ impl Default for MongoDBConfig {
 impl std::fmt::Display for MongoDBConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Redact any credentials embedded in the connection URI before writing.
-        let uri = super::redact_userinfo(&self.uri);
+        let uri = super::redact_uri(&self.uri);
         write!(
             f,
             "{}/{} steps={}, events={} (timeout: {}s)",
@@ -208,6 +208,27 @@ mod tests {
         // Clean up
         remove_var("MONGODB_URI");
         remove_var("MONGODB_TIMEOUT");
+    }
+
+    #[test]
+    fn test_display_and_debug_redact_delimiter_passwords() {
+        // Whole-URI redaction bounds userinfo by the LAST '@', so passwords
+        // containing '/', whitespace, or '@' never leak.
+        for pw in ["p/secret-pw", "p secret-pw", "p@secret-pw"] {
+            let config = MongoDBConfig {
+                uri: format!("mongodb://admin:{pw}@localhost:27017"),
+                database: "db".to_string(),
+                steps_collection: "steps".to_string(),
+                events_collection: "events".to_string(),
+                timeout: 30,
+            };
+            let display = format!("{}", config);
+            let debug = format!("{:?}", config);
+            assert!(!display.contains(pw), "Display leaked {pw:?}: {display}");
+            assert!(!debug.contains(pw), "Debug leaked {pw:?}: {debug}");
+            assert!(display.contains("***@localhost:27017"));
+            assert!(config.uri.contains(pw));
+        }
     }
 
     #[test]

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -1,7 +1,11 @@
 use std::{env, fmt};
 
 /// Configuration for a Redis connection
-#[derive(Clone, Debug)]
+///
+/// `Debug` is implemented manually (not derived) so that credentials are never
+/// leaked through `{:?}` logging; both `Debug` and `Display` render the same
+/// redacted form.
+#[derive(Clone)]
 pub struct RedisConfig {
     /// The hostname of the Redis server
     pub host: String,
@@ -81,10 +85,18 @@ impl Default for RedisConfig {
 
 impl fmt::Display for RedisConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let url = self.url();
+        // Redact any credentials embedded in the connection URL before writing.
+        let url = super::redact_userinfo(&self.url());
 
-        // Write the complete URL and timeout
+        // Write the redacted URL and timeout
         write!(f, "{} (timeout: {}s)", url, self.timeout)
+    }
+}
+
+impl fmt::Debug for RedisConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Never leak credentials through `{:?}`; render the redacted form.
+        write!(f, "{}", self)
     }
 }
 
@@ -223,9 +235,10 @@ mod tests {
             timeout: 30,
         };
 
+        // Credentials must be redacted, never printed.
         assert_eq!(
             format!("{}", config),
-            "redis://testuser@localhost:6379 (timeout: 30s)"
+            "redis://***@localhost:6379 (timeout: 30s)"
         );
     }
 
@@ -240,9 +253,10 @@ mod tests {
             timeout: 30,
         };
 
+        // Credentials must be redacted, never printed.
         assert_eq!(
             format!("{}", config),
-            "redis://:testpass@localhost:6379 (timeout: 30s)"
+            "redis://***@localhost:6379 (timeout: 30s)"
         );
     }
 
@@ -257,9 +271,10 @@ mod tests {
             timeout: 30,
         };
 
+        // Credentials must be redacted, never printed.
         assert_eq!(
             format!("{}", config),
-            "redis://testuser:testpass@localhost:6379 (timeout: 30s)"
+            "redis://***@localhost:6379 (timeout: 30s)"
         );
     }
 
@@ -291,10 +306,39 @@ mod tests {
             timeout: 45,
         };
 
+        // Credentials must be redacted, never printed.
         assert_eq!(
             format!("{}", config),
-            "redis://admin:s3cret@redis.example.com:6380/5 (timeout: 45s)"
+            "redis://***@redis.example.com:6380/5 (timeout: 45s)"
         );
+    }
+
+    #[test]
+    fn test_display_and_debug_redact_password() {
+        let config = RedisConfig {
+            host: "localhost".to_string(),
+            port: 6379,
+            username: Some("admin".to_string()),
+            password: Some("s3ntinel-pw".to_string()),
+            database: 0,
+            timeout: 30,
+        };
+
+        let display = format!("{}", config);
+        let debug = format!("{:?}", config);
+
+        // Neither Display nor Debug may leak the password or the username.
+        assert!(!display.contains("s3ntinel-pw"));
+        assert!(!display.contains("admin"));
+        assert!(display.contains("***"));
+        assert!(!debug.contains("s3ntinel-pw"));
+        assert!(!debug.contains("admin"));
+        assert!(debug.contains("***"));
+
+        // The connection URL must still carry the real credentials so the
+        // connection path keeps working.
+        assert!(config.url().contains("s3ntinel-pw"));
+        assert!(config.url().contains("admin"));
     }
 
     #[test]

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -85,11 +85,19 @@ impl Default for RedisConfig {
 
 impl fmt::Display for RedisConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Redact any credentials embedded in the connection URL before writing.
-        let url = super::redact_userinfo(&self.url());
-
-        // Write the redacted URL and timeout
-        write!(f, "{} (timeout: {}s)", url, self.timeout)
+        // Build the redacted form directly from the fields: the password never
+        // enters the formatted string, so no parser can be defeated by
+        // delimiter-containing credentials (`/`, whitespace, `@`, ...).
+        let creds = if self.username.is_some() || self.password.is_some() {
+            "***@"
+        } else {
+            ""
+        };
+        write!(f, "redis://{}{}:{}", creds, self.host, self.port)?;
+        if self.database > 0 {
+            write!(f, "/{}", self.database)?;
+        }
+        write!(f, " (timeout: {}s)", self.timeout)
     }
 }
 
@@ -311,6 +319,29 @@ mod tests {
             format!("{}", config),
             "redis://***@redis.example.com:6380/5 (timeout: 45s)"
         );
+    }
+
+    #[test]
+    fn test_display_and_debug_redact_delimiter_passwords() {
+        // Display/Debug are built from fields, so passwords containing URL
+        // delimiters ('/', whitespace, '@') can never leak through parsing.
+        for pw in ["p/secret-pw", "p secret-pw", "p@secret-pw"] {
+            let config = RedisConfig {
+                host: "localhost".to_string(),
+                port: 6379,
+                username: Some("user".to_string()),
+                password: Some(pw.to_string()),
+                database: 0,
+                timeout: 30,
+            };
+            let display = format!("{}", config);
+            let debug = format!("{:?}", config);
+            assert!(!display.contains(pw), "Display leaked {pw:?}: {display}");
+            assert!(!debug.contains(pw), "Debug leaked {pw:?}: {debug}");
+            assert!(display.contains("***@"));
+            // The connection URL still carries the real credential.
+            assert!(config.url().contains(pw));
+        }
     }
 
     #[test]

--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::infrastructure::config::mongo::MongoDBConfig;
-use crate::infrastructure::config::redact_userinfo;
+use crate::infrastructure::config::{redact_uri, redact_userinfo};
 use crate::utils::ChainError;
 use mongodb::options::ClientOptions;
 use serde::Serialize;
@@ -25,7 +25,7 @@ impl MongoDBClient {
     #[instrument(skip(config), level = "debug")]
     pub async fn new(config: MongoDBConfig) -> Result<Self, ChainError> {
         // The URI may embed credentials; never log it raw.
-        info!("Connecting to MongoDB at {}", redact_userinfo(&config.uri));
+        info!("Connecting to MongoDB at {}", redact_uri(&config.uri));
 
         // Driver errors can echo the connection URI back, so every error string
         // is passed through `redact_userinfo` before it reaches a log or a

--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::infrastructure::config::mongo::MongoDBConfig;
+use crate::infrastructure::config::redact_userinfo;
 use crate::utils::ChainError;
 use mongodb::options::ClientOptions;
 use serde::Serialize;
@@ -23,24 +24,37 @@ impl MongoDBClient {
     /// Creates a new MongoDB client with the provided configuration
     #[instrument(skip(config), level = "debug")]
     pub async fn new(config: MongoDBConfig) -> Result<Self, ChainError> {
-        info!("Connecting to MongoDB at {}", config.uri);
+        // The URI may embed credentials; never log it raw.
+        info!("Connecting to MongoDB at {}", redact_userinfo(&config.uri));
 
-        let mut client_options = ClientOptions::parse(&config.uri)
-            .await
-            .map_err(|e| ChainError::Internal(format!("Failed to parse MongoDB URI: {}", e)))?;
+        // Driver errors can echo the connection URI back, so every error string
+        // is passed through `redact_userinfo` before it reaches a log or a
+        // `ChainError`.
+        let mut client_options = ClientOptions::parse(&config.uri).await.map_err(|e| {
+            ChainError::Internal(redact_userinfo(&format!(
+                "Failed to parse MongoDB URI: {}",
+                e
+            )))
+        })?;
 
         client_options.app_name = Some("OptionChain-Simulator".to_string());
         client_options.connect_timeout = Some(std::time::Duration::from_secs(config.timeout));
 
-        let client = mongodb::Client::with_options(client_options)
-            .map_err(|e| ChainError::Internal(format!("Failed to create MongoDB client: {}", e)))?;
+        let client = mongodb::Client::with_options(client_options).map_err(|e| {
+            ChainError::Internal(redact_userinfo(&format!(
+                "Failed to create MongoDB client: {}",
+                e
+            )))
+        })?;
 
         // Test connection
         client
             .database("admin")
             .run_command(doc! {"ping": 1})
             .await
-            .map_err(|e| ChainError::Internal(format!("Failed to ping MongoDB: {}", e)))?;
+            .map_err(|e| {
+                ChainError::Internal(redact_userinfo(&format!("Failed to ping MongoDB: {}", e)))
+            })?;
 
         info!("Successfully connected to MongoDB");
 

--- a/src/infrastructure/redis/client.rs
+++ b/src/infrastructure/redis/client.rs
@@ -1,3 +1,4 @@
+use crate::infrastructure::config::redact_userinfo;
 use crate::infrastructure::config::redis::RedisConfig;
 use redis::{Client, Commands, Connection, RedisError, RedisResult};
 use std::sync::{Arc, Mutex};
@@ -15,16 +16,28 @@ impl RedisClient {
     /// Creates a new Redis client with the provided configuration
     #[instrument(skip(config), level = "debug")]
     pub fn new(config: RedisConfig) -> Result<Self, RedisError> {
-        // Build Redis connection URL
+        // Build Redis connection URL (used only to connect, never logged raw).
         let url = config.url();
-        info!("Connecting to Redis at {}", url);
+        // The config's Display impl is already credential-redacted.
+        info!("Connecting to Redis at {}", config);
 
         // Create Redis client
-        let client = Client::open(url)?;
+        let client = Client::open(url).inspect_err(|e| {
+            // Sanitize in case the driver echoes the URL back in its error.
+            error!(
+                "Failed to open Redis client: {}",
+                redact_userinfo(&e.to_string())
+            );
+        })?;
 
         // Create a single connection for now
         // In a production system, you might want to use a more robust connection pool
-        let connection = client.get_connection()?;
+        let connection = client.get_connection().inspect_err(|e| {
+            error!(
+                "Failed to connect to Redis: {}",
+                redact_userinfo(&e.to_string())
+            );
+        })?;
         let connection_pool = Arc::new(Mutex::new(connection));
 
         info!("Successfully connected to Redis");


### PR DESCRIPTION
## Summary

Redis and MongoDB credentials were printed in plaintext by the config
`Display`/derived `Debug` impls and logged at three startup sites, leaking
secrets into local logs, container logs, CI output, and observability
backends. This PR redacts credentials from every formatted/logged form while
leaving the actual connection strings untouched.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 1 (bottom of the stack)**
- **Base branch:** `main`
- **Stacked on:** — (first in the chain)
- **Blocks:** the next PR in the stack (#13)

## Changes

- Shared `redact_userinfo` helper (plain string scanning, no new deps) that
  replaces URL userinfo with `***` in any URL-like substring.
- `RedisConfig`: derived `Debug` dropped; manual `Display`/`Debug` render the
  redacted URL. `url()` (the connection value) is unchanged.
- `MongoDBConfig`: derived `Debug`/`Serialize`/`Deserialize` removed (nothing
  in the crate serializes it); manual `Display`/`Debug` redact the URI.
- `RedisClient::new` and `MongoDBClient::new` log redacted forms; driver
  connection errors that can echo the URI are sanitized before logging or
  wrapping into `ChainError`.
- Sentinel tests assert `s3ntinel-pw` never appears in `Display`/`Debug`/
  sanitized-error output; old tests that asserted the leaking output were
  rewritten to expect redaction.

## Testing

- [x] Unit tests added or updated (`LOGLEVEL=WARN cargo test --workspace`, MongoDB up): 229 + 2 passed, 0 failed
- [x] Sentinel-secret assertions on Display / Debug / sanitized errors
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] Errors converge on `ChainError`; no driver error leaks through `pub` signatures
- [x] No `.unwrap()` / `.expect()` / unchecked indexing on request paths
- [x] `tracing` only for logging
- [x] No `unsafe` introduced; no new dependencies
- [x] Connection behavior unchanged (`url()`/`uri` intact)

Known follow-up (out of scope here): `ClickHouseConfig` still derives `Debug`
(its `Display` does not print the password, but `{:?}` would) — same
treatment tracked as a follow-up issue.

Closes #15
