### PR TITLE
Sync total_steps when parameters change (#6)

### DIFF
--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -900,4 +900,48 @@ mod tests {
         assert_eq!(post_reset, ref_tape_new);
         assert_ne!(post_reset, ref_tape_old);
     }
+
+    /// Regression for issue #6: PATCHing `steps` must keep `parameters.steps`
+    /// and `total_steps` equal, and the session must serve exactly the NEW
+    /// number of snapshots — both when growing and when shrinking the tape.
+    #[tokio::test]
+    async fn test_patch_steps_syncs_total_steps_up_and_down() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = SessionManager::new(store.clone());
+
+        // Start with 2 steps, PATCH up to 5.
+        let session = manager
+            .create_session(seeded_parameters(2, 7))
+            .expect("failed to create session");
+        let id = session.id;
+
+        let patched = manager
+            .update_session(id, seeded_parameters(5, 7))
+            .expect("update failed");
+        assert_eq!(patched.parameters.steps, patched.total_steps);
+        assert_eq!(patched.total_steps, 5);
+
+        // The regenerated walk and the progression limit agree: exactly 5 advances.
+        for expected_cursor in 1..=5 {
+            let (s, _chain) = manager.get_next_step(id).await.expect("advance failed");
+            assert_eq!(s.current_step, expected_cursor);
+        }
+        assert!(manager.get_next_step(id).await.is_err());
+        let stored = store.get(id).expect("session missing from store");
+        assert_eq!(stored.state, SessionState::Completed);
+        assert_eq!(stored.total_steps, 5);
+
+        // PATCH down to 3: metadata stays consistent and only 3 advances succeed.
+        let patched_down = manager
+            .update_session(id, seeded_parameters(3, 7))
+            .expect("downward update failed");
+        assert_eq!(patched_down.parameters.steps, patched_down.total_steps);
+        assert_eq!(patched_down.total_steps, 3);
+
+        for expected_cursor in 1..=3 {
+            let (s, _chain) = manager.get_next_step(id).await.expect("advance failed");
+            assert_eq!(s.current_step, expected_cursor);
+        }
+        assert!(manager.get_next_step(id).await.is_err());
+    }
 }

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -396,17 +396,17 @@ impl Session {
     ///
     /// # Behavior
     /// - The `parameters` field of the session is updated with the provided `new_params`.
+    /// - `total_steps` is synced to `new_params.steps` so the progression limit,
+    ///   the regenerated walk length, and the advertised parameters always agree —
+    ///   diverging metadata lets a session terminate early or index past the tape.
     /// - The `updated_at` field is set to the current system time, marking the time of modification.
     /// - The session's `state` is updated to `SessionState::Modified` to reflect the change.
     ///
     /// # Notes
     /// This method assumes that the caller has mutable access to the session object and is responsible for ensuring
     /// that the modified parameters are valid within the context of the simulation.
-    ///
-    /// # Panics
-    /// This function does not explicitly handle errors; however, any issues such as obtaining the current system time
-    /// (if `SystemTime::now()` fails) may panic depending on the environment.
     pub fn modify_parameters(&mut self, new_params: SimulationParameters) {
+        self.total_steps = new_params.steps;
         self.parameters = new_params;
         self.updated_at = SystemTime::now();
         self.state = SessionState::Modified;
@@ -1307,8 +1307,29 @@ mod tests_session {
         // Assert
         assert_eq!(session.parameters.symbol, "MODIFIED");
         assert_eq!(session.parameters.steps, 20);
+        assert_eq!(session.total_steps, 20);
         assert_eq!(session.state, SessionState::Modified);
         assert!(session.updated_at > original_time);
+    }
+
+    #[test]
+    fn test_modify_parameters_syncs_total_steps_up_and_down() {
+        let uuid_gen = UuidGenerator::new(Uuid::new_v4());
+        let mut session = Session::new_with_generator(create_test_parameters(), &uuid_gen);
+
+        // Upward: 10 -> 25
+        let mut up = create_test_parameters();
+        up.steps = 25;
+        session.modify_parameters(up);
+        assert_eq!(session.parameters.steps, session.total_steps);
+        assert_eq!(session.total_steps, 25);
+
+        // Downward: 25 -> 4
+        let mut down = create_test_parameters();
+        down.steps = 4;
+        session.modify_parameters(down);
+        assert_eq!(session.parameters.steps, session.total_steps);
+        assert_eq!(session.total_steps, 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Changing `steps` through PATCH updated `parameters.steps` but left the
session's `total_steps` at its creation value, so the regenerated walk and the
state machine used different limits — the session could terminate early or
advertise contradictory metadata. `modify_parameters` now syncs `total_steps`,
mirroring `reinitialize`.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 8**
- **Base branch:** `stack/7-4-reinitialized-transition`
- **Stacked on:** #29 · **Blocks:** the next PR in the stack (#20)
- The diff is cumulative until the lower PRs merge — review against the base branch.
- Note: after PR 7 the PATCH manager path routes through `reinitialize` (which
  already synced `total_steps`); this PR fixes `modify_parameters` itself so
  every caller of the model API keeps the invariant.

## Changes

- `Session::modify_parameters` sets `total_steps = new_params.steps` before
  replacing `parameters` (doc updated; the stale `# Panics` note removed).

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 292 + 2 passed, 0 failed
- [x] Model-level: `modify_parameters` syncs up (10→25) and down (25→4); `parameters.steps == total_steps` asserted
- [x] Manager-level PATCH regression: steps 2→5 serves exactly 5 snapshots then terminal + persisted `Completed`; 5→3 serves exactly 3 — walk length and progression limit agree in both directions
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] Stored-session serde shape unchanged
- [x] No `.unwrap()` / `.expect()` on production paths
- [x] No new dependencies; no `unsafe`

Closes #6
