### PR TITLE
Use random session ids and fail on create collisions (#7)

### DIFF
--- a/src/api/rest/error.rs
+++ b/src/api/rest/error.rs
@@ -6,6 +6,9 @@ pub(crate) fn map_error(error: ChainError) -> HttpResponse {
         ChainError::NotFound(_) => {
             HttpResponse::NotFound().json(serde_json::json!({"error": error.to_string()}))
         }
+        ChainError::AlreadyExists(_) => {
+            HttpResponse::Conflict().json(serde_json::json!({"error": error.to_string()}))
+        }
         ChainError::InvalidState(_) => {
             HttpResponse::BadRequest().json(serde_json::json!({"error": error.to_string()}))
         }
@@ -31,6 +34,18 @@ mod tests {
         let err = ChainError::NotFound("item_xyz".into());
         let resp: HttpResponse = map_error(err.clone());
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = to_bytes(resp.into_body()).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, serde_json::json!({"error": err.to_string()}));
+    }
+
+    /// AlreadyExists should map to 409 with the error message from `Display`.
+    #[actix_web::test]
+    async fn test_map_error_already_exists() {
+        let err = ChainError::AlreadyExists("session_abc".into());
+        let resp: HttpResponse = map_error(err.clone());
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
 
         let body = to_bytes(resp.into_body()).await.unwrap();
         let json: Value = serde_json::from_slice(&body).unwrap();

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -49,6 +49,7 @@ use uuid::Uuid;
     responses(
         (status = 201, description = "Session created successfully", body = SessionResponse),
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
+        (status = 409, description = "Session id already exists", body = ErrorResponse),
         (status = 500, description = "Internal server error")
     )
 )]

--- a/src/infrastructure/redis/client.rs
+++ b/src/infrastructure/redis/client.rs
@@ -100,6 +100,52 @@ impl RedisClient {
         }
     }
 
+    /// Atomically sets a value in Redis only if the key does not already exist
+    /// (`SET key value NX [EX secs]`), with an optional expiration in seconds.
+    ///
+    /// # Returns
+    /// - `Ok(true)` if the key was created (it did not exist before).
+    /// - `Ok(false)` if the key already existed and was left untouched.
+    /// - `Err(RedisError)` if the command failed.
+    #[instrument(skip(self, value), level = "debug")]
+    pub fn set_nx<T: redis::ToSingleRedisArg>(
+        &self,
+        key: &str,
+        value: T,
+        expiry_secs: Option<u64>,
+    ) -> RedisResult<bool> {
+        let mut connection = self.get_connection()?;
+        let connection = &mut *connection;
+
+        // Redis replies with "OK" when the key was set and nil when NX prevented
+        // the write; deserializing into `Option<String>` distinguishes the two.
+        let outcome: Option<String> = match expiry_secs {
+            Some(secs) => {
+                debug!(
+                    "Setting key '{}' in Redis with NX and expiry of {} seconds",
+                    key, secs
+                );
+                redis::cmd("SET")
+                    .arg(key)
+                    .arg(value)
+                    .arg("NX")
+                    .arg("EX")
+                    .arg(secs)
+                    .query(connection)?
+            }
+            None => {
+                debug!("Setting key '{}' in Redis with NX and no expiry", key);
+                redis::cmd("SET")
+                    .arg(key)
+                    .arg(value)
+                    .arg("NX")
+                    .query(connection)?
+            }
+        };
+
+        Ok(outcome.is_some())
+    }
+
     /// Deletes a key from Redis
     #[instrument(skip(self), level = "debug")]
     pub fn delete(&self, key: &str) -> RedisResult<bool> {

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -2,13 +2,15 @@ use crate::domain::Simulator;
 use crate::session::SessionStore;
 use crate::session::model::{Session, SimulationParameters};
 use crate::session::state_handler::StateProgressionHandler;
-use crate::utils::UuidGenerator;
 use crate::utils::error::ChainError;
 use optionstratlib::chains::OptionChain;
 use std::string::ToString;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Deterministic UUID namespace kept for the `Default for Session` impl in
+/// `src/session/model.rs`. New session ids are random (`Uuid::new_v4`) so a
+/// restarted manager or a second replica never reproduces an id sequence.
 pub(crate) const DEFAULT_NAMESPACE: &str = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 
 /// Manages the lifecycle of simulation sessions
@@ -16,7 +18,6 @@ pub struct SessionManager {
     store: Arc<dyn SessionStore>,
     state_handler: StateProgressionHandler,
     simulator: Simulator,
-    uuid_generator: UuidGenerator,
 }
 
 impl SessionManager {
@@ -37,20 +38,10 @@ impl SessionManager {
     ///   specific processes or operations as per the required functionality.
     ///
     pub fn new(store: Arc<dyn SessionStore>) -> Self {
-        // Create a new namespace for each session manager instance
-        // let namespace_uuid = Uuid::new_v4().to_string();
-        // let namespace = Uuid::parse_str(&namespace_uuid)
-        //     .expect("Failed to parse default UUID namespace");
-
-        // Create a default namespace for compatibility
-        let namespace =
-            Uuid::parse_str(DEFAULT_NAMESPACE).expect("Failed to parse default UUID namespace");
-        let uuid_generator = UuidGenerator::new(namespace);
         Self {
             store,
             state_handler: StateProgressionHandler::new(),
             simulator: Simulator::new(),
-            uuid_generator,
         }
     }
 
@@ -72,8 +63,11 @@ impl SessionManager {
     /// - When the session fails to be stored in the backend storage.
     ///
     pub fn create_session(&self, params: SimulationParameters) -> Result<Session, ChainError> {
-        let session = Session::new(params, &self.uuid_generator);
-        self.store.save(session.clone())?;
+        // Random session ids (see `Session::with_random_id`) plus a non-overwriting
+        // `create` guarantee a fresh session never clobbers a live one after a restart
+        // or across replicas.
+        let session = Session::with_random_id(params);
+        self.store.create(session.clone())?;
         Ok(session)
     }
 
@@ -271,5 +265,69 @@ impl SessionManager {
     /// storage backend is properly equipped to remove outdated or invalid sessions.
     pub fn cleanup_sessions(&self) -> Result<usize, ChainError> {
         self.store.cleanup()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{InMemorySessionStore, SimulationMethod};
+    use optionstratlib::utils::TimeFrame;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal::Decimal;
+
+    fn test_parameters() -> SimulationParameters {
+        SimulationParameters {
+            symbol: "AAPL".to_string(),
+            steps: 10,
+            initial_price: pos_or_panic!(100.0),
+            days_to_expiration: pos_or_panic!(30.0),
+            volatility: pos_or_panic!(0.2),
+            risk_free_rate: Decimal::ZERO,
+            dividend_yield: Positive::ZERO,
+            method: SimulationMethod::Brownian {
+                dt: pos_or_panic!(1.0 / 252.0),
+                drift: Decimal::ZERO,
+                volatility: pos_or_panic!(0.2),
+            },
+            time_frame: TimeFrame::Day,
+            chain_size: Some(15),
+            strike_interval: Some(pos_or_panic!(1.0)),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(pos_or_panic!(0.02)),
+            seed: None,
+        }
+    }
+
+    /// Regression for issue #7: two freshly built managers (each with its own store,
+    /// as after a restart or on a second replica) must not emit the same first id.
+    #[test]
+    fn test_fresh_managers_produce_different_first_ids() {
+        let manager_a = SessionManager::new(Arc::new(InMemorySessionStore::new()));
+        let manager_b = SessionManager::new(Arc::new(InMemorySessionStore::new()));
+
+        let session_a = manager_a
+            .create_session(test_parameters())
+            .expect("first manager failed to create session");
+        let session_b = manager_b
+            .create_session(test_parameters())
+            .expect("second manager failed to create session");
+
+        assert_ne!(
+            session_a.id, session_b.id,
+            "fresh managers must not reproduce the same id sequence"
+        );
+    }
+
+    /// Successive creates on the same manager also yield distinct ids.
+    #[test]
+    fn test_sequential_creates_have_unique_ids() {
+        let manager = SessionManager::new(Arc::new(InMemorySessionStore::new()));
+
+        let first = manager.create_session(test_parameters()).unwrap();
+        let second = manager.create_session(test_parameters()).unwrap();
+
+        assert_ne!(first.id, second.id);
     }
 }

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -264,6 +264,40 @@ impl Session {
         Self::new_with_generator(parameters, uuid_generator)
     }
 
+    /// Creates a new session with a randomly generated identifier (`Uuid::new_v4`).
+    ///
+    /// Unlike [`Session::new_with_generator`], this constructor does not derive the id
+    /// from a deterministic namespace + counter sequence. Random ids guarantee that a
+    /// freshly started manager (after a restart, or a second service replica) never
+    /// reproduces the id sequence of a manager that is still holding live sessions, so
+    /// a create can no longer collide with — and silently overwrite — an existing one.
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - The `SimulationParameters` that configure the session; the
+    ///   session's `total_steps` is taken from `parameters.steps`.
+    ///
+    /// # Returns
+    ///
+    /// A new `Session` with:
+    ///   - `id`: a random v4 UUID.
+    ///   - `created_at` / `updated_at`: the current system time.
+    ///   - `current_step`: 0.
+    ///   - `total_steps`: `parameters.steps`.
+    ///   - `state`: `SessionState::Initialized`.
+    pub fn with_random_id(parameters: SimulationParameters) -> Self {
+        let now = SystemTime::now();
+        Self {
+            id: Uuid::new_v4(),
+            created_at: now,
+            updated_at: now,
+            current_step: 0,
+            total_steps: parameters.steps,
+            parameters,
+            state: SessionState::Initialized,
+        }
+    }
+
     /// Advances the session to the next step while updating its state and timestamp.
     ///
     /// # Behavior

--- a/src/session/store/in_memory.rs
+++ b/src/session/store/in_memory.rs
@@ -60,6 +60,22 @@ impl SessionStore for InMemorySessionStore {
             .ok_or_else(|| ChainError::NotFound(format!("Session with id {} not found", id)))
     }
 
+    fn create(&self, session: Session) -> Result<(), ChainError> {
+        let mut sessions = self.sessions.lock().map_err(|_| {
+            ChainError::Internal("Failed to acquire lock on session store".to_string())
+        })?;
+
+        if sessions.contains_key(&session.id) {
+            return Err(ChainError::AlreadyExists(format!(
+                "Session with id {} already exists",
+                session.id
+            )));
+        }
+
+        sessions.insert(session.id, session);
+        Ok(())
+    }
+
     fn save(&self, session: Session) -> Result<(), ChainError> {
         let mut sessions = self.sessions.lock().map_err(|_| {
             ChainError::Internal("Failed to acquire lock on session store".to_string())
@@ -203,6 +219,53 @@ mod tests {
         assert_eq!(retrieved_session.id, id);
         assert_eq!(retrieved_session.parameters.symbol, "TEST");
         assert_eq!(retrieved_session.state, SessionState::Initialized);
+    }
+
+    #[test]
+    fn test_create_new_session() {
+        let store = InMemorySessionStore::new();
+        let session = create_test_session(None);
+        let id = session.id;
+
+        // create succeeds on a new id
+        assert!(store.create(session).is_ok());
+
+        // and the session is retrievable
+        assert!(store.get(id).is_ok());
+    }
+
+    #[test]
+    fn test_create_duplicate_returns_already_exists() {
+        let store = InMemorySessionStore::new();
+        let session = create_test_session(None);
+
+        // first create wins
+        assert!(store.create(session.clone()).is_ok());
+
+        // second create with the same id is rejected instead of overwriting
+        match store.create(session) {
+            Err(ChainError::AlreadyExists(msg)) => {
+                assert!(msg.contains("already exists"));
+            }
+            other => panic!("Expected AlreadyExists error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_save_still_updates_after_create() {
+        let store = InMemorySessionStore::new();
+        let mut session = create_test_session(None);
+        let id = session.id;
+
+        // create the session, then save (upsert) an updated copy
+        assert!(store.create(session.clone()).is_ok());
+        session.current_step = 7;
+        session.state = SessionState::InProgress;
+        assert!(store.save(session).is_ok());
+
+        let retrieved = store.get(id).unwrap();
+        assert_eq!(retrieved.current_step, 7);
+        assert_eq!(retrieved.state, SessionState::InProgress);
     }
 
     #[test]

--- a/src/session/store/in_redis.rs
+++ b/src/session/store/in_redis.rs
@@ -100,6 +100,43 @@ impl SessionStore for InRedisSessionStore {
     }
 
     #[instrument(skip(self, session), level = "debug")]
+    fn create(&self, session: Session) -> Result<(), ChainError> {
+        let key = self.session_key(session.id);
+        debug!(session_id = %session.id, key = %key, "Creating session in Redis");
+
+        // Serialize session to JSON
+        let json_str = match serde_json::to_string(&session) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(session_id = %session.id, error = %e, "Failed to serialize session");
+                return Err(ChainError::Internal(format!(
+                    "Failed to serialize session: {}",
+                    e
+                )));
+            }
+        };
+
+        // SET NX guarantees we never overwrite an existing session id.
+        match self.client.set_nx(&key, json_str, Some(self.session_ttl)) {
+            Ok(true) => {
+                debug!(session_id = %session.id, "Session created successfully");
+                Ok(())
+            }
+            Ok(false) => {
+                error!(session_id = %session.id, "Session id already exists in Redis");
+                Err(ChainError::AlreadyExists(format!(
+                    "Session with id {} already exists",
+                    session.id
+                )))
+            }
+            Err(e) => {
+                error!(session_id = %session.id, error = %e, "Redis error while creating session");
+                Err(Self::map_redis_error(e))
+            }
+        }
+    }
+
+    #[instrument(skip(self, session), level = "debug")]
     fn save(&self, session: Session) -> Result<(), ChainError> {
         let key = self.session_key(session.id);
         debug!(session_id = %session.id, key = %key, "Saving session to Redis");
@@ -231,6 +268,33 @@ mod tests {
             }
         }
 
+        fn create(&self, session: Session) -> Result<(), ChainError> {
+            let key = self.session_key(session.id);
+
+            // Serialize session to JSON
+            let json_str = match serde_json::to_string(&session) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err(ChainError::Internal(format!(
+                        "Failed to serialize session: {}",
+                        e
+                    )));
+                }
+            };
+
+            // Mirror the real store's SET NX behaviour: reject id collisions.
+            let mut sessions = self.sessions.lock().unwrap();
+            if sessions.contains_key(&key) {
+                return Err(ChainError::AlreadyExists(format!(
+                    "Session with id {} already exists",
+                    session.id
+                )));
+            }
+            sessions.insert(key, json_str);
+
+            Ok(())
+        }
+
         fn save(&self, session: Session) -> Result<(), ChainError> {
             let key = self.session_key(session.id);
 
@@ -353,6 +417,61 @@ mod tests {
     }
 
     #[test]
+    fn test_create_new_session() {
+        let store = TestInRedisSessionStore::new(None, None);
+
+        let session = create_test_session();
+        let session_id = session.id;
+
+        // create succeeds on a fresh id
+        assert!(store.create(session).is_ok());
+        assert_eq!(store.get_store_size(), 1);
+
+        // and the session is retrievable
+        assert!(store.get(session_id).is_ok());
+    }
+
+    #[test]
+    fn test_create_duplicate_returns_already_exists() {
+        let store = TestInRedisSessionStore::new(None, None);
+
+        let session = create_test_session();
+
+        // first create wins
+        assert!(store.create(session.clone()).is_ok());
+
+        // second create with the same id is rejected instead of overwriting
+        match store.create(session) {
+            Err(ChainError::AlreadyExists(msg)) => {
+                assert!(msg.contains("already exists"));
+            }
+            other => panic!("Expected AlreadyExists error, got {:?}", other),
+        }
+
+        // still exactly one stored entry (no overwrite / no duplicate)
+        assert_eq!(store.get_store_size(), 1);
+    }
+
+    #[test]
+    fn test_save_still_updates_after_create() {
+        let store = TestInRedisSessionStore::new(None, None);
+
+        let mut session = create_test_session();
+        let session_id = session.id;
+
+        assert!(store.create(session.clone()).is_ok());
+
+        // save is still an upsert on top of a created session
+        session.current_step = 3;
+        session.state = SessionState::InProgress;
+        assert!(store.save(session).is_ok());
+
+        let updated = store.get(session_id).unwrap();
+        assert_eq!(updated.current_step, 3);
+        assert_eq!(updated.state, SessionState::InProgress);
+    }
+
+    #[test]
     fn test_get_non_existent_session() {
         let store = TestInRedisSessionStore::new(None, None);
 
@@ -453,6 +572,13 @@ mod tests {
             )))
         }
 
+        fn create(&self, session: Session) -> Result<(), ChainError> {
+            Err(ChainError::Internal(format!(
+                "Simulated error creating session {}",
+                session.id
+            )))
+        }
+
         fn save(&self, session: Session) -> Result<(), ChainError> {
             Err(ChainError::Internal(format!(
                 "Simulated error saving session {}",
@@ -482,6 +608,9 @@ mod tests {
         let session_id = session.id;
 
         // Test that errors are properly propagated
+        let create_result = error_store.create(session.clone());
+        assert!(create_result.is_err());
+
         let save_result = error_store.save(session);
         assert!(save_result.is_err());
 

--- a/src/session/store/interface.rs
+++ b/src/session/store/interface.rs
@@ -69,6 +69,26 @@ pub trait SessionStore: Send + Sync {
     ///
     fn get(&self, id: Uuid) -> Result<Session, ChainError>;
 
+    /// Creates a brand-new session, failing if one with the same id already exists.
+    ///
+    /// Unlike [`SessionStore::save`], which is a blind upsert, `create` must never
+    /// overwrite an existing session. This is what makes a fresh manager (after a
+    /// restart, or a second replica) safe: a colliding id is rejected instead of
+    /// silently clobbering a live session.
+    ///
+    /// # Parameters
+    /// - `session`: The `Session` to insert.
+    ///
+    /// # Returns
+    /// - `Ok(())`: If the session was inserted.
+    /// - `Err(ChainError::AlreadyExists)`: If a session with the same id already exists.
+    /// - `Err(ChainError)`: If the underlying storage operation fails.
+    ///
+    /// # Errors
+    /// Returns `ChainError::AlreadyExists` on an id collision, or another `ChainError`
+    /// variant on a storage/serialization failure.
+    fn create(&self, session: Session) -> Result<(), ChainError>;
+
     /// Saves the provided session into persistent storage or memory.
     ///
     /// # Parameters
@@ -136,6 +156,7 @@ mod tests {
         pub SessionStore {}
         impl SessionStore for SessionStore {
             fn get(&self, id: Uuid) -> Result<Session, ChainError>;
+            fn create(&self, session: Session) -> Result<(), ChainError>;
             fn save(&self, session: Session) -> Result<(), ChainError>;
             fn delete(&self, id: Uuid) -> Result<bool, ChainError>;
             fn cleanup(&self) -> Result<usize, ChainError>;
@@ -165,6 +186,18 @@ mod tests {
                     id
                 ))),
             }
+        }
+
+        fn create(&self, session: Session) -> Result<(), ChainError> {
+            let mut sessions = self.sessions.lock().unwrap();
+            if sessions.contains_key(&session.id) {
+                return Err(ChainError::AlreadyExists(format!(
+                    "Session with id {} already exists",
+                    session.id
+                )));
+            }
+            sessions.insert(session.id, session);
+            Ok(())
         }
 
         fn save(&self, session: Session) -> Result<(), ChainError> {
@@ -275,6 +308,36 @@ mod tests {
         // Verify it was saved by retrieving it
         let get_result = store.get(session_id);
         assert!(get_result.is_ok());
+    }
+
+    #[test]
+    fn test_create_new_session() {
+        let store = TestSessionStore::new();
+        let session = create_test_session(None);
+        let session_id = session.id;
+
+        // First create succeeds on a fresh id
+        let create_result = store.create(session);
+        assert!(create_result.is_ok());
+
+        // Verify it was stored
+        assert!(store.get(session_id).is_ok());
+    }
+
+    #[test]
+    fn test_create_duplicate_session_returns_already_exists() {
+        let store = TestSessionStore::new();
+        let session = create_test_session(None);
+
+        // First create succeeds
+        assert!(store.create(session.clone()).is_ok());
+
+        // Second create with the same id must be rejected, not overwrite
+        let dup_result = store.create(session);
+        match dup_result {
+            Err(ChainError::AlreadyExists(_)) => {}
+            other => panic!("Expected AlreadyExists error, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -26,6 +26,11 @@ pub enum ChainError {
     /// - `NotFound(String)`
     ///   Denotes that a requested resource or item was not found. Includes a `String` detailing what was not found.
     NotFound(String),
+    /// - `AlreadyExists(String)`
+    ///   Denotes that a resource with the given identifier already exists and cannot be
+    ///   created again. Raised by `SessionStore::create` when a session id is already
+    ///   present, guarding against silently overwriting a live session.
+    AlreadyExists(String),
     /// - `SimulatorError(String)`
     ///   Indicates an error specific to a simulation process. Provides a `String` for more context.
     SimulatorError(String),
@@ -81,6 +86,7 @@ impl fmt::Display for ChainError {
             ChainError::InvalidState(msg) => write!(f, "Invalid State: {}", msg),
             ChainError::Internal(msg) => write!(f, "Internal Error: {}", msg),
             ChainError::NotFound(msg) => write!(f, "Not Found: {}", msg),
+            ChainError::AlreadyExists(msg) => write!(f, "Already Exists: {}", msg),
             ChainError::SimulatorError(msg) => write!(f, "Simulator Error: {}", msg),
             ChainError::ClickHouseError(msg) => write!(f, "ClickHouse Error: {}", msg),
             ChainError::NotEnoughData(msg) => write!(f, "Not Enough Data: {}", msg),
@@ -181,6 +187,10 @@ mod tests {
                 "Not Found: resource missing",
             ),
             (
+                ChainError::AlreadyExists("resource present".to_string()),
+                "Already Exists: resource present",
+            ),
+            (
                 ChainError::SimulatorError("simulation failed".to_string()),
                 "Simulator Error: simulation failed",
             ),
@@ -220,6 +230,7 @@ mod tests {
             ChainError::InvalidState("invalid state".to_string()),
             ChainError::Internal("internal issue".to_string()),
             ChainError::NotFound("not found".to_string()),
+            ChainError::AlreadyExists("already exists".to_string()),
             ChainError::SimulatorError("simulation problem".to_string()),
             ChainError::ClickHouseError("database issue".to_string()),
             ChainError::NotEnoughData("insufficient data".to_string()),
@@ -232,6 +243,7 @@ mod tests {
                 ChainError::InvalidState(msg) => assert_eq!(msg, "invalid state"),
                 ChainError::Internal(msg) => assert_eq!(msg, "internal issue"),
                 ChainError::NotFound(msg) => assert_eq!(msg, "not found"),
+                ChainError::AlreadyExists(msg) => assert_eq!(msg, "already exists"),
                 ChainError::SimulatorError(msg) => assert_eq!(msg, "simulation problem"),
                 ChainError::ClickHouseError(msg) => assert_eq!(msg, "database issue"),
                 ChainError::NotEnoughData(msg) => assert_eq!(msg, "insufficient data"),


### PR DESCRIPTION
## Summary

Every `SessionManager` started the same deterministic UUIDv5 sequence at
counter zero with a fixed namespace, so the first session after every restart
— or in every replica — received the same id, and `store.save` (a blind
upsert) silently overwrote the still-live session in Redis. Session ids are
now random v4 UUIDs and creation goes through a non-overwriting store
operation.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 3**
- **Base branch:** `stack/2-13-clickhouse-sql-binding`
- **Stacked on:** #24 · **Blocks:** the next PR in the stack (#10)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- `Session::with_random_id` (`Uuid::new_v4()`); `SessionManager::create_session`
  uses it and no longer owns a `UuidGenerator` (the deterministic generator
  stays in `utils` for its other uses).
- New `SessionStore::create` that FAILS on an existing id — in-memory via a
  `contains_key` guard, Redis via a new `RedisClient::set_nx` (`SET … NX EX`),
  mapping an unset key to the new `ChainError::AlreadyExists`.
- `AlreadyExists` → HTTP 409 in `map_error`; POST utoipa annotation documents
  the 409.

## Contract impact

Additive: POST `/api/v1/chain` can now return 409 on an id collision
(previously it silently overwrote). Session ids are no longer deterministic
across restarts — that determinism was the bug; the tape-reproducibility
contract (parameters + seed) is unaffected.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 246 + 2 passed, 0 failed (11 new tests)
- [x] Restart-collision regression: two fresh managers produce different first ids
- [x] `create` collision → `AlreadyExists` in both store impls; `save` still updates
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] Stored-session serde shape unchanged
- [x] Effective-seed guarantee untouched
- [x] No `.unwrap()` / `.expect()` on production paths; `tracing` only
- [x] No new dependencies; no `unsafe`

Closes #7
