### PR TITLE
Parameterize ClickHouse symbol queries (#13)

### DIFF
--- a/src/infrastructure/clickhouse/client.rs
+++ b/src/infrastructure/clickhouse/client.rs
@@ -1,8 +1,10 @@
 use crate::infrastructure::ClickHouseConfig;
 use crate::infrastructure::clickhouse::model::{ClickHouseRow, OHLCVData, PriceType};
+use crate::infrastructure::clickhouse::validate_symbol;
 use crate::utils::ChainError;
 use chrono::{DateTime, Utc};
 use clickhouse::Client;
+use clickhouse::query::Query;
 use optionstratlib::utils::TimeFrame;
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -98,6 +100,73 @@ impl Default for ClickHouseClient {
     }
 }
 
+/// Builds the SQL text for a timeframe query using `?` placeholders for the
+/// user-controlled values (symbol, start timestamp and limit, in that order).
+///
+/// The interval literals (`INTERVAL 1 HOUR`, etc.) are derived from the internal
+/// `TimeFrame` match and are never user input, so they stay inline. No external
+/// value is ever interpolated into the returned string; callers must bind the
+/// three parameters before executing.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] when the timeframe is not supported.
+fn timeframe_query_template(timeframe: &TimeFrame) -> Result<String, ChainError> {
+    // Base query for minute data (smallest timeframe supported)
+    if *timeframe == TimeFrame::Minute {
+        return Ok(
+            "SELECT symbol, toInt64(toUnixTimestamp(timestamp)) as timestamp, \
+            open, high, low, close, toUInt64(volume) as volume \
+            FROM ohlcv \
+            WHERE symbol = ? \
+            AND timestamp >= FROM_UNIXTIME(?) \
+            ORDER BY timestamp LIMIT ?"
+                .to_string(),
+        );
+    }
+
+    // For larger timeframes, we need to aggregate the minute data. The interval
+    // literal comes exclusively from this internal match, never from user input.
+    let interval = match timeframe {
+        TimeFrame::Minute => "1 MINUTE", // Already handled above, but included for completeness
+        TimeFrame::Hour => "1 HOUR",
+        TimeFrame::Day => "1 DAY",
+        TimeFrame::Week => "1 WEEK",
+        TimeFrame::Month => "1 MONTH",
+        _ => {
+            return Err(ChainError::ClickHouseError(format!(
+                "Unsupported timeframe: {:?}",
+                timeframe
+            )));
+        }
+    };
+
+    // Query with aggregation for larger timeframes
+    Ok(format!(
+        "WITH intervals AS (
+            SELECT
+                symbol,
+                toStartOfInterval(timestamp, INTERVAL {}) as interval_start,
+                any(open) as open,
+                max(high) as high,
+                min(low) as low,
+                any(close) as close,
+                sum(volume) as volume
+            FROM ohlcv
+            WHERE symbol = ? \
+            AND timestamp >= FROM_UNIXTIME(?) \
+            GROUP BY symbol, interval_start
+            ORDER BY interval_start
+        )
+        SELECT
+            symbol,
+            toInt64(toUnixTimestamp(interval_start)) as timestamp,
+            open, high, low, close, volume
+        FROM intervals LIMIT ?",
+        interval
+    ))
+}
+
 impl ClickHouseClient {
     /// Creates a new ClickHouse client with the provided configuration
     #[instrument(name = "clickhouse_client_new", skip(config), level = "debug")]
@@ -125,12 +194,16 @@ impl ClickHouseClient {
         start_date: &DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<Positive>, ChainError> {
+        validate_symbol(symbol)?;
+
         debug!(
-            "Fetching historical {} prices for {} from {} with timeframe {:?}",
-            limit, symbol, start_date, timeframe
+            symbol = %symbol,
+            limit,
+            ?timeframe,
+            "fetching historical prices"
         );
 
-        // Build the SQL query based on the timeframe
+        // Build the parameterized SQL query based on the timeframe and bind values
         let query = self.build_timeframe_query(symbol, timeframe, start_date, limit)?;
 
         // Execute the query
@@ -153,12 +226,16 @@ impl ClickHouseClient {
         start_date: &DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<OHLCVData>, ChainError> {
+        validate_symbol(symbol)?;
+
         debug!(
-            "Fetching {} OHLCV data for {} from {} with timeframe {:?}",
-            limit, symbol, start_date, timeframe
+            symbol = %symbol,
+            limit,
+            ?timeframe,
+            "fetching OHLCV data"
         );
 
-        // Build the SQL query based on the timeframe
+        // Build the parameterized SQL query based on the timeframe and bind values
         let query = self.build_timeframe_query(symbol, timeframe, start_date, limit)?;
 
         // Execute the query directly
@@ -182,8 +259,11 @@ impl ClickHouseClient {
     /// - `end_date`: A reference to a `DateTime<Utc>` indicating the end of the time range for the query.
     ///
     /// ### Returns
-    /// - On success: A `Result<String, ChainError>` containing the SQL query as a string.
-    /// - On error: A `ChainError::ClickHouseError` if the provided timeframe is unsupported.
+    /// - On success: A `Result<clickhouse::query::Query, ChainError>` holding a
+    ///   prepared query whose SQL uses `?` placeholders with the symbol, start
+    ///   timestamp and limit already bound as escaped parameters.
+    /// - On error: A `ChainError::ClickHouseError` if the symbol is invalid or the
+    ///   provided timeframe is unsupported.
     ///
     /// ### Behavior
     /// 1. If the timeframe is `TimeFrame::Minute`, it directly constructs a query to retrieve minute-level data
@@ -213,64 +293,28 @@ impl ClickHouseClient {
         timeframe: &TimeFrame,
         start_date: &DateTime<Utc>,
         limit: usize,
-    ) -> Result<String, ChainError> {
+    ) -> Result<Query, ChainError> {
+        // Defense in depth: reject anything outside the allowed symbol pattern
+        // before it ever reaches the driver.
+        validate_symbol(symbol)?;
+
+        // Build the SQL text with `?` placeholders (no user input interpolated).
+        let sql = timeframe_query_template(timeframe)?;
+
         // Convert date to Unix timestamp for the query
         let start_timestamp = start_date.timestamp();
 
-        // Base query for minute data (smallest timeframe supported)
-        if *timeframe == TimeFrame::Minute {
-            let query = format!(
-                "SELECT symbol, toInt64(toUnixTimestamp(timestamp)) as timestamp, 
-            open, high, low, close, toUInt64(volume) as volume \
-            FROM ohlcv \
-            WHERE symbol = '{}' \
-            AND timestamp >= FROM_UNIXTIME({}) \
-            ORDER BY timestamp LIMIT {}",
-                symbol, start_timestamp, limit
-            );
+        debug!(symbol = %symbol, sql = %sql, "running timeframe query");
 
-            return Ok(query);
-        }
-
-        // For larger timeframes, we need to aggregate the minute data
-        let interval = match timeframe {
-            TimeFrame::Minute => "1 MINUTE", // Already handled above, but included for completeness
-            TimeFrame::Hour => "1 HOUR",
-            TimeFrame::Day => "1 DAY",
-            TimeFrame::Week => "1 WEEK",
-            TimeFrame::Month => "1 MONTH",
-            _ => {
-                return Err(ChainError::ClickHouseError(format!(
-                    "Unsupported timeframe: {:?}",
-                    timeframe
-                )));
-            }
-        };
-
-        // Query with aggregation for larger timeframes
-        let query = format!(
-            "WITH intervals AS (
-            SELECT 
-                symbol,
-                toStartOfInterval(timestamp, INTERVAL {}) as interval_start,
-                any(open) as open,
-                max(high) as high,
-                min(low) as low,
-                any(close) as close,
-                sum(volume) as volume
-            FROM ohlcv
-            WHERE symbol = '{}' \
-            AND timestamp >= FROM_UNIXTIME({}) \
-            GROUP BY symbol, interval_start
-            ORDER BY interval_start
-        )
-        SELECT 
-            symbol,
-            toInt64(toUnixTimestamp(interval_start)) as timestamp,
-            open, high, low, close, volume
-        FROM intervals LIMIT {}",
-            interval, symbol, start_timestamp, limit
-        );
+        // Bind the user-controlled values as query parameters (escaped by the
+        // driver). Binding order must match the placeholder order in the SQL:
+        // symbol, start_timestamp, limit.
+        let query = self
+            .client
+            .query(&sql)
+            .bind(symbol)
+            .bind(start_timestamp)
+            .bind(limit as u64);
 
         Ok(query)
     }
@@ -280,7 +324,8 @@ impl ClickHouseClient {
     /// # Arguments
     ///
     /// * `&self` - Reference to the instance of the implementing struct.
-    /// * `query` - A `String` containing the ClickHouse query to execute.
+    /// * `query` - A prepared `clickhouse::query::Query` (with all parameters
+    ///   already bound) to execute.
     ///
     /// # Returns
     ///
@@ -317,10 +362,8 @@ impl ClickHouseClient {
     ///
     /// Ensure the query fetches all the required fields (`symbol`, `timestamp`, `open`, `high`, `low`, `close`, `volume`)
     /// to avoid `ChainError` during runtime.
-    async fn execute_query(&self, query: String) -> Result<Vec<OHLCVData>, ChainError> {
-        debug!("Executing ClickHouse query: {}", query);
-
-        let rows: Vec<ClickHouseRow> = self.client.query(&query).fetch_all().await?;
+    async fn execute_query(&self, query: Query) -> Result<Vec<OHLCVData>, ChainError> {
+        let rows: Vec<ClickHouseRow> = query.fetch_all().await?;
 
         let mut results = Vec::new();
 
@@ -386,155 +429,61 @@ mod tests {
     use rust_decimal::Decimal;
 
     #[test]
-    fn test_build_timeframe_query_minute() {
-        let _config = ClickHouseConfig {
+    fn test_timeframe_query_template_minute_uses_placeholders() {
+        let sql = timeframe_query_template(&TimeFrame::Minute).unwrap();
+
+        // The three user-controlled values are bound, never interpolated.
+        assert!(sql.contains("WHERE symbol = ?"));
+        assert!(sql.contains("FROM_UNIXTIME(?)"));
+        assert!(sql.contains("LIMIT ?"));
+        assert!(sql.contains("FROM ohlcv"));
+
+        // A malicious symbol can never appear in the SQL text because the SQL
+        // template does not carry the symbol at all.
+        assert!(!sql.contains("EVIL'--"));
+        assert!(!sql.contains('\''));
+    }
+
+    #[test]
+    fn test_timeframe_query_template_day_uses_placeholders() {
+        let sql = timeframe_query_template(&TimeFrame::Day).unwrap();
+
+        // The interval literal is internal and stays inline.
+        assert!(sql.contains("toStartOfInterval(timestamp, INTERVAL 1 DAY)"));
+        assert!(sql.contains("GROUP BY symbol, interval_start"));
+        assert!(sql.contains("max(high) as high"));
+        assert!(sql.contains("min(low) as low"));
+        assert!(sql.contains("sum(volume) as volume"));
+
+        // User-controlled values are bound as `?` placeholders.
+        assert!(sql.contains("WHERE symbol = ?"));
+        assert!(sql.contains("FROM_UNIXTIME(?)"));
+        assert!(sql.contains("LIMIT ?"));
+        assert!(!sql.contains("EVIL'--"));
+        assert!(!sql.contains('\''));
+    }
+
+    #[test]
+    fn test_timeframe_query_template_unsupported_timeframe() {
+        let result = timeframe_query_template(&TimeFrame::Year);
+        assert!(matches!(result, Err(ChainError::ClickHouseError(_))));
+    }
+
+    #[test]
+    fn test_build_timeframe_query_rejects_invalid_symbol() {
+        let client = ClickHouseClient::new(ClickHouseConfig {
             host: "test-host".to_string(),
             port: 8123,
             username: "test-user".to_string(),
             password: "test-pass".to_string(),
             database: "test-db".to_string(),
-        };
+        })
+        .unwrap();
 
-        fn build_timeframe_query(
-            symbol: &str,
-            timeframe: &TimeFrame,
-            start_date: &DateTime<Utc>,
-            end_date: &DateTime<Utc>,
-        ) -> Result<String, ChainError> {
-            let start_date_str = start_date.format("%Y-%m-%d %H:%M:%S").to_string();
-            let end_date_str = end_date.format("%Y-%m-%d %H:%M:%S").to_string();
-
-            if *timeframe == TimeFrame::Minute {
-                return Ok(format!(
-                    "SELECT symbol, timestamp, open, high, low, close, volume \
-                    FROM ohlcv \
-                    WHERE symbol = '{}' \
-                    AND timestamp BETWEEN '{}' AND '{}' \
-                    ORDER BY timestamp",
-                    symbol, start_date_str, end_date_str
-                ));
-            }
-
-            let interval = match timeframe {
-                TimeFrame::Minute => "1 MINUTE",
-                TimeFrame::Hour => "1 HOUR",
-                TimeFrame::Day => "1 DAY",
-                TimeFrame::Week => "1 WEEK",
-                TimeFrame::Month => "1 MONTH",
-                _ => {
-                    return Err(ChainError::ClickHouseError(format!(
-                        "Unsupported timeframe: {:?}",
-                        timeframe
-                    )));
-                }
-            };
-
-            Ok(format!(
-                "SELECT 
-                    symbol,
-                    toStartOfInterval(timestamp, INTERVAL {}) as timestamp,
-                    any(open) as open,
-                    max(high) as high,
-                    min(low) as low,
-                    any(arrayElement(
-                        groupArray(close), 
-                        length(groupArray(close))
-                    )) as close,
-                    sum(volume) as volume
-                FROM ohlcv
-                WHERE symbol = '{}' 
-                AND timestamp BETWEEN '{}' AND '{}'
-                GROUP BY symbol, timestamp
-                ORDER BY timestamp",
-                interval, symbol, start_date_str, end_date_str
-            ))
-        }
-
-        let symbol = "AAPL";
-        let timeframe = TimeFrame::Minute;
         let start_date = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
-        let end_date = Utc.with_ymd_and_hms(2023, 1, 2, 0, 0, 0).unwrap();
+        let result = client.build_timeframe_query("EVIL'--", &TimeFrame::Minute, &start_date, 10);
 
-        let query = build_timeframe_query(symbol, &timeframe, &start_date, &end_date).unwrap();
-
-        assert!(query.contains("SELECT symbol, timestamp, open, high, low, close, volume"));
-        assert!(query.contains("FROM ohlcv"));
-        assert!(query.contains("WHERE symbol = 'AAPL'"));
-        assert!(
-            query.contains("AND timestamp BETWEEN '2023-01-01 00:00:00' AND '2023-01-02 00:00:00'")
-        );
-        assert!(query.contains("ORDER BY timestamp"));
-    }
-
-    #[test]
-    fn test_build_timeframe_query_day() {
-        fn build_timeframe_query(
-            symbol: &str,
-            timeframe: &TimeFrame,
-            start_date: &DateTime<Utc>,
-            end_date: &DateTime<Utc>,
-        ) -> Result<String, ChainError> {
-            let start_date_str = start_date.format("%Y-%m-%d %H:%M:%S").to_string();
-            let end_date_str = end_date.format("%Y-%m-%d %H:%M:%S").to_string();
-
-            if *timeframe == TimeFrame::Minute {
-                return Ok(format!(
-                    "SELECT symbol, timestamp, open, high, low, close, volume \
-                    FROM ohlcv \
-                    WHERE symbol = '{}' \
-                    AND timestamp BETWEEN '{}' AND '{}' \
-                    ORDER BY timestamp",
-                    symbol, start_date_str, end_date_str
-                ));
-            }
-
-            let interval = match timeframe {
-                TimeFrame::Minute => "1 MINUTE",
-                TimeFrame::Hour => "1 HOUR",
-                TimeFrame::Day => "1 DAY",
-                TimeFrame::Week => "1 WEEK",
-                TimeFrame::Month => "1 MONTH",
-                _ => {
-                    return Err(ChainError::ClickHouseError(format!(
-                        "Unsupported timeframe: {:?}",
-                        timeframe
-                    )));
-                }
-            };
-
-            Ok(format!(
-                "SELECT 
-                    symbol,
-                    toStartOfInterval(timestamp, INTERVAL {}) as timestamp,
-                    any(open) as open,
-                    max(high) as high,
-                    min(low) as low,
-                    any(arrayElement(
-                        groupArray(close), 
-                        length(groupArray(close))
-                    )) as close,
-                    sum(volume) as volume
-                FROM ohlcv
-                WHERE symbol = '{}' 
-                AND timestamp BETWEEN '{}' AND '{}'
-                GROUP BY symbol, timestamp
-                ORDER BY timestamp",
-                interval, symbol, start_date_str, end_date_str
-            ))
-        }
-
-        let symbol = "AAPL";
-        let timeframe = TimeFrame::Day;
-        let start_date = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
-        let end_date = Utc.with_ymd_and_hms(2023, 1, 31, 0, 0, 0).unwrap();
-
-        let query = build_timeframe_query(symbol, &timeframe, &start_date, &end_date).unwrap();
-
-        assert!(query.contains("toStartOfInterval(timestamp, INTERVAL 1 DAY)"));
-        assert!(query.contains("GROUP BY symbol, timestamp"));
-        assert!(query.contains("max(high) as high"));
-        assert!(query.contains("min(low) as low"));
-        assert!(query.contains("sum(volume) as volume"));
+        assert!(matches!(result, Err(ChainError::ClickHouseError(_))));
     }
 
     #[test]

--- a/src/infrastructure/clickhouse/mod.rs
+++ b/src/infrastructure/clickhouse/mod.rs
@@ -5,4 +5,4 @@ pub(crate) mod utils;
 
 pub use client::ClickHouseClient;
 pub use interface::HistoricalDataRepository;
-pub(crate) use utils::{calculate_required_duration, select_random_date};
+pub(crate) use utils::{calculate_required_duration, select_random_date, validate_symbol};

--- a/src/infrastructure/clickhouse/utils.rs
+++ b/src/infrastructure/clickhouse/utils.rs
@@ -3,6 +3,38 @@ use chrono::{DateTime, Duration, Utc};
 use optionstratlib::utils::TimeFrame;
 use rand::{Rng, RngExt};
 
+/// Maximum number of characters allowed in a symbol.
+const MAX_SYMBOL_LEN: usize = 32;
+
+/// Validates an externally supplied symbol as a defense-in-depth measure on top
+/// of query parameter binding.
+///
+/// The allowed pattern is `^[A-Za-z0-9._-]{1,32}$`, i.e. between 1 and 32 ASCII
+/// alphanumeric characters, dots, underscores or hyphens. The check is
+/// implemented with plain character inspection to avoid pulling in a regex
+/// dependency, and it rejects any non-ASCII input (e.g. look-alike Unicode
+/// characters) as well as empty or overly long values.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] when the symbol is empty, longer than
+/// 32 characters, or contains a character outside the allowed set.
+pub fn validate_symbol(symbol: &str) -> Result<(), ChainError> {
+    let len = symbol.chars().count();
+    let is_valid = (1..=MAX_SYMBOL_LEN).contains(&len)
+        && symbol
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(ChainError::ClickHouseError(format!(
+            "invalid symbol: {symbol}"
+        )))
+    }
+}
+
 /// Calculates the required duration based on timeframe and steps
 pub fn calculate_required_duration(timeframe: &TimeFrame, steps: usize) -> Duration {
     match timeframe {
@@ -65,6 +97,38 @@ mod tests {
     mock! {
         pub Row<'a> {
             fn get<T: 'static>(&self, field_name: &str) -> Result<T, ChainError>;
+        }
+    }
+
+    #[test]
+    fn test_validate_symbol_accepts_valid_symbols() {
+        for symbol in ["AAPL", "BRK.B", "BTC-USD", "spx_w", "A", &"X".repeat(32)] {
+            assert!(
+                validate_symbol(symbol).is_ok(),
+                "expected {symbol} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_symbol_rejects_injection_and_unicode() {
+        let cases = [
+            "A'\u{2014}",                // A'— (single quote + em dash)
+            "A' OR '1'='1",              // classic SQL injection payload
+            "A\"; DROP TABLE ohlcv; --", // stacked statement attempt
+            "A\u{0410}",                 // trailing Cyrillic 'А' look-alike
+            "\u{0410}",                  // lone Cyrillic 'А'
+            &"X".repeat(33),             // 33 chars, one over the limit
+            "",                          // empty string
+            "AA PL",                     // embedded space
+        ];
+
+        for symbol in cases {
+            let result = validate_symbol(symbol);
+            assert!(
+                matches!(result, Err(ChainError::ClickHouseError(_))),
+                "expected {symbol:?} to be rejected"
+            );
         }
     }
 

--- a/src/infrastructure/repositories/historical_repo.rs
+++ b/src/infrastructure/repositories/historical_repo.rs
@@ -1,11 +1,14 @@
 //! A repository that interacts with ClickHouse to provide historical financial data.
-use crate::infrastructure::clickhouse::{ClickHouseClient, HistoricalDataRepository};
+use crate::infrastructure::clickhouse::{
+    ClickHouseClient, HistoricalDataRepository, validate_symbol,
+};
 use crate::utils::ChainError;
 use async_trait::async_trait;
 use chrono::Utc;
 use optionstratlib::utils::TimeFrame;
 use positive::Positive;
 use std::sync::Arc;
+use tracing::debug;
 
 /// Represents a repository for accessing historical data stored in a ClickHouse database.
 ///
@@ -22,6 +25,14 @@ use std::sync::Arc;
 /// The `ClickHouseHistoricalRepository` assumes that the provided `ClickHouseClient` is properly
 /// configured to interact with the database (e.g., connection details and authentication).
 ///
+/// SQL template for the per-symbol date range query. The symbol is bound as an
+/// escaped `?` parameter, never interpolated into this string.
+const DATE_RANGE_QUERY: &str = "SELECT \
+        toInt64(toUnixTimestamp(min(timestamp))) as min_date, \
+        toInt64(toUnixTimestamp(max(timestamp))) as max_date \
+    FROM ohlcv \
+    WHERE symbol = ?";
+
 pub struct ClickHouseHistoricalRepository {
     /// The underlying ClickHouse client
     client: Arc<ClickHouseClient>,
@@ -82,6 +93,7 @@ impl HistoricalDataRepository for ClickHouseHistoricalRepository {
         start_date: &chrono::DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<Positive>, ChainError> {
+        validate_symbol(symbol)?;
         self.client
             .fetch_historical_prices(symbol, timeframe, start_date, limit)
             .await
@@ -178,14 +190,9 @@ impl HistoricalDataRepository for ClickHouseHistoricalRepository {
         &self,
         symbol: &str,
     ) -> Result<(chrono::DateTime<Utc>, chrono::DateTime<Utc>), ChainError> {
-        let query = format!(
-            "SELECT 
-                toInt64(toUnixTimestamp(min(timestamp))) as min_date, 
-                toInt64(toUnixTimestamp(max(timestamp))) as max_date 
-            FROM ohlcv 
-            WHERE symbol = '{}'",
-            symbol
-        );
+        validate_symbol(symbol)?;
+
+        debug!(symbol = %symbol, "running date-range query");
 
         #[derive(Debug, clickhouse::Row, serde::Deserialize)]
         struct DateRange {
@@ -193,7 +200,14 @@ impl HistoricalDataRepository for ClickHouseHistoricalRepository {
             max_date: i64,
         }
 
-        let rows: Vec<DateRange> = self.client.client.query(&query).fetch_all().await?;
+        // The symbol is bound as an escaped query parameter, never interpolated.
+        let rows: Vec<DateRange> = self
+            .client
+            .client
+            .query(DATE_RANGE_QUERY)
+            .bind(symbol)
+            .fetch_all()
+            .await?;
 
         if let Some(row) = rows.first() {
             let min_date =
@@ -374,6 +388,15 @@ mod tests {
         assert_eq!(symbols, expected_symbols);
         assert_eq!(symbols.len(), 3);
         assert_eq!(symbols[0], "AAPL");
+    }
+
+    #[test]
+    fn test_date_range_query_uses_placeholder() {
+        // The symbol is bound, never interpolated: the template carries a `?`
+        // and can never contain a malicious symbol value.
+        assert!(DATE_RANGE_QUERY.contains("WHERE symbol = ?"));
+        assert!(!DATE_RANGE_QUERY.contains("EVIL'--"));
+        assert!(!DATE_RANGE_QUERY.contains('\''));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

User-controlled symbols were interpolated with `format!` directly into
ClickHouse SQL (timeframe queries and the date-range query), letting a symbol
containing a quote alter the predicate, and the fully-interpolated SQL was
logged at debug level. Queries now use the clickhouse crate's `?` binding for
every external value, with identifier-format validation as defense in depth.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 2**
- **Base branch:** `stack/1-15-redact-credentials`
- **Stacked on:** #23 · **Blocks:** the next PR in the stack (#7)
- The diff is cumulative until PR #23 merges — review against the base branch.

## Changes

- `build_timeframe_query` now returns a prepared `clickhouse::query::Query`
  with `symbol` / `start_timestamp` / `limit` bound via `.bind()` (driver
  escaping); the SQL templates carry only `?` placeholders. Interval literals
  stay inline (internal match, not user input).
- `get_date_range_for_symbol` parameterized the same way
  (`const DATE_RANGE_QUERY` + `.bind(symbol)`).
- New `validate_symbol` (`^[A-Za-z0-9._-]{1,32}$`, plain char checks, no new
  deps) at the entry of every symbol-taking path — defense in depth, not the
  escaping mechanism.
- Interpolated-SQL debug logging removed; logs now carry the template and the
  symbol as structured fields.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 235 + 2 passed, 0 failed (7 new tests)
- [x] Injection cases covered: quotes, `' OR '1'='1`, `"; DROP TABLE ohlcv; --`, Cyrillic homoglyph, oversize, empty
- [x] SQL templates asserted to contain `?` and never a raw symbol
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] No external string concatenated into SQL
- [x] Errors converge on `ChainError` at the adapter
- [x] No `.unwrap()` / `.expect()` on production paths; `tracing` only
- [x] No new dependencies; no `unsafe`

Closes #13
