### PR TITLE
Validate simulation parameters instead of panicking (#10)

### DIFF
--- a/src/api/rest/error.rs
+++ b/src/api/rest/error.rs
@@ -12,6 +12,11 @@ pub(crate) fn map_error(error: ChainError) -> HttpResponse {
         ChainError::InvalidState(_) => {
             HttpResponse::BadRequest().json(serde_json::json!({"error": error.to_string()}))
         }
+        // Validation failures carry the offending field so clients can point the user
+        // at the exact parameter; the body keeps the `{"error": ...}` shape and adds a
+        // `field` key.
+        ChainError::Validation { ref field, .. } => HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": error.to_string(), "field": field})),
         ChainError::SimulatorError(err) => {
             HttpResponse::Gone().json(serde_json::json!({"error": err}))
         }
@@ -74,6 +79,24 @@ mod tests {
         let body = to_bytes(resp.into_body()).await.unwrap();
         let json: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json, serde_json::json!({"error": "sim_fail"}));
+    }
+
+    /// Validation should map to 400 with the error message and the offending field.
+    #[actix_web::test]
+    async fn test_map_error_validation() {
+        let err = ChainError::Validation {
+            field: "initial_price".into(),
+            reason: "must be a finite number".into(),
+        };
+        let resp: HttpResponse = map_error(err.clone());
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let body = to_bytes(resp.into_body()).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"error": err.to_string(), "field": "initial_price"})
+        );
     }
 
     /// Any other variant (e.g., SessionError) should map to 500 with a generic message.

--- a/src/api/rest/error.rs
+++ b/src/api/rest/error.rs
@@ -13,10 +13,14 @@ pub(crate) fn map_error(error: ChainError) -> HttpResponse {
             HttpResponse::BadRequest().json(serde_json::json!({"error": error.to_string()}))
         }
         // Validation failures carry the offending field so clients can point the user
-        // at the exact parameter; the body keeps the `{"error": ...}` shape and adds a
-        // `field` key.
-        ChainError::Validation { ref field, .. } => HttpResponse::BadRequest()
-            .json(serde_json::json!({"error": error.to_string(), "field": field})),
+        // at the exact parameter; the wire shape is the documented
+        // `ValidationErrorResponse` ({"error", "field"}).
+        ChainError::Validation { ref field, .. } => {
+            HttpResponse::BadRequest().json(crate::api::rest::responses::ValidationErrorResponse {
+                error: error.to_string(),
+                field: field.clone(),
+            })
+        }
         ChainError::SimulatorError(err) => {
             HttpResponse::Gone().json(serde_json::json!({"error": err}))
         }

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -1,17 +1,17 @@
 use crate::api::rest::error::map_error;
+use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
 use crate::api::rest::models::SessionId;
 use crate::api::rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 use crate::api::rest::responses::{
     ChainResponse, ErrorResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
     SessionParametersResponse, SessionResponse,
 };
+use crate::api::rest::validation::{self, decimal_field, positive_field, strictly_positive_field};
 use crate::infrastructure::{MetricsCollector, MongoDBRepository};
 use crate::session::{SessionManager, SimulationParameters};
 use crate::utils::ChainError;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use chrono::{DateTime, Utc};
-use positive::pos_or_panic;
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -48,7 +48,7 @@ use uuid::Uuid;
     ),
     responses(
         (status = 201, description = "Session created successfully", body = SessionResponse),
-        (status = 400, description = "Invalid request parameters", body = ErrorResponse),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range (e.g. negative price/volatility), or steps/chain_size exceeded the configured limits. The body includes an `error` message and the offending `field`.", body = ErrorResponse),
         (status = 409, description = "Session id already exists", body = ErrorResponse),
         (status = 500, description = "Internal server error")
     )
@@ -61,10 +61,17 @@ pub(crate) async fn create_session(
     json_req: web::Json<CreateSessionRequest>,
 ) -> impl Responder {
     info!("{} {}: body={}", req.method(), req.path(), json_req.0);
-    metrics_collector.increment_active_sessions();
 
-    // Convert request to domain SimulationParameters
-    let simulation_params: SimulationParameters = json_req.0.into();
+    // Validate and convert the request into domain SimulationParameters. Invalid input
+    // (negative/non-finite numerics, out-of-range steps/chain_size, ...) yields a 400
+    // instead of panicking during conversion. Validate before touching the active-session
+    // metric so a rejected request does not inflate the counter.
+    let simulation_params: SimulationParameters = match json_req.0.try_into() {
+        Ok(params) => params,
+        Err(error) => return map_error(error),
+    };
+
+    metrics_collector.increment_active_sessions();
 
     // Create session using session manager
     match session_manager.create_session(simulation_params) {
@@ -229,7 +236,7 @@ pub(crate) async fn get_next_step(
     ),
     responses(
         (status = 200, description = "Session replaced", body = SessionResponse),
-        (status = 400, description = "Invalid request parameters"),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits. The body includes an `error` message and the offending `field`."),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     )
@@ -260,8 +267,12 @@ pub(crate) async fn replace_session(
         }
     };
 
-    // Convert request to domain SimulationParameters
-    let simulation_params: SimulationParameters = json_req.0.into();
+    // Validate and convert the request into domain SimulationParameters; reuse the same
+    // fallible conversion as create so PUT cannot bypass the parameter bounds.
+    let simulation_params: SimulationParameters = match json_req.0.try_into() {
+        Ok(params) => params,
+        Err(error) => return map_error(error),
+    };
 
     // Replace session using session manager
     match session_manager.reinitialize_session(session_id, simulation_params) {
@@ -320,7 +331,7 @@ pub(crate) async fn replace_session(
     responses(
         (status = 200, description = "Session updated", body = SessionResponse),
         (status = 404, description = "Session not found"),
-        (status = 400, description = "Invalid request parameters"),
+        (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits. The body includes an `error` message and the offending `field`."),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -359,57 +370,109 @@ pub(crate) async fn update_session(
     // Create a new SimulationParameters object with updated values
     let mut updated_params = current_session.parameters.clone();
 
-    // Update only the fields that are provided in the request
+    // Update only the fields that are provided in the request. Every user-supplied
+    // numeric is validated with the same helpers as the create/replace conversions, so a
+    // bad float yields a 400 instead of panicking during the PATCH merge.
     if let Some(symbol) = &json_req.symbol {
         updated_params.symbol = symbol.clone();
     }
 
     if let Some(steps) = json_req.steps {
+        if steps < 1 {
+            return map_error(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "must be at least 1".to_string(),
+            });
+        }
+        if steps > *MAX_STEPS {
+            return map_error(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_STEPS, steps),
+            });
+        }
         updated_params.steps = steps;
     }
 
     if let Some(initial_price) = json_req.initial_price {
-        updated_params.initial_price = pos_or_panic!(initial_price);
+        updated_params.initial_price = match positive_field("initial_price", initial_price) {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(days_to_expiration) = json_req.days_to_expiration {
-        updated_params.days_to_expiration = pos_or_panic!(days_to_expiration);
+        updated_params.days_to_expiration =
+            match positive_field("days_to_expiration", days_to_expiration) {
+                Ok(value) => value,
+                Err(error) => return map_error(error),
+            };
     }
 
     if let Some(volatility) = json_req.volatility {
-        updated_params.volatility = pos_or_panic!(volatility);
+        updated_params.volatility = match positive_field("volatility", volatility) {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(risk_free_rate) = json_req.risk_free_rate {
-        updated_params.risk_free_rate = Decimal::try_from(risk_free_rate).unwrap_or_default();
+        updated_params.risk_free_rate = match decimal_field("risk_free_rate", risk_free_rate) {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(dividend_yield) = json_req.dividend_yield {
-        updated_params.dividend_yield = pos_or_panic!(dividend_yield);
+        updated_params.dividend_yield = match positive_field("dividend_yield", dividend_yield) {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(method) = &json_req.method {
-        updated_params.method = method.clone().into();
+        updated_params.method = match method.clone().try_into() {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(time_frame) = json_req.time_frame {
-        updated_params.time_frame = time_frame.into();
+        updated_params.time_frame = match validation::time_frame_field("time_frame", time_frame) {
+            Ok(value) => value,
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(chain_size) = json_req.chain_size {
+        if chain_size > *MAX_CHAIN_SIZE {
+            return map_error(ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_CHAIN_SIZE, chain_size),
+            });
+        }
         updated_params.chain_size = Some(chain_size);
     }
 
     if let Some(strike_interval) = json_req.strike_interval {
-        updated_params.strike_interval = Some(pos_or_panic!(strike_interval));
+        updated_params.strike_interval =
+            match strictly_positive_field("strike_interval", strike_interval) {
+                Ok(value) => Some(value),
+                Err(error) => return map_error(error),
+            };
     }
 
     if let Some(smile_curve) = json_req.smile_curve {
-        updated_params.smile_curve = Some(Decimal::try_from(smile_curve).unwrap_or_default());
+        updated_params.smile_curve = match decimal_field("smile_curve", smile_curve) {
+            Ok(value) => Some(value),
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(spread) = json_req.spread {
-        updated_params.spread = Some(pos_or_panic!(spread));
+        updated_params.spread = match positive_field("spread", spread) {
+            Ok(value) => Some(value),
+            Err(error) => return map_error(error),
+        };
     }
 
     if let Some(seed) = json_req.seed {

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -4,7 +4,7 @@ use crate::api::rest::models::SessionId;
 use crate::api::rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 use crate::api::rest::responses::{
     ChainResponse, ErrorResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
-    SessionParametersResponse, SessionResponse,
+    SessionParametersResponse, SessionResponse, ValidationErrorResponse,
 };
 use crate::api::rest::validation::{self, decimal_field, positive_field, strictly_positive_field};
 use crate::infrastructure::{MetricsCollector, MongoDBRepository};
@@ -48,7 +48,7 @@ use uuid::Uuid;
     ),
     responses(
         (status = 201, description = "Session created successfully", body = SessionResponse),
-        (status = 400, description = "Validation failed: a parameter was non-finite, out of range (e.g. negative price/volatility), or steps/chain_size exceeded the configured limits. The body includes an `error` message and the offending `field`.", body = ErrorResponse),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range (e.g. negative price/volatility), or steps/chain_size exceeded the configured limits.", body = ValidationErrorResponse),
         (status = 409, description = "Session id already exists", body = ErrorResponse),
         (status = 500, description = "Internal server error")
     )
@@ -236,7 +236,7 @@ pub(crate) async fn get_next_step(
     ),
     responses(
         (status = 200, description = "Session replaced", body = SessionResponse),
-        (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits. The body includes an `error` message and the offending `field`."),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     )
@@ -331,7 +331,7 @@ pub(crate) async fn replace_session(
     responses(
         (status = 200, description = "Session updated", body = SessionResponse),
         (status = 404, description = "Session not found"),
-        (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits. The body includes an `error` message and the offending `field`."),
+        (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
         (status = 500, description = "Internal server error")
     )
 )]

--- a/src/api/rest/limits.rs
+++ b/src/api/rest/limits.rs
@@ -1,0 +1,121 @@
+//! Configurable upper bounds for client-supplied simulation parameters.
+//!
+//! These caps protect the service from pathological requests (an enormous number of
+//! steps, an oversized option chain, or a huge historical price series) that would
+//! otherwise blow up memory or CPU. Each limit is read once from an environment
+//! variable via [`std::sync::LazyLock`]; an unset or invalid value falls back to the
+//! documented default and emits a `tracing::warn!`.
+//!
+//! | Env var                    | Default   | Meaning                                  |
+//! |----------------------------|-----------|------------------------------------------|
+//! | `OCS_MAX_STEPS`            | `10_000`  | Max simulation steps per session         |
+//! | `OCS_MAX_CHAIN_SIZE`       | `500`     | Max option-chain size per request        |
+//! | `OCS_MAX_HISTORICAL_PRICES`| `100_000` | Max historical prices in a walk request  |
+
+use std::sync::LazyLock;
+use tracing::warn;
+
+/// Default cap on the number of simulation steps per session.
+pub(crate) const DEFAULT_MAX_STEPS: usize = 10_000;
+/// Default cap on the option-chain size per request.
+pub(crate) const DEFAULT_MAX_CHAIN_SIZE: usize = 500;
+/// Default cap on the number of historical prices in a `Historical` walk request.
+pub(crate) const DEFAULT_MAX_HISTORICAL_PRICES: usize = 100_000;
+
+/// Maximum number of simulation steps a session may request (`OCS_MAX_STEPS`).
+pub(crate) static MAX_STEPS: LazyLock<usize> =
+    LazyLock::new(|| parse_limit(std::env::var("OCS_MAX_STEPS").ok(), DEFAULT_MAX_STEPS));
+
+/// Maximum option-chain size a request may ask for (`OCS_MAX_CHAIN_SIZE`).
+pub(crate) static MAX_CHAIN_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    parse_limit(
+        std::env::var("OCS_MAX_CHAIN_SIZE").ok(),
+        DEFAULT_MAX_CHAIN_SIZE,
+    )
+});
+
+/// Maximum number of historical prices a `Historical` walk may carry
+/// (`OCS_MAX_HISTORICAL_PRICES`).
+pub(crate) static MAX_HISTORICAL_PRICES: LazyLock<usize> = LazyLock::new(|| {
+    parse_limit(
+        std::env::var("OCS_MAX_HISTORICAL_PRICES").ok(),
+        DEFAULT_MAX_HISTORICAL_PRICES,
+    )
+});
+
+/// Parses a raw environment value into a positive `usize` limit.
+///
+/// Returns `default` when `raw` is `None` (variable unset) or when it does not parse
+/// into an integer `>= 1`. Invalid values are logged at `WARN` and never abort startup,
+/// keeping the service resilient to misconfiguration.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(parse_limit(None, 10), 10);
+/// assert_eq!(parse_limit(Some("42".to_string()), 10), 42);
+/// assert_eq!(parse_limit(Some("nope".to_string()), 10), 10);
+/// ```
+#[must_use]
+pub(crate) fn parse_limit(raw: Option<String>, default: usize) -> usize {
+    match raw {
+        None => default,
+        Some(value) => match value.trim().parse::<usize>() {
+            Ok(parsed) if parsed >= 1 => parsed,
+            _ => {
+                warn!(
+                    raw = %value,
+                    default,
+                    "invalid limit value; falling back to default"
+                );
+                default
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_limit_unset_uses_default() {
+        assert_eq!(parse_limit(None, 10), 10);
+    }
+
+    #[test]
+    fn test_parse_limit_valid_value_is_used() {
+        assert_eq!(parse_limit(Some("42".to_string()), 10), 42);
+    }
+
+    #[test]
+    fn test_parse_limit_trims_whitespace() {
+        assert_eq!(parse_limit(Some("  25  ".to_string()), 10), 25);
+    }
+
+    #[test]
+    fn test_parse_limit_non_numeric_falls_back() {
+        assert_eq!(parse_limit(Some("not-a-number".to_string()), 10), 10);
+    }
+
+    #[test]
+    fn test_parse_limit_zero_falls_back() {
+        assert_eq!(parse_limit(Some("0".to_string()), 10), 10);
+    }
+
+    #[test]
+    fn test_parse_limit_negative_falls_back() {
+        assert_eq!(parse_limit(Some("-5".to_string()), 10), 10);
+    }
+
+    #[test]
+    fn test_default_limits_match_documentation() {
+        // Without env overrides the parsed limits equal the documented defaults.
+        assert_eq!(*MAX_STEPS, DEFAULT_MAX_STEPS);
+        assert_eq!(*MAX_STEPS, 10_000);
+        assert_eq!(*MAX_CHAIN_SIZE, DEFAULT_MAX_CHAIN_SIZE);
+        assert_eq!(*MAX_CHAIN_SIZE, 500);
+        assert_eq!(*MAX_HISTORICAL_PRICES, DEFAULT_MAX_HISTORICAL_PRICES);
+        assert_eq!(*MAX_HISTORICAL_PRICES, 100_000);
+    }
+}

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -2,11 +2,13 @@ pub(crate) mod controller;
 mod error;
 mod favicon;
 pub(crate) mod handlers;
+pub(crate) mod limits;
 mod middleware;
 pub(crate) mod models;
 pub(crate) mod requests;
 pub(crate) mod responses;
 mod routes;
 pub mod swagger;
+pub(crate) mod validation;
 
 pub(crate) use favicon::get_favicon;

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -1,7 +1,11 @@
+use crate::api::rest::limits::MAX_HISTORICAL_PRICES;
+use crate::api::rest::validation::{
+    bounded_decimal_field, decimal_field, positive_field, strictly_positive_field,
+};
+use crate::utils::ChainError;
 use optionstratlib::simulation::WalkType;
 use optionstratlib::utils::TimeFrame;
 use positive::pos_or_panic;
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -387,26 +391,39 @@ impl From<WalkType> for ApiWalkType {
     }
 }
 
-impl From<ApiWalkType> for WalkType {
-    fn from(value: ApiWalkType) -> Self {
-        match value {
+impl TryFrom<ApiWalkType> for WalkType {
+    type Error = ChainError;
+
+    /// Validates a client-supplied [`ApiWalkType`] and converts it into the domain
+    /// [`WalkType`]. Every raw `f64` field is checked before conversion: `dt` must be
+    /// strictly positive, volatilities and other `Positive` fields must be finite and
+    /// non-negative, `Decimal` fields must be finite, an `autocorrelation` (when present)
+    /// must lie in `[-1, 1]`, and a `Historical` price series must be non-negative and no
+    /// longer than [`MAX_HISTORICAL_PRICES`]. Invalid input yields a
+    /// [`ChainError::Validation`] naming the offending field instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] on the first field that fails validation.
+    fn try_from(value: ApiWalkType) -> Result<Self, Self::Error> {
+        let walk = match value {
             ApiWalkType::Brownian {
                 dt,
                 drift,
                 volatility,
             } => WalkType::Brownian {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
             },
             ApiWalkType::GeometricBrownian {
                 dt,
                 drift,
                 volatility,
             } => WalkType::GeometricBrownian {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
             },
             ApiWalkType::LogReturns {
                 dt,
@@ -414,11 +431,12 @@ impl From<ApiWalkType> for WalkType {
                 volatility,
                 autocorrelation,
             } => WalkType::LogReturns {
-                dt: pos_or_panic!(dt),
-                expected_return: Decimal::try_from(expected_return).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
+                dt: strictly_positive_field("dt", dt)?,
+                expected_return: decimal_field("expected_return", expected_return)?,
+                volatility: positive_field("volatility", volatility)?,
                 autocorrelation: autocorrelation
-                    .map(|ac| Decimal::try_from(ac).unwrap_or_default()),
+                    .map(|ac| bounded_decimal_field("autocorrelation", ac, -1.0, 1.0))
+                    .transpose()?,
             },
             ApiWalkType::MeanReverting {
                 dt,
@@ -426,10 +444,10 @@ impl From<ApiWalkType> for WalkType {
                 speed,
                 mean,
             } => WalkType::MeanReverting {
-                dt: pos_or_panic!(dt),
-                volatility: pos_or_panic!(volatility),
-                speed: pos_or_panic!(speed),
-                mean: pos_or_panic!(mean),
+                dt: strictly_positive_field("dt", dt)?,
+                volatility: positive_field("volatility", volatility)?,
+                speed: positive_field("speed", speed)?,
+                mean: positive_field("mean", mean)?,
             },
             ApiWalkType::JumpDiffusion {
                 dt,
@@ -439,12 +457,12 @@ impl From<ApiWalkType> for WalkType {
                 jump_mean,
                 jump_volatility,
             } => WalkType::JumpDiffusion {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
-                intensity: pos_or_panic!(intensity),
-                jump_mean: Decimal::try_from(jump_mean).unwrap_or_default(),
-                jump_volatility: pos_or_panic!(jump_volatility),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
+                intensity: positive_field("intensity", intensity)?,
+                jump_mean: decimal_field("jump_mean", jump_mean)?,
+                jump_volatility: positive_field("jump_volatility", jump_volatility)?,
             },
             ApiWalkType::Garch {
                 dt,
@@ -453,11 +471,11 @@ impl From<ApiWalkType> for WalkType {
                 alpha,
                 beta,
             } => WalkType::Garch {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
-                alpha: pos_or_panic!(alpha),
-                beta: pos_or_panic!(beta),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
+                alpha: positive_field("alpha", alpha)?,
+                beta: positive_field("beta", beta)?,
             },
             ApiWalkType::Heston {
                 dt,
@@ -468,13 +486,13 @@ impl From<ApiWalkType> for WalkType {
                 xi,
                 rho,
             } => WalkType::Heston {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
-                kappa: pos_or_panic!(kappa),
-                theta: pos_or_panic!(theta),
-                xi: pos_or_panic!(xi),
-                rho: Decimal::try_from(rho).unwrap_or_default(),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
+                kappa: positive_field("kappa", kappa)?,
+                theta: positive_field("theta", theta)?,
+                xi: positive_field("xi", xi)?,
+                rho: decimal_field("rho", rho)?,
             },
             ApiWalkType::Custom {
                 dt,
@@ -484,12 +502,12 @@ impl From<ApiWalkType> for WalkType {
                 vol_speed,
                 vol_mean,
             } => WalkType::Custom {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
-                vov: pos_or_panic!(vov),
-                vol_speed: pos_or_panic!(vol_speed),
-                vol_mean: pos_or_panic!(vol_mean),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
+                vov: positive_field("vov", vov)?,
+                vol_speed: positive_field("vol_speed", vol_speed)?,
+                vol_mean: positive_field("vol_mean", vol_mean)?,
             },
             ApiWalkType::Telegraph {
                 dt,
@@ -500,24 +518,45 @@ impl From<ApiWalkType> for WalkType {
                 vol_multiplier_up,
                 vol_multiplier_down,
             } => WalkType::Telegraph {
-                dt: pos_or_panic!(dt),
-                drift: Decimal::try_from(drift).unwrap_or_default(),
-                volatility: pos_or_panic!(volatility),
-                lambda_up: pos_or_panic!(lambda_up),
-                lambda_down: pos_or_panic!(lambda_down),
-                vol_multiplier_up: vol_multiplier_up.map(|v| pos_or_panic!(v)),
-                vol_multiplier_down: vol_multiplier_down.map(|v| pos_or_panic!(v)),
+                dt: strictly_positive_field("dt", dt)?,
+                drift: decimal_field("drift", drift)?,
+                volatility: positive_field("volatility", volatility)?,
+                lambda_up: positive_field("lambda_up", lambda_up)?,
+                lambda_down: positive_field("lambda_down", lambda_down)?,
+                vol_multiplier_up: vol_multiplier_up
+                    .map(|v| positive_field("vol_multiplier_up", v))
+                    .transpose()?,
+                vol_multiplier_down: vol_multiplier_down
+                    .map(|v| positive_field("vol_multiplier_down", v))
+                    .transpose()?,
             },
             ApiWalkType::Historical {
                 timeframe,
                 prices,
                 symbol,
-            } => WalkType::Historical {
-                timeframe: timeframe.into(),
-                prices: prices.into_iter().map(|p| pos_or_panic!(p)).collect(),
-                symbol,
-            },
-        }
+            } => {
+                if prices.len() > *MAX_HISTORICAL_PRICES {
+                    return Err(ChainError::Validation {
+                        field: "prices".to_string(),
+                        reason: format!(
+                            "must not exceed {} entries, got {}",
+                            *MAX_HISTORICAL_PRICES,
+                            prices.len()
+                        ),
+                    });
+                }
+                let mut converted = Vec::with_capacity(prices.len());
+                for price in prices {
+                    converted.push(strictly_positive_field("prices", price)?);
+                }
+                WalkType::Historical {
+                    timeframe: timeframe.into(),
+                    prices: converted,
+                    symbol,
+                }
+            }
+        };
+        Ok(walk)
     }
 }
 
@@ -674,7 +713,8 @@ mod api_walktype_tests {
     fn test_walktype_to_api_walktype_conversion() {
         for walk_type in create_test_walk_types() {
             let api_walk_type: ApiWalkType = walk_type.clone().into();
-            let converted_back: WalkType = api_walk_type.into();
+            let converted_back: WalkType =
+                api_walk_type.try_into().expect("valid walk type converts");
 
             // Ensure the converted back type matches the original
             assert_eq!(
@@ -727,13 +767,87 @@ mod api_walktype_tests {
 
         for walk_type in edge_cases {
             let api_walk_type: ApiWalkType = walk_type.clone().into();
-            let converted_back: WalkType = api_walk_type.into();
+            let converted_back: WalkType =
+                api_walk_type.try_into().expect("valid walk type converts");
 
             assert_eq!(
                 walk_type, converted_back,
                 "Edge case conversion failed for {:?}",
                 walk_type
             );
+        }
+    }
+
+    /// A zero `dt` is structurally invalid and must be rejected, not panic.
+    #[test]
+    fn test_apiwalktype_zero_dt_is_validation_error() {
+        let api = ApiWalkType::Brownian {
+            dt: 0.0,
+            drift: 0.05,
+            volatility: 0.2,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "dt"),
+            other => panic!("expected Validation error for dt, got {other:?}"),
+        }
+    }
+
+    /// A non-finite volatility must be rejected, not panic.
+    #[test]
+    fn test_apiwalktype_nan_volatility_is_validation_error() {
+        let api = ApiWalkType::Brownian {
+            dt: 0.004,
+            drift: 0.05,
+            volatility: f64::NAN,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "volatility"),
+            other => panic!("expected Validation error for volatility, got {other:?}"),
+        }
+    }
+
+    /// An autocorrelation outside `[-1, 1]` must be rejected.
+    #[test]
+    fn test_apiwalktype_autocorrelation_out_of_range_is_validation_error() {
+        let api = ApiWalkType::LogReturns {
+            dt: 0.004,
+            expected_return: 0.02,
+            volatility: 0.25,
+            autocorrelation: Some(1.5),
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "autocorrelation"),
+            other => panic!("expected Validation error for autocorrelation, got {other:?}"),
+        }
+    }
+
+    /// A negative historical price must be rejected, not panic.
+    #[test]
+    fn test_apiwalktype_negative_historical_price_is_validation_error() {
+        let api = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: vec![100.0, -1.0, 102.0],
+            symbol: None,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "prices"),
+            other => panic!("expected Validation error for prices, got {other:?}"),
+        }
+    }
+
+    /// A historical price series longer than the cap must be rejected.
+    #[test]
+    fn test_apiwalktype_oversized_historical_prices_is_validation_error() {
+        use crate::api::rest::limits::MAX_HISTORICAL_PRICES;
+        let prices = vec![100.0; *MAX_HISTORICAL_PRICES + 1];
+        let api = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: None,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "prices"),
+            other => panic!("expected Validation error for prices, got {other:?}"),
         }
     }
 }

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -1,6 +1,7 @@
 use crate::api::rest::limits::MAX_HISTORICAL_PRICES;
 use crate::api::rest::validation::{
-    bounded_decimal_field, decimal_field, positive_field, strictly_positive_field,
+    bounded_decimal_field, decimal_field, positive_field, strictly_positive_field, symbol_field,
+    time_frame_field,
 };
 use crate::utils::ChainError;
 use optionstratlib::simulation::WalkType;
@@ -470,13 +471,29 @@ impl TryFrom<ApiWalkType> for WalkType {
                 volatility,
                 alpha,
                 beta,
-            } => WalkType::Garch {
-                dt: strictly_positive_field("dt", dt)?,
-                drift: decimal_field("drift", drift)?,
-                volatility: positive_field("volatility", volatility)?,
-                alpha: positive_field("alpha", alpha)?,
-                beta: positive_field("beta", beta)?,
-            },
+            } => {
+                let alpha_p = positive_field("alpha", alpha)?;
+                let beta_p = positive_field("beta", beta)?;
+                // GARCH(1,1) stationarity: alpha + beta < 1. Rejecting here
+                // keeps invalid model domains from being stored and failing
+                // later inside the simulation.
+                if alpha + beta >= 1.0 {
+                    return Err(ChainError::Validation {
+                        field: "alpha".to_string(),
+                        reason: format!(
+                            "alpha + beta must be < 1 for GARCH stationarity, got {}",
+                            alpha + beta
+                        ),
+                    });
+                }
+                WalkType::Garch {
+                    dt: strictly_positive_field("dt", dt)?,
+                    drift: decimal_field("drift", drift)?,
+                    volatility: positive_field("volatility", volatility)?,
+                    alpha: alpha_p,
+                    beta: beta_p,
+                }
+            }
             ApiWalkType::Heston {
                 dt,
                 drift,
@@ -492,7 +509,7 @@ impl TryFrom<ApiWalkType> for WalkType {
                 kappa: positive_field("kappa", kappa)?,
                 theta: positive_field("theta", theta)?,
                 xi: positive_field("xi", xi)?,
-                rho: decimal_field("rho", rho)?,
+                rho: bounded_decimal_field("rho", rho, -1.0, 1.0)?,
             },
             ApiWalkType::Custom {
                 dt,
@@ -545,12 +562,15 @@ impl TryFrom<ApiWalkType> for WalkType {
                         ),
                     });
                 }
+                if let Some(ref sym) = symbol {
+                    symbol_field("method.symbol", sym)?;
+                }
                 let mut converted = Vec::with_capacity(prices.len());
                 for price in prices {
                     converted.push(strictly_positive_field("prices", price)?);
                 }
                 WalkType::Historical {
-                    timeframe: timeframe.into(),
+                    timeframe: time_frame_field("method.timeframe", timeframe)?,
                     prices: converted,
                     symbol,
                 }
@@ -848,6 +868,78 @@ mod api_walktype_tests {
         match WalkType::try_from(api) {
             Err(ChainError::Validation { field, .. }) => assert_eq!(field, "prices"),
             other => panic!("expected Validation error for prices, got {other:?}"),
+        }
+    }
+
+    /// A negative or zero custom timeframe on a Historical walk must be a 400,
+    /// not a worker panic through the infallible conversion.
+    #[test]
+    fn test_apiwalktype_historical_negative_custom_timeframe_is_validation_error() {
+        for bad in [-1.0, 0.0] {
+            let api = ApiWalkType::Historical {
+                timeframe: ApiTimeFrame::Custom(bad),
+                prices: vec![100.0, 101.0],
+                symbol: None,
+            };
+            match WalkType::try_from(api) {
+                Err(ChainError::Validation { field, .. }) => {
+                    assert_eq!(field, "method.timeframe")
+                }
+                other => panic!("expected Validation error for timeframe {bad}, got {other:?}"),
+            }
+        }
+    }
+
+    /// An injection-shaped historical symbol must be rejected as client input
+    /// (400) at the conversion boundary, not surface later as an adapter 500.
+    #[test]
+    fn test_apiwalktype_historical_invalid_symbol_is_validation_error() {
+        let api = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: vec![],
+            symbol: Some("A' OR '1'='1".to_string()),
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "method.symbol"),
+            other => panic!("expected Validation error for symbol, got {other:?}"),
+        }
+    }
+
+    /// Heston correlation outside [-1, 1] must be rejected at creation.
+    #[test]
+    fn test_apiwalktype_heston_rho_out_of_range_is_validation_error() {
+        let api = ApiWalkType::Heston {
+            dt: 0.004,
+            drift: 0.05,
+            volatility: 0.2,
+            kappa: 1.0,
+            theta: 0.04,
+            xi: 0.3,
+            rho: 1.5,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "rho"),
+            other => panic!("expected Validation error for rho, got {other:?}"),
+        }
+    }
+
+    /// GARCH parameters violating stationarity (alpha + beta >= 1) must be
+    /// rejected before the session is stored.
+    #[test]
+    fn test_apiwalktype_garch_nonstationary_is_validation_error() {
+        let api = ApiWalkType::Garch {
+            dt: 0.004,
+            drift: 0.0,
+            volatility: 0.2,
+            alpha: 0.6,
+            beta: 0.5,
+        };
+        match WalkType::try_from(api) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "alpha");
+                assert!(reason.contains("stationarity"));
+            }
+            other => panic!("expected Validation error for alpha+beta, got {other:?}"),
         }
     }
 }

--- a/src/api/rest/responses.rs
+++ b/src/api/rest/responses.rs
@@ -126,6 +126,18 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+/// Error body returned for request-validation failures (HTTP 400): the
+/// human-readable message plus the exact request field that failed, so
+/// generated clients match the actual wire shape.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+pub struct ValidationErrorResponse {
+    /// Human-readable description of the validation failure.
+    pub error: String,
+    /// The request field that failed validation (e.g. `initial_price`,
+    /// `method.symbol`).
+    pub field: String,
+}
+
 /// Default implementation for SessionParametersResponse
 impl Default for SessionParametersResponse {
     fn default() -> Self {

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -17,6 +17,7 @@ use utoipa::OpenApi;
             crate::api::rest::requests::CreateSessionRequest,
             crate::api::rest::requests::UpdateSessionRequest,
             crate::api::rest::models::SessionId,
+            crate::api::rest::responses::ValidationErrorResponse,
         )
     ),
     tags(

--- a/src/api/rest/validation.rs
+++ b/src/api/rest/validation.rs
@@ -1,0 +1,239 @@
+//! Field-level validators for client-supplied numeric request parameters.
+//!
+//! The REST DTOs speak `f64` for JSON ergonomics, but the domain works in
+//! `Positive` / `Decimal`. These helpers perform the fallible `f64 -> typed`
+//! conversion at the DTO boundary, rejecting non-finite (`NaN`/`±inf`), negative,
+//! or out-of-domain values with a [`ChainError::Validation`] that names the
+//! offending field — instead of panicking via `pos_or_panic!` or silently zeroing
+//! bad input via `unwrap_or_default`.
+//!
+//! They are shared by every conversion that ingests raw request floats:
+//! `TryFrom<CreateSessionRequest>`, `TryFrom<ApiWalkType>`, and the PATCH merge path.
+
+use crate::api::rest::models::ApiTimeFrame;
+use crate::utils::ChainError;
+use optionstratlib::utils::TimeFrame;
+use positive::Positive;
+use rust_decimal::Decimal;
+
+/// Rejects a non-finite (`NaN` or `±inf`) user-supplied float.
+///
+/// This is checked before any conversion so the error message can point at the
+/// raw request field rather than surfacing an opaque downstream conversion error.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when `value` is not finite.
+#[must_use = "the validated value must be used"]
+pub(crate) fn finite_field(field: &str, value: f64) -> Result<f64, ChainError> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: format!("must be a finite number, got {value}"),
+        })
+    }
+}
+
+/// Validates and converts a request float into a non-negative [`Positive`] (`>= 0`).
+///
+/// Rejects `NaN`/`±inf` and negative values.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the value is non-finite or negative.
+#[must_use = "the validated value must be used"]
+pub(crate) fn positive_field(field: &str, value: f64) -> Result<Positive, ChainError> {
+    let value = finite_field(field, value)?;
+    Positive::new(value).map_err(|e| ChainError::Validation {
+        field: field.to_string(),
+        reason: e.to_string(),
+    })
+}
+
+/// Validates and converts a request float into a strictly positive [`Positive`] (`> 0`).
+///
+/// Like [`positive_field`] but additionally rejects exactly zero — used for values
+/// where zero is structurally invalid (e.g. a `dt` time step or a `strike_interval`).
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the value is non-finite, negative, or zero.
+#[must_use = "the validated value must be used"]
+pub(crate) fn strictly_positive_field(field: &str, value: f64) -> Result<Positive, ChainError> {
+    let positive = positive_field(field, value)?;
+    if positive == Positive::ZERO {
+        return Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: format!("must be greater than zero, got {value}"),
+        });
+    }
+    Ok(positive)
+}
+
+/// Validates and converts a request float into a [`Decimal`].
+///
+/// Rejects `NaN`/`±inf` and any value `Decimal` cannot represent, instead of the
+/// previous `unwrap_or_default` that silently coerced bad input to zero.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the value is non-finite or not
+/// representable as a `Decimal`.
+#[must_use = "the validated value must be used"]
+pub(crate) fn decimal_field(field: &str, value: f64) -> Result<Decimal, ChainError> {
+    let value = finite_field(field, value)?;
+    Decimal::try_from(value).map_err(|e| ChainError::Validation {
+        field: field.to_string(),
+        reason: e.to_string(),
+    })
+}
+
+/// Validates and converts a request float into a [`Decimal`] constrained to
+/// `[min, max]` (inclusive) — used for bounded parameters such as an
+/// autocorrelation coefficient in `[-1, 1]`.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the value is non-finite, outside the
+/// range, or not representable as a `Decimal`.
+#[must_use = "the validated value must be used"]
+pub(crate) fn bounded_decimal_field(
+    field: &str,
+    value: f64,
+    min: f64,
+    max: f64,
+) -> Result<Decimal, ChainError> {
+    let value = finite_field(field, value)?;
+    if !(min..=max).contains(&value) {
+        return Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: format!("must be within [{min}, {max}], got {value}"),
+        });
+    }
+    decimal_field(field, value)
+}
+
+/// Validates and converts a request [`ApiTimeFrame`] into a [`TimeFrame`].
+///
+/// The named variants convert infallibly; a `Custom(periods_per_year)` value is
+/// user input and must be a finite, strictly positive number — the infallible
+/// `From` impl would panic on a negative value.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when a `Custom` periods-per-year value is
+/// non-finite, negative, or zero.
+#[must_use = "the validated value must be used"]
+pub(crate) fn time_frame_field(field: &str, value: ApiTimeFrame) -> Result<TimeFrame, ChainError> {
+    if let ApiTimeFrame::Custom(periods) = value {
+        let validated = strictly_positive_field(field, periods)?;
+        return Ok(TimeFrame::Custom(validated));
+    }
+    Ok(value.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_time_frame_field_accepts_named_variants() {
+        assert!(matches!(
+            time_frame_field("time_frame", ApiTimeFrame::Day),
+            Ok(TimeFrame::Day)
+        ));
+    }
+
+    #[test]
+    fn test_time_frame_field_accepts_valid_custom() {
+        assert!(time_frame_field("time_frame", ApiTimeFrame::Custom(52.0)).is_ok());
+    }
+
+    #[test]
+    fn test_time_frame_field_rejects_negative_custom() {
+        match time_frame_field("time_frame", ApiTimeFrame::Custom(-1.0)) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "time_frame"),
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_time_frame_field_rejects_nan_custom() {
+        assert!(matches!(
+            time_frame_field("time_frame", ApiTimeFrame::Custom(f64::NAN)),
+            Err(ChainError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn test_finite_field_accepts_finite() {
+        assert_eq!(finite_field("x", 1.5).expect("finite is accepted"), 1.5);
+    }
+
+    #[test]
+    fn test_finite_field_rejects_nan() {
+        let err = finite_field("volatility", f64::NAN);
+        match err {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "volatility"),
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_finite_field_rejects_infinity() {
+        assert!(matches!(
+            finite_field("risk_free_rate", f64::INFINITY),
+            Err(ChainError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn test_positive_field_rejects_negative() {
+        match positive_field("initial_price", -1.0) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "initial_price"),
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_positive_field_accepts_zero() {
+        assert_eq!(
+            positive_field("dividend_yield", 0.0).expect("zero is a valid Positive"),
+            Positive::ZERO
+        );
+    }
+
+    #[test]
+    fn test_strictly_positive_field_rejects_zero() {
+        match strictly_positive_field("strike_interval", 0.0) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "strike_interval");
+                assert!(reason.contains("greater than zero"));
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decimal_field_rejects_nan() {
+        assert!(matches!(
+            decimal_field("skew_slope", f64::NAN),
+            Err(ChainError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn test_bounded_decimal_field_rejects_out_of_range() {
+        match bounded_decimal_field("autocorrelation", 1.5, -1.0, 1.0) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "autocorrelation"),
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bounded_decimal_field_accepts_within_range() {
+        assert!(bounded_decimal_field("autocorrelation", 0.5, -1.0, 1.0).is_ok());
+    }
+}

--- a/src/api/rest/validation.rs
+++ b/src/api/rest/validation.rs
@@ -134,9 +134,45 @@ pub(crate) fn time_frame_field(field: &str, value: ApiTimeFrame) -> Result<TimeF
     Ok(value.into())
 }
 
+/// Validates a client-supplied symbol at the REST boundary.
+///
+/// Delegates to the ClickHouse-layer identifier check (charset
+/// `[A-Za-z0-9._-]`, 1–32 chars) but reports the failure as a
+/// [`ChainError::Validation`] naming the request field, so a bad symbol is a
+/// client-input 400 instead of surfacing later as an adapter 500. The
+/// ClickHouse-layer check remains in place as defense in depth.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the symbol violates the identifier
+/// format.
+#[must_use = "the validation result must be used"]
+pub(crate) fn symbol_field(field: &str, symbol: &str) -> Result<(), ChainError> {
+    crate::infrastructure::validate_symbol(symbol).map_err(|e| ChainError::Validation {
+        field: field.to_string(),
+        reason: match e {
+            ChainError::ClickHouseError(msg) => msg,
+            other => other.to_string(),
+        },
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_symbol_field_accepts_valid_symbol() {
+        assert!(symbol_field("method.symbol", "BRK.B").is_ok());
+    }
+
+    #[test]
+    fn test_symbol_field_rejects_injection_as_validation() {
+        match symbol_field("method.symbol", "A' OR '1'='1") {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "method.symbol"),
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_time_frame_field_accepts_named_variants() {

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -8,7 +8,7 @@ mod telemetry;
 pub use clickhouse::ClickHouseClient;
 pub use clickhouse::interface::HistoricalDataRepository;
 pub use clickhouse::model::{OHLCVData, PriceType};
-pub(crate) use clickhouse::{calculate_required_duration, select_random_date};
+pub(crate) use clickhouse::{calculate_required_duration, select_random_date, validate_symbol};
 pub use config::clickhouse::ClickHouseConfig;
 pub use config::redis::RedisConfig;
 pub use redis::RedisClient;

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -1,4 +1,6 @@
 use crate::api::CreateSessionRequest;
+use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
+use crate::api::rest::validation::{decimal_field, positive_field, strictly_positive_field};
 use crate::session::manager::DEFAULT_NAMESPACE;
 use crate::utils::{ChainError, UuidGenerator};
 pub use optionstratlib::simulation::WalkType as SimulationMethod;
@@ -145,32 +147,84 @@ impl fmt::Display for SimulationParameters {
     }
 }
 
-impl From<CreateSessionRequest> for SimulationParameters {
-    fn from(req: CreateSessionRequest) -> Self {
-        Self {
+impl TryFrom<CreateSessionRequest> for SimulationParameters {
+    type Error = ChainError;
+
+    /// Validates a client-supplied [`CreateSessionRequest`] and converts it into the
+    /// domain [`SimulationParameters`]. This is the single place where the REST `f64`
+    /// boundary is turned into `Positive`/`Decimal`, so it rejects every out-of-domain
+    /// value here rather than panicking downstream:
+    ///
+    /// - `steps` must be in `1..=MAX_STEPS`;
+    /// - `chain_size`, when provided, must not exceed `MAX_CHAIN_SIZE`;
+    /// - numeric fields must be finite (no `NaN`/`±inf`) and, where a `Positive` is
+    ///   required, non-negative (`strike_interval` must be strictly positive);
+    /// - `risk_free_rate`, `skew_slope`, and `smile_curve` must be representable as a
+    ///   `Decimal`.
+    ///
+    /// The effective-seed contract is preserved: when the client omits the seed, one is
+    /// generated so the session stays reproducible and the seed can be reported back.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the first field that fails validation.
+    fn try_from(req: CreateSessionRequest) -> Result<Self, Self::Error> {
+        if req.steps < 1 {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "must be at least 1".to_string(),
+            });
+        }
+        if req.steps > *MAX_STEPS {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_STEPS, req.steps),
+            });
+        }
+        if let Some(chain_size) = req.chain_size
+            && chain_size > *MAX_CHAIN_SIZE
+        {
+            return Err(ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_CHAIN_SIZE, chain_size),
+            });
+        }
+
+        Ok(Self {
             symbol: req.symbol,
             steps: req.steps,
-            initial_price: pos_or_panic!(req.initial_price),
-            days_to_expiration: pos_or_panic!(req.days_to_expiration),
-            volatility: pos_or_panic!(req.volatility),
-            risk_free_rate: Decimal::try_from(req.risk_free_rate).unwrap_or_default(),
-            dividend_yield: pos_or_panic!(req.dividend_yield),
-            method: req.method.into(),
-            time_frame: req.time_frame.into(),
+            initial_price: positive_field("initial_price", req.initial_price)?,
+            days_to_expiration: positive_field("days_to_expiration", req.days_to_expiration)?,
+            volatility: positive_field("volatility", req.volatility)?,
+            risk_free_rate: decimal_field("risk_free_rate", req.risk_free_rate)?,
+            dividend_yield: positive_field("dividend_yield", req.dividend_yield)?,
+            method: req.method.try_into()?,
+            time_frame: crate::api::rest::validation::time_frame_field(
+                "time_frame",
+                req.time_frame,
+            )?,
             chain_size: req.chain_size,
-            strike_interval: req.strike_interval.map(|v| pos_or_panic!(v)),
+            strike_interval: req
+                .strike_interval
+                .map(|v| strictly_positive_field("strike_interval", v))
+                .transpose()?,
             skew_slope: req
                 .skew_slope
-                .map(|v| Decimal::try_from(v).unwrap_or_default()),
+                .map(|v| decimal_field("skew_slope", v))
+                .transpose()?,
             smile_curve: req
                 .smile_curve
-                .map(|v| Decimal::try_from(v).unwrap_or_default()),
-            spread: req.spread.map(|v| pos_or_panic!(v)),
+                .map(|v| decimal_field("smile_curve", v))
+                .transpose()?,
+            spread: req
+                .spread
+                .map(|v| positive_field("spread", v))
+                .transpose()?,
             // When the client does not provide a seed, generate one so the
             // session is still reproducible and the effective seed can be
             // reported back in the session response.
             seed: Some(req.seed.unwrap_or_else(|| rand::rng().random())),
-        }
+        })
     }
 }
 
@@ -466,7 +520,7 @@ mod tests_seed_conversion {
             ..Default::default()
         };
 
-        let params: SimulationParameters = req.into();
+        let params: SimulationParameters = req.try_into().expect("valid request converts");
         assert_eq!(params.seed, Some(42));
     }
 
@@ -478,7 +532,7 @@ mod tests_seed_conversion {
             ..Default::default()
         };
 
-        let params: SimulationParameters = req.into();
+        let params: SimulationParameters = req.try_into().expect("valid request converts");
         // An effective seed must be generated so the session is reproducible
         // and the seed can be reported back to the client
         assert!(params.seed.is_some());
@@ -491,7 +545,7 @@ mod tests_seed_conversion {
             seed: Some(7),
             ..Default::default()
         };
-        let params: SimulationParameters = req.into();
+        let params: SimulationParameters = req.try_into().expect("valid request converts");
 
         let json = serde_json::to_string(&params).unwrap();
         let restored: SimulationParameters = serde_json::from_str(&json).unwrap();
@@ -521,6 +575,99 @@ mod tests_seed_conversion {
 
         let params: SimulationParameters = serde_json::from_str(json).unwrap();
         assert_eq!(params.seed, None);
+    }
+}
+
+#[cfg(test)]
+mod tests_try_from_validation {
+    use super::*;
+    use crate::api::rest::limits::MAX_STEPS;
+
+    #[test]
+    fn test_negative_initial_price_is_validation_error() {
+        let req = CreateSessionRequest {
+            initial_price: -1.0,
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "initial_price"),
+            other => panic!("expected Validation error for initial_price, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_nan_volatility_is_validation_error() {
+        let req = CreateSessionRequest {
+            volatility: f64::NAN,
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "volatility"),
+            other => panic!("expected Validation error for volatility, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_infinite_risk_free_rate_is_validation_error() {
+        let req = CreateSessionRequest {
+            risk_free_rate: f64::INFINITY,
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "risk_free_rate"),
+            other => panic!("expected Validation error for risk_free_rate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_zero_steps_is_validation_error() {
+        let req = CreateSessionRequest {
+            steps: 0,
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "steps");
+                assert!(reason.contains("at least 1"));
+            }
+            other => panic!("expected Validation error for steps, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_steps_over_max_is_validation_error() {
+        let req = CreateSessionRequest {
+            steps: *MAX_STEPS + 1,
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "steps"),
+            other => panic!("expected Validation error for steps, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_chain_size_over_max_is_validation_error() {
+        let req = CreateSessionRequest {
+            chain_size: Some(*MAX_CHAIN_SIZE + 1),
+            ..Default::default()
+        };
+        match SimulationParameters::try_from(req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "chain_size"),
+            other => panic!("expected Validation error for chain_size, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_valid_request_converts_and_preserves_seed() {
+        let req = CreateSessionRequest {
+            seed: Some(99),
+            ..Default::default()
+        };
+        let params = SimulationParameters::try_from(req).expect("valid request converts");
+        assert_eq!(params.seed, Some(99));
+        assert_eq!(params.initial_price, pos_or_panic!(100.0));
+        assert_eq!(params.steps, 20);
     }
 }
 

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -40,6 +40,18 @@ pub enum ChainError {
     /// - `NotEnoughData(String)`
     ///   Represents errors when there isn't enough data to fulfill the requested steps.
     NotEnoughData(String),
+    /// - `Validation { field, reason }`
+    ///   Indicates that a client-supplied request parameter failed validation before it
+    ///   could be converted into a domain type (e.g. a negative `initial_price`, a
+    ///   non-finite volatility, or an out-of-range `steps` count). `field` names the
+    ///   offending request field and `reason` explains why it was rejected. This maps to
+    ///   an HTTP 400 at the REST boundary instead of panicking during conversion.
+    Validation {
+        /// The name of the request field that failed validation.
+        field: String,
+        /// A human-readable explanation of why the value was rejected.
+        reason: String,
+    },
 }
 
 impl<'a> From<&'a str> for ChainError {
@@ -90,6 +102,9 @@ impl fmt::Display for ChainError {
             ChainError::SimulatorError(msg) => write!(f, "Simulator Error: {}", msg),
             ChainError::ClickHouseError(msg) => write!(f, "ClickHouse Error: {}", msg),
             ChainError::NotEnoughData(msg) => write!(f, "Not Enough Data: {}", msg),
+            ChainError::Validation { field, reason } => {
+                write!(f, "Validation Error: {}: {}", field, reason)
+            }
         }
     }
 }
@@ -202,6 +217,13 @@ mod tests {
                 ChainError::NotEnoughData("insufficient data points".to_string()),
                 "Not Enough Data: insufficient data points",
             ),
+            (
+                ChainError::Validation {
+                    field: "initial_price".to_string(),
+                    reason: "must be greater than zero".to_string(),
+                },
+                "Validation Error: initial_price: must be greater than zero",
+            ),
         ];
 
         for (error, expected_str) in test_cases {
@@ -234,6 +256,10 @@ mod tests {
             ChainError::SimulatorError("simulation problem".to_string()),
             ChainError::ClickHouseError("database issue".to_string()),
             ChainError::NotEnoughData("insufficient data".to_string()),
+            ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "out of range".to_string(),
+            },
         ];
 
         for error in errors {
@@ -247,7 +273,24 @@ mod tests {
                 ChainError::SimulatorError(msg) => assert_eq!(msg, "simulation problem"),
                 ChainError::ClickHouseError(msg) => assert_eq!(msg, "database issue"),
                 ChainError::NotEnoughData(msg) => assert_eq!(msg, "insufficient data"),
+                ChainError::Validation { field, reason } => {
+                    assert_eq!(field, "steps");
+                    assert_eq!(reason, "out of range");
+                }
             }
         }
+    }
+
+    // Validation error Display names the field and reason.
+    #[test]
+    fn test_validation_display_names_field_and_reason() {
+        let error = ChainError::Validation {
+            field: "volatility".to_string(),
+            reason: "must be a finite number".to_string(),
+        };
+        assert_eq!(
+            error.to_string(),
+            "Validation Error: volatility: must be a finite number"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Request DTOs accepted unconstrained numbers and the infallible `From`
conversions called panicking macros — a request with `initial_price = -1.0`
panicked a worker instead of returning 400, invalid decimals were silently
zeroed by `unwrap_or_default`, and `steps`/`chain_size`/historical payloads
had no resource bounds. All user-controlled numerics are now validated through
fallible conversions that return a structured 400 naming the offending field.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 4**
- **Base branch:** `stack/3-7-unique-session-ids`
- **Stacked on:** #25 · **Blocks:** the next PR in the stack (#21)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- New `ChainError::Validation { field, reason }` → HTTP 400 with `{"error", "field"}` body.
- `From` → `TryFrom` for `CreateSessionRequest → SimulationParameters` and
  `ApiWalkType → WalkType` (still exhaustive, no `_ =>`): finite checks before
  conversion, `Positive::new` instead of `pos_or_panic!` on user input,
  `Decimal::try_from` errors propagate, autocorrelation ∈ [-1,1], historical
  prices each positive and capped.
- `ApiTimeFrame::Custom` validated (finite, > 0) via `time_frame_field` — the
  infallible conversion panicked on a negative custom timeframe.
- Env-configurable bounds in `api/rest/limits.rs` (`OCS_MAX_STEPS` 10_000,
  `OCS_MAX_CHAIN_SIZE` 500, `OCS_MAX_HISTORICAL_PRICES` 100_000; parse-once
  `LazyLock`, warn+default on invalid).
- Shared `api/rest/validation.rs` helpers reused by create/PUT/PATCH merge
  paths; PATCH no longer uses any panicking conversion.
- POST metric increment moved after validation (a rejected request no longer
  inflates the active-sessions gauge — completes under #16 later in the stack).

## Contract impact

Additive: requests that previously panicked the worker or silently zeroed
values now return a documented 400 whose body includes `field`. Success
responses unchanged. Effective-seed generation and the same-seed ⇒ same-tape
contract untouched (reproducibility tests green).

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 280 + 2 passed, 0 failed (~30 new tests)
- [x] Panic regression: `initial_price = -1.0` → `Validation`, no panic; NaN/inf/zero-steps/over-bounds/oversized-prices/autocorrelation 1.5 all covered
- [x] Bounds parser unit-tested as a pure function; defaults asserted
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] f64 → typed conversion stays only in the `From`/`TryFrom` impls + shared validators
- [x] `ApiWalkType` matches remain exhaustive both directions
- [x] No `.unwrap()` / `.expect()` on request input paths
- [x] No new dependencies; no `unsafe`; `tracing` only

Closes #10
