### PR TITLE
Split safe GET peek from POST step advancement (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,21 @@ Infra --> MongoDB[(MongoDB)]
 ```mermaid
 stateDiagram-v2
 [*] --> Initialized: POST /api/v1/chain
-Initialized --> InProgress: GET
-InProgress --> InProgress: GET
+Initialized --> InProgress: POST /api/v1/chain/step
+InProgress --> InProgress: POST /api/v1/chain/step
 InProgress --> Modified: PATCH
-Modified --> InProgress: GET
+Modified --> InProgress: POST /api/v1/chain/step
 InProgress --> Reinitialized: PUT
 Modified --> Reinitialized: PUT
-Reinitialized --> InProgress: GET
+Reinitialized --> InProgress: POST /api/v1/chain/step
 Initialized --> [*]: DELETE
 InProgress --> [*]: DELETE
 Modified --> [*]: DELETE
 Reinitialized --> [*]: DELETE
 ```
+
+`GET /api/v1/chain` is a safe, repeatable peek and does not appear here because it
+never changes the session state — only `POST /api/v1/chain/step` advances the cursor.
 
 ### API Request Flow
 
@@ -66,25 +69,40 @@ SS-->>SM: Initial state
 SM-->>API: Session created (id: abc123)
 API-->>Client: 201 Created (session details)
 
-Client->>API: GET /api/v1/chain
-API->>SM: Get next step
+Client->>API: POST /api/v1/chain/step
+API->>SM: Advance one step
 SM->>SS: Advance simulation
 SS-->>SM: Step data
 SM-->>API: Chain data
 API-->>Client: 200 OK (Chain data)
+
+Client->>API: GET /api/v1/chain
+API->>SM: Peek current step
+SM->>SS: Read current snapshot
+SS-->>SM: Step data (no advance)
+SM-->>API: Chain data
+API-->>Client: 200 OK (same snapshot, repeatable)
 ```
 
 ### REST API Endpoints
 
 The OptionChain-Simulator exposes the following REST API endpoints:
 
-| Method | Endpoint       | Action           | Description                                      |
-|--------|---------------|------------------|--------------------------------------------------|
-| POST   | /api/v1/chain | Create Session   | Creates a new simulation session                 |
-| GET    | /api/v1/chain | Read Next Step   | Gets the next step in the simulation            |
-| PUT    | /api/v1/chain | Replace Session  | Completely replaces session parameters          |
-| PATCH  | /api/v1/chain | Update Parameters| Updates specific session parameters             |
-| DELETE | /api/v1/chain | Delete Session   | Terminates and removes a session                 |
+| Method | Endpoint           | Action              | Description                                                      |
+|--------|--------------------|---------------------|------------------------------------------------------------------|
+| POST   | /api/v1/chain      | Create Session      | Creates a new simulation session                                 |
+| GET    | /api/v1/chain      | Read Current Step   | Returns the current snapshot WITHOUT advancing (safe, repeatable)|
+| POST   | /api/v1/chain/step | Advance Step        | Advances one step, serves the snapshot, and persists the advance |
+| PUT    | /api/v1/chain      | Replace Session     | Completely replaces session parameters                           |
+| PATCH  | /api/v1/chain      | Update Parameters   | Updates specific session parameters                              |
+| DELETE | /api/v1/chain      | Delete Session      | Terminates and removes a session                                 |
+
+> **Migration (breaking, issue #21):** `GET /api/v1/chain` used to advance the
+> session and consume a step. It is now a read-only, repeatable **peek** that returns
+> the current snapshot without mutating state. To advance the cursor, clients must now
+> call **`POST /api/v1/chain/step`** (same response shape, same 200/404/410/500 status
+> codes as the old GET). Downstream consumers such as IronCondor must switch their
+> step-advancing call from `GET /api/v1/chain` to `POST /api/v1/chain/step`.
 
 ### Request/Response Models
 
@@ -138,7 +156,12 @@ The OptionChain-Simulator exposes the following REST API endpoints:
 }
 ```
 
-#### 2. Get Next Step (GET /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
+#### 2. Peek Current Step (GET /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
+
+Safe and repeatable: returns the session's current snapshot without advancing the
+cursor or persisting anything. To advance the session and consume a step, use
+`POST /api/v1/chain/step?sessionid=...` (issue #21) — it takes the same query
+parameter and returns the same body shown below.
 
 **Response (200 OK):**
 ```json

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -8,14 +8,61 @@ use crate::api::rest::responses::{
 };
 use crate::api::rest::validation::{self, decimal_field, positive_field, strictly_positive_field};
 use crate::infrastructure::{MetricsCollector, MongoDBRepository};
-use crate::session::{SessionManager, SimulationParameters};
+use crate::session::{Session, SessionManager, SimulationParameters};
 use crate::utils::ChainError;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use chrono::{DateTime, Utc};
+use optionstratlib::chains::OptionChain;
 use rust_decimal::prelude::ToPrimitive;
 use std::sync::Arc;
 use tracing::{error, info};
 use uuid::Uuid;
+
+/// Builds the `ChainResponse` DTO shared by the advance (`POST /api/v1/chain/step`) and
+/// peek (`GET /api/v1/chain`) endpoints from a session and its current option-chain
+/// snapshot. Kept as a single place so both surfaces emit an identical response shape.
+fn build_chain_response(session: &Session, option_chain: &OptionChain) -> ChainResponse {
+    let expiration = option_chain.get_expiration_date();
+    ChainResponse {
+        underlying: option_chain.symbol.clone(),
+        timestamp: Utc::now().to_rfc3339(),
+        price: option_chain.underlying_price.into(),
+        contracts: option_chain
+            .iter()
+            .map(|contract| {
+                let (call_delta, put_delta) = contract.current_deltas();
+                let call_ask = contract.get_call_buy_price();
+                let put_ask = contract.get_put_buy_price();
+                let call_bid = contract.get_call_sell_price();
+                let put_bid = contract.get_put_sell_price();
+                let volatility = contract.get_volatility();
+                OptionContractResponse {
+                    strike: contract.strike().into(),
+                    expiration: expiration.clone(),
+                    call: OptionPriceResponse {
+                        bid: call_bid.map(|b| b.into()),
+                        ask: call_ask.map(|a| a.into()),
+                        mid: contract.call_middle.map(|m| m.into()),
+                        delta: call_delta.map(|d| d.to_f64().unwrap_or(0.0)),
+                    },
+                    put: OptionPriceResponse {
+                        bid: put_bid.map(|b| b.into()),
+                        ask: put_ask.map(|a| a.into()),
+                        mid: contract.put_middle.map(|m| m.into()),
+                        delta: put_delta.map(|d| d.to_f64().unwrap_or(0.0)),
+                    },
+                    implied_volatility: Some(volatility.into()),
+                    gamma: contract.current_gamma().map(|g| g.to_f64().unwrap_or(0.0)),
+                }
+            })
+            .collect(),
+        session_info: SessionInfoResponse {
+            id: session.id.to_string(),
+            current_step: session.current_step,
+            total_steps: session.total_steps,
+        },
+    }
+}
 
 #[utoipa::path(
     post,
@@ -121,19 +168,22 @@ pub(crate) async fn create_session(
 }
 
 #[utoipa::path(
-    get,
-    path = "/api/v1/chain",
+    post,
+    path = "/api/v1/chain/step",
+    description = "Advance the session one step and return the served snapshot. This is an \
+        explicit, state-mutating command (the former GET behavior): it serves the next \
+        step and persists the advance. Use GET /api/v1/chain for a safe, repeatable peek.",
     params(
-        ("sessionid" = String, Query, description = "ID of the session to get next step for")
+        ("sessionid" = String, Query, description = "ID of the session to advance one step")
     ),
     responses(
-        (status = 200, description = "Next step returned", body = ChainResponse),
+        (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
         (status = 404, description = "Session not found"),
         (status = 410, description = "Simulation completed. No more steps available"),
         (status = 500, description = "Internal server error")
     )
 )]
-pub(crate) async fn get_next_step(
+pub(crate) async fn advance_step(
     req: HttpRequest,
     session_manager: web::Data<Arc<SessionManager>>,
     metrics_collector: web::Data<Arc<MetricsCollector>>,
@@ -158,50 +208,10 @@ pub(crate) async fn get_next_step(
         }
     };
 
-    // Get next step from session manager
+    // Advance the session one step (mutates state and persists it).
     match session_manager.get_next_step(session_id).await {
         Ok((session, option_chain)) => {
-            // Convert session and option chain to ChainResponse
-            let expiration = option_chain.get_expiration_date();
-            let response = ChainResponse {
-                underlying: option_chain.symbol.clone(),
-                timestamp: Utc::now().to_rfc3339(),
-                price: option_chain.underlying_price.into(),
-                contracts: option_chain
-                    .iter()
-                    .map(|contract| {
-                        let (call_delta, put_delta) = contract.current_deltas();
-                        let call_ask = contract.get_call_buy_price();
-                        let put_ask = contract.get_put_buy_price();
-                        let call_bid = contract.get_call_sell_price();
-                        let put_bid = contract.get_put_sell_price();
-                        let volatility = contract.get_volatility();
-                        OptionContractResponse {
-                            strike: contract.strike().into(),
-                            expiration: expiration.clone(),
-                            call: OptionPriceResponse {
-                                bid: call_bid.map(|b| b.into()),
-                                ask: call_ask.map(|a| a.into()),
-                                mid: contract.call_middle.map(|m| m.into()),
-                                delta: call_delta.map(|d| d.to_f64().unwrap()),
-                            },
-                            put: OptionPriceResponse {
-                                bid: put_bid.map(|b| b.into()),
-                                ask: put_ask.map(|a| a.into()),
-                                mid: contract.put_middle.map(|m| m.into()),
-                                delta: put_delta.map(|d| d.to_f64().unwrap()),
-                            },
-                            implied_volatility: Some(volatility.into()),
-                            gamma: contract.current_gamma().map(|g| g.to_f64().unwrap()),
-                        }
-                    })
-                    .collect(),
-                session_info: SessionInfoResponse {
-                    id: session.id.to_string(),
-                    current_step: session.current_step,
-                    total_steps: session.total_steps,
-                },
-            };
+            let response = build_chain_response(&session, &option_chain);
             let duration = start_time.elapsed();
             metrics_collector.record_simulation_step(&session.parameters.method.to_string());
             metrics_collector.record_simulation_duration(duration);
@@ -218,6 +228,57 @@ pub(crate) async fn get_next_step(
                 error!(session_id = %session_id, "Failed to save chain step to MongoDB: {}", e);
                 // Continue as this is not critical for the main flow
             }
+            HttpResponse::Ok().json(response)
+        }
+        Err(error) => map_error(error),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/chain",
+    description = "Returns the current snapshot without advancing the session; safe and \
+        repeatable (a peek). The same snapshot is returned until an explicit advance via \
+        POST /api/v1/chain/step moves the cursor. This endpoint does not mutate session \
+        state or record a simulation step.",
+    params(
+        ("sessionid" = String, Query, description = "ID of the session to read the current snapshot for")
+    ),
+    responses(
+        (status = 200, description = "Current snapshot returned (read-only; repeatable)", body = ChainResponse),
+        (status = 404, description = "Session not found"),
+        (status = 410, description = "Session completed; no current step available"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub(crate) async fn get_current_step(
+    req: HttpRequest,
+    session_manager: web::Data<Arc<SessionManager>>,
+    query: web::Query<SessionId>,
+) -> impl Responder {
+    info!(
+        "{} {}: session_id={}",
+        req.method(),
+        req.path(),
+        query.session_id
+    );
+
+    // Parse the session ID
+    let session_id = match Uuid::parse_str(&query.session_id) {
+        Ok(id) => id,
+        Err(_) => {
+            return map_error(ChainError::InvalidState(
+                "Invalid session ID format".to_string(),
+            ));
+        }
+    };
+
+    // Peek the current snapshot: read-only, repeatable, no state change and no persistence.
+    // No simulation-step metric is recorded and no chain-step event is written, because the
+    // same step is served repeatedly.
+    match session_manager.peek_current_step(session_id).await {
+        Ok((session, option_chain)) => {
+            let response = build_chain_response(&session, &option_chain);
             HttpResponse::Ok().json(response)
         }
         Err(error) => map_error(error),

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -14,8 +14,10 @@ use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use chrono::{DateTime, Utc};
 use optionstratlib::chains::OptionChain;
 use rust_decimal::prelude::ToPrimitive;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, info};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 /// Builds the `ChainResponse` DTO shared by the advance (`POST /api/v1/chain/step`) and
@@ -167,19 +169,39 @@ pub(crate) async fn create_session(
     }
 }
 
+/// Query parameters for the advance-step command: the session id plus an
+/// optional expected-cursor precondition for safe retries.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub(crate) struct AdvanceStepQuery {
+    /// ID of the session to advance one step.
+    #[serde(rename = "sessionid")]
+    pub(crate) session_id: String,
+    /// Optional expected cursor: when provided, the advance only proceeds if
+    /// the session's current step matches — otherwise 412 is returned with
+    /// the actual cursor, letting a client resolve an ambiguous retry
+    /// (response lost after the save) without consuming another step.
+    #[serde(default)]
+    pub(crate) expected_step: Option<usize>,
+}
+
 #[utoipa::path(
     post,
     path = "/api/v1/chain/step",
     description = "Advance the session one step and return the served snapshot. This is an \
         explicit, state-mutating command (the former GET behavior): it serves the next \
-        step and persists the advance. Use GET /api/v1/chain for a safe, repeatable peek.",
+        step and persists the advance. Use GET /api/v1/chain for a safe, repeatable peek. \
+        Pass `expected_step` (the cursor you believe the session is at) to make retries \
+        safe: if a previous attempt already consumed the step, the call returns 412 with \
+        the actual cursor instead of consuming another one.",
     params(
-        ("sessionid" = String, Query, description = "ID of the session to advance one step")
+        ("sessionid" = String, Query, description = "ID of the session to advance one step"),
+        ("expected_step" = Option<usize>, Query, description = "Expected current cursor; mismatch returns 412 without advancing")
     ),
     responses(
         (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
         (status = 404, description = "Session not found"),
         (status = 410, description = "Simulation completed. No more steps available"),
+        (status = 412, description = "expected_step does not match the session's current cursor; body carries `error` and `current_step`"),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -188,7 +210,7 @@ pub(crate) async fn advance_step(
     session_manager: web::Data<Arc<SessionManager>>,
     metrics_collector: web::Data<Arc<MetricsCollector>>,
     mongodb_repo: web::Data<Arc<MongoDBRepository>>,
-    query: web::Query<SessionId>,
+    query: web::Query<AdvanceStepQuery>,
 ) -> impl Responder {
     info!(
         "{} {}: session_id={}",
@@ -207,6 +229,22 @@ pub(crate) async fn advance_step(
             ));
         }
     };
+
+    // Expected-cursor precondition: a transport-level check (412) so an
+    // ambiguous retry can be resolved without consuming another step.
+    if let Some(expected) = query.expected_step {
+        match session_manager.get_session(session_id) {
+            Ok(session) => {
+                if session.current_step != expected {
+                    return HttpResponse::PreconditionFailed().json(serde_json::json!({
+                        "error": "expected_step does not match the session's current cursor",
+                        "current_step": session.current_step,
+                    }));
+                }
+            }
+            Err(error) => return map_error(error),
+        }
+    }
 
     // Advance the session one step (mutates state and persists it).
     match session_manager.get_next_step(session_id).await {
@@ -645,5 +683,25 @@ pub(crate) async fn delete_session(
             error!("{}", error);
             map_error(error)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_advance_step_query {
+    use super::AdvanceStepQuery;
+
+    #[test]
+    fn test_expected_step_absent_deserializes_to_none() {
+        let q: AdvanceStepQuery =
+            serde_json::from_str(r#"{"sessionid":"abc"}"#).expect("query must parse");
+        assert_eq!(q.session_id, "abc");
+        assert_eq!(q.expected_step, None);
+    }
+
+    #[test]
+    fn test_expected_step_present_deserializes_to_some() {
+        let q: AdvanceStepQuery = serde_json::from_str(r#"{"sessionid":"abc","expected_step":3}"#)
+            .expect("query must parse");
+        assert_eq!(q.expected_step, Some(3));
     }
 }

--- a/src/api/rest/routes.rs
+++ b/src/api/rest/routes.rs
@@ -1,6 +1,6 @@
 use crate::api::rest::get_favicon;
 use crate::api::rest::handlers::{
-    create_session, delete_session, get_next_step, replace_session, update_session,
+    advance_step, create_session, delete_session, get_current_step, replace_session, update_session,
 };
 use crate::api::rest::middleware::metrics_endpoint;
 use crate::api::rest::swagger::ApiDoc;
@@ -30,10 +30,15 @@ use utoipa_swagger_ui::SwaggerUi;
 /// - **POST** `/api/v1/chain`  
 ///   Handled by the `create_session` function. This is used to create a new session.
 ///
-/// - **GET** `/api/v1/chain`  
-///   Handled by the `get_next_step` function. This is used to fetch the next step of the session.
+/// - **GET** `/api/v1/chain`
+///   Handled by the `get_current_step` function. This is a safe, repeatable peek that
+///   returns the session's current snapshot WITHOUT advancing or persisting it.
 ///
-/// - **PUT** `/api/v1/chain`  
+/// - **POST** `/api/v1/chain/step`
+///   Handled by the `advance_step` function. This advances the session one step, serves
+///   the resulting snapshot, and persists the advance (the former GET behavior).
+///
+/// - **PUT** `/api/v1/chain`
 ///   Handled by the `replace_session` function. This is used to replace an existing session with new data.
 ///
 /// - **PATCH** `/api/v1/chain`  
@@ -60,11 +65,12 @@ pub fn configure_routes(
         .service(
             web::resource("/api/v1/chain")
                 .route(web::post().to(create_session))
-                .route(web::get().to(get_next_step))
+                .route(web::get().to(get_current_step))
                 .route(web::put().to(replace_session))
                 .route(web::patch().to(update_session))
                 .route(web::delete().to(delete_session)),
         )
+        .service(web::resource("/api/v1/chain/step").route(web::post().to(advance_step)))
         .route("/metrics", web::get().to(metrics_endpoint))
         .route("/favicon.ico", web::get().to(get_favicon))
         .service(

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -4,7 +4,8 @@ use utoipa::OpenApi;
 #[openapi(
     paths(
         crate::api::rest::handlers::create_session,
-        crate::api::rest::handlers::get_next_step,
+        crate::api::rest::handlers::get_current_step,
+        crate::api::rest::handlers::advance_step,
         crate::api::rest::handlers::replace_session,
         crate::api::rest::handlers::update_session,
         crate::api::rest::handlers::delete_session,
@@ -61,7 +62,8 @@ mod tests {
 
         // Expected paths based on the OpenAPI derive macro
         let expected_paths = vec![
-            "/api/v1/chain", // Matches the handlers in the macro
+            "/api/v1/chain",      // create / peek (GET) / replace / update / delete
+            "/api/v1/chain/step", // advance one step (POST)
         ];
 
         for path in expected_paths {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,18 +20,21 @@
 //! ```mermaid
 //! stateDiagram-v2
 //! [*] --> Initialized: POST /api/v1/chain
-//! Initialized --> InProgress: GET
-//! InProgress --> InProgress: GET
+//! Initialized --> InProgress: POST /api/v1/chain/step
+//! InProgress --> InProgress: POST /api/v1/chain/step
 //! InProgress --> Modified: PATCH
-//! Modified --> InProgress: GET
+//! Modified --> InProgress: POST /api/v1/chain/step
 //! InProgress --> Reinitialized: PUT
 //! Modified --> Reinitialized: PUT
-//! Reinitialized --> InProgress: GET
+//! Reinitialized --> InProgress: POST /api/v1/chain/step
 //! Initialized --> [*]: DELETE
 //! InProgress --> [*]: DELETE
 //! Modified --> [*]: DELETE
 //! Reinitialized --> [*]: DELETE
 //! ```
+//!
+//! `GET /api/v1/chain` is a safe, repeatable peek and does not appear here because it
+//! never changes the session state — only `POST /api/v1/chain/step` advances the cursor.
 //!
 //! ## API Request Flow
 //!
@@ -49,25 +52,40 @@
 //! SM-->>API: Session created (id: abc123)
 //! API-->>Client: 201 Created (session details)
 //!
-//! Client->>API: GET /api/v1/chain
-//! API->>SM: Get next step
+//! Client->>API: POST /api/v1/chain/step
+//! API->>SM: Advance one step
 //! SM->>SS: Advance simulation
 //! SS-->>SM: Step data
 //! SM-->>API: Chain data
 //! API-->>Client: 200 OK (Chain data)
+//!
+//! Client->>API: GET /api/v1/chain
+//! API->>SM: Peek current step
+//! SM->>SS: Read current snapshot
+//! SS-->>SM: Step data (no advance)
+//! SM-->>API: Chain data
+//! API-->>Client: 200 OK (same snapshot, repeatable)
 //! ```
 //!
 //! ## REST API Endpoints
 //!
 //! The OptionChain-Simulator exposes the following REST API endpoints:
 //!
-//! | Method | Endpoint       | Action           | Description                                      |
-//! |--------|---------------|------------------|--------------------------------------------------|
-//! | POST   | /api/v1/chain | Create Session   | Creates a new simulation session                 |
-//! | GET    | /api/v1/chain | Read Next Step   | Gets the next step in the simulation            |
-//! | PUT    | /api/v1/chain | Replace Session  | Completely replaces session parameters          |
-//! | PATCH  | /api/v1/chain | Update Parameters| Updates specific session parameters             |
-//! | DELETE | /api/v1/chain | Delete Session   | Terminates and removes a session                 |
+//! | Method | Endpoint           | Action              | Description                                                      |
+//! |--------|--------------------|---------------------|------------------------------------------------------------------|
+//! | POST   | /api/v1/chain      | Create Session      | Creates a new simulation session                                 |
+//! | GET    | /api/v1/chain      | Read Current Step   | Returns the current snapshot WITHOUT advancing (safe, repeatable)|
+//! | POST   | /api/v1/chain/step | Advance Step        | Advances one step, serves the snapshot, and persists the advance |
+//! | PUT    | /api/v1/chain      | Replace Session     | Completely replaces session parameters                           |
+//! | PATCH  | /api/v1/chain      | Update Parameters   | Updates specific session parameters                              |
+//! | DELETE | /api/v1/chain      | Delete Session      | Terminates and removes a session                                 |
+//!
+//! > **Migration (breaking, issue #21):** `GET /api/v1/chain` used to advance the
+//! > session and consume a step. It is now a read-only, repeatable **peek** that returns
+//! > the current snapshot without mutating state. To advance the cursor, clients must now
+//! > call **`POST /api/v1/chain/step`** (same response shape, same 200/404/410/500 status
+//! > codes as the old GET). Downstream consumers such as IronCondor must switch their
+//! > step-advancing call from `GET /api/v1/chain` to `POST /api/v1/chain/step`.
 //!
 //! ## Request/Response Models
 //!
@@ -121,7 +139,12 @@
 //! }
 //! ```
 //!
-//! ### 2. Get Next Step (GET /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
+//! ### 2. Peek Current Step (GET /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
+//!
+//! Safe and repeatable: returns the session's current snapshot without advancing the
+//! cursor or persisting anything. To advance the session and consume a step, use
+//! `POST /api/v1/chain/step?sessionid=...` (issue #21) — it takes the same query
+//! parameter and returns the same body shown below.
 //!
 //! **Response (200 OK):**
 //! ```json

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -178,6 +178,14 @@ impl SessionManager {
                 "session completed; no current step".to_string(),
             ));
         }
+        // `Error` is the other terminal state (`Session::is_active`); a peek
+        // must reject it like the advance path does instead of serving a
+        // snapshot from a session that can no longer progress.
+        if session.state == SessionState::Error {
+            return Err(ChainError::InvalidState(
+                "Session is in error state".to_string(),
+            ));
+        }
 
         // Read-only: build/read the walk at the current step. This never advances the
         // counter and never persists the session.
@@ -462,6 +470,31 @@ mod tests {
                 assert_eq!(msg, "session completed; no current step");
             }
             other => panic!("expected SimulatorError for completed peek, got {other:?}"),
+        }
+    }
+
+    /// `Error` is terminal too: a peek must reject it instead of serving a
+    /// snapshot from a session that can no longer progress.
+    #[tokio::test]
+    async fn test_peek_on_error_session_returns_invalid_state() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = SessionManager::new(store.clone());
+        let session = manager
+            .create_session(test_parameters())
+            .expect("failed to create session");
+        let id = session.id;
+
+        let mut errored = store.get(id).expect("session missing from store");
+        errored.state = SessionState::Error;
+        store
+            .save(errored)
+            .expect("failed to persist errored session");
+
+        match manager.peek_current_step(id).await {
+            Err(ChainError::InvalidState(msg)) => {
+                assert_eq!(msg, "Session is in error state");
+            }
+            other => panic!("expected InvalidState for errored peek, got {other:?}"),
         }
     }
 }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,6 +1,6 @@
 use crate::domain::Simulator;
 use crate::session::SessionStore;
-use crate::session::model::{Session, SimulationParameters};
+use crate::session::model::{Session, SessionState, SimulationParameters};
 use crate::session::state_handler::StateProgressionHandler;
 use crate::utils::error::ChainError;
 use optionstratlib::chains::OptionChain;
@@ -136,6 +136,56 @@ impl SessionManager {
 
         // Save updated session
         self.store.save(session.clone())?;
+
+        Ok((session, chain))
+    }
+
+    /// Returns the session's CURRENT chain snapshot without advancing or persisting it.
+    ///
+    /// This is the read-only, repeatable counterpart to [`SessionManager::get_next_step`]:
+    /// it serves the snapshot at `session.current_step` and leaves the session state, the
+    /// step counter, and the store untouched. Calling it repeatedly yields the same
+    /// snapshot until an explicit advance ([`SessionManager::get_next_step`]) moves the
+    /// cursor.
+    ///
+    /// The domain walk cache may be populated as a side effect of building the snapshot,
+    /// but no session state ever changes and nothing is written back to the store.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - A `Uuid` identifying the session to peek.
+    ///
+    /// # Returns
+    ///
+    /// A tuple `(Session, OptionChain)` with the unchanged session and its current
+    /// snapshot.
+    ///
+    /// # Errors
+    ///
+    /// This function may return the following errors encapsulated in `ChainError`:
+    /// - [`ChainError::NotFound`] if the session does not exist in the store.
+    /// - [`ChainError::SimulatorError`] if the session has already completed all steps
+    ///   (there is no current step to serve); this maps to HTTP 410 like the
+    ///   exhausted-advance path.
+    /// - Any error surfaced by the simulator while building the current snapshot.
+    pub async fn peek_current_step(&self, id: Uuid) -> Result<(Session, OptionChain), ChainError> {
+        let session = self.store.get(id)?;
+
+        // A completed session has no current step to serve; mirror the exhausted-advance
+        // path (410 Gone) rather than returning stale data.
+        if session.state == SessionState::Completed {
+            return Err(ChainError::SimulatorError(
+                "session completed; no current step".to_string(),
+            ));
+        }
+
+        // Read-only: build/read the walk at the current step. This never advances the
+        // counter and never persists the session.
+        let chain = self
+            .simulator
+            .simulate_next_step(&session)
+            .await
+            .map_err(|e| ChainError::SimulatorError(e.to_string()))?;
 
         Ok((session, chain))
     }
@@ -329,5 +379,89 @@ mod tests {
         let second = manager.create_session(test_parameters()).unwrap();
 
         assert_ne!(first.id, second.id);
+    }
+
+    /// Issue #21: GET is a peek. `peek_current_step` must be repeatable and must not
+    /// mutate the stored session (no cursor advance, no state change, no save).
+    #[tokio::test]
+    async fn test_peek_current_step_is_repeatable_and_read_only() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = SessionManager::new(store.clone());
+        let session = manager
+            .create_session(test_parameters())
+            .expect("failed to create session");
+        let id = session.id;
+
+        let (first, _) = manager
+            .peek_current_step(id)
+            .await
+            .expect("first peek failed");
+        let (second, _) = manager
+            .peek_current_step(id)
+            .await
+            .expect("second peek failed");
+
+        // Peek is repeatable: the served cursor does not move between calls.
+        assert_eq!(first.current_step, second.current_step);
+        assert_eq!(first.current_step, 0);
+        assert_eq!(first.state, SessionState::Initialized);
+
+        // Peek is read-only: the stored session is untouched.
+        let stored = store.get(id).expect("session missing from store");
+        assert_eq!(stored.current_step, 0);
+        assert_eq!(stored.state, SessionState::Initialized);
+    }
+
+    /// After an explicit advance, peek reflects the new cursor and still does not move it.
+    #[tokio::test]
+    async fn test_advance_then_peek_reflects_new_cursor() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = SessionManager::new(store.clone());
+        let session = manager
+            .create_session(test_parameters())
+            .expect("failed to create session");
+        let id = session.id;
+
+        // Advance moves the cursor and persists it.
+        let (advanced, _) = manager.get_next_step(id).await.expect("advance failed");
+        assert_eq!(advanced.current_step, 1);
+
+        // Peek now reflects the advanced cursor without moving it further.
+        let (peeked, _) = manager
+            .peek_current_step(id)
+            .await
+            .expect("peek after advance failed");
+        assert_eq!(peeked.current_step, advanced.current_step);
+
+        let stored = store.get(id).expect("session missing from store");
+        assert_eq!(stored.current_step, 1);
+        assert_eq!(stored.state, SessionState::InProgress);
+    }
+
+    /// Peek on a Completed session has no current step to serve and returns a
+    /// `SimulatorError` (mapped to HTTP 410), mirroring the exhausted-advance path.
+    #[tokio::test]
+    async fn test_peek_on_completed_session_returns_simulator_error() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = SessionManager::new(store.clone());
+        let session = manager
+            .create_session(test_parameters())
+            .expect("failed to create session");
+        let id = session.id;
+
+        // Force the session into the Completed state directly in the store.
+        let mut completed = store.get(id).expect("session missing from store");
+        completed.current_step = completed.total_steps;
+        completed.state = SessionState::Completed;
+        store
+            .save(completed)
+            .expect("failed to persist completed session");
+
+        match manager.peek_current_step(id).await {
+            Err(ChainError::SimulatorError(msg)) => {
+                assert_eq!(msg, "session completed; no current step");
+            }
+            other => panic!("expected SimulatorError for completed peek, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/chain` advanced and persisted the session on every call — a
mutating GET that let browsers, proxies, retries, prefetchers, and monitoring
consume steps unintentionally. Reads and advances are now separate endpoints:
GET is a safe, repeatable peek; advancing is an explicit POST command.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 5**
- **Base branch:** `stack/4-10-validate-request-params`
- **Stacked on:** #26 · **Blocks:** the next PR in the stack (#5)
- The diff is cumulative until the lower PRs merge — review against the base branch.
- Note: the cursor semantics POST exposes (serve-then-advance, index-0
  handling, persisted completion) are fixed by the NEXT PR in the stack
  (issue #5); this PR only splits the HTTP surface.

## Changes

- New `SessionManager::peek_current_step` — `store.get` + simulate at the
  current cursor, NO `advance_state`, NO `store.save`. Peek on a `Completed`
  session → 410 (consistent with the exhausted-advance path).
- `GET /api/v1/chain` → `get_current_step` (peek; no step metrics, no Mongo
  step events). `POST /api/v1/chain/step` → `advance_step` (the old behavior:
  advance + persist + metrics + event log).
- Shared `build_chain_response` helper; delta/gamma conversions no longer use
  bare `.unwrap()` on the response path.
- utoipa + `src/lib.rs` docs + regenerated `README.md` document the migration.

## Contract impact

**BREAKING (explicitly accepted by issue #21).** The `ChainResponse` DTO shape
and status codes are unchanged; the break is the verb/path split: clients that
advanced via `GET /api/v1/chain` must now call `POST /api/v1/chain/step`.
IronCondor's `ApiClient` needs that one-line change — coordinate before
releasing. Reproducibility contract untouched (peek only reads the walk at the
existing cursor).

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 283 + 2 passed, 0 failed
- [x] Peek is repeatable and read-only (stored state asserted unchanged); advance-then-peek reflects the new cursor; peek on Completed → 410 error kind
- [x] OpenAPI paths test covers `/api/v1/chain/step`
- [x] clippy `-D warnings` + fmt clean; `README.md` regenerated via cargo-readme

## Checklist

- [x] DTO shapes unchanged; `SessionParametersResponse.seed` untouched
- [x] Error mapping stays centralized in `map_error`
- [x] No `.unwrap()` / `.expect()` on request paths; `tracing` only
- [x] No new dependencies; no `unsafe`

Closes #21
