### PR TITLE
Tri-state PATCH semantics with patchable skew_slope (#20)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod rest;
 
 pub use rest::controller::start_server;
 pub use rest::models::ListenOn;
+pub use rest::patch::Patch;
 pub use rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 pub use rest::responses::*;

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -1,6 +1,7 @@
 use crate::api::rest::error::map_error;
 use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
 use crate::api::rest::models::SessionId;
+use crate::api::rest::patch::Patch;
 use crate::api::rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 use crate::api::rest::responses::{
     ChainResponse, ErrorResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
@@ -13,6 +14,7 @@ use crate::utils::ChainError;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use chrono::{DateTime, Utc};
 use optionstratlib::chains::OptionChain;
+use rand::RngExt;
 use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -64,6 +66,134 @@ fn build_chain_response(session: &Session, option_chain: &OptionChain) -> ChainR
             total_steps: session.total_steps,
         },
     }
+}
+
+/// Merges a partial [`UpdateSessionRequest`] into existing [`SimulationParameters`]
+/// in place, applying the tri-state PATCH semantics and validating every
+/// user-supplied numeric with the same helpers as the create/replace conversions
+/// (so a bad float yields a `ChainError::Validation` instead of panicking).
+///
+/// Per-field behavior:
+/// - domain-required fields (`symbol`, `steps`, `initial_price`,
+///   `days_to_expiration`, `volatility`, `risk_free_rate`, `dividend_yield`,
+///   `method`, `time_frame`) are `Option`: absent keeps the current value, a
+///   value replaces it after validation;
+/// - domain-optional fields (`chain_size`, `strike_interval`, `skew_slope`,
+///   `smile_curve`, `spread`) are [`Patch`]: [`Patch::Absent`] keeps,
+///   [`Patch::Null`] clears to `None`, [`Patch::Value`] replaces after validation;
+/// - `seed` is [`Patch`] but its invariant forbids `None`: [`Patch::Value`] sets
+///   the given seed, [`Patch::Null`] re-seeds with a fresh random seed, and
+///   [`Patch::Absent`] keeps the current seed — `params.seed` stays `Some` so the
+///   session remains reproducible and its effective seed is always reportable.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming the first field that fails
+/// validation.
+pub(crate) fn apply_update(
+    params: &mut SimulationParameters,
+    req: &UpdateSessionRequest,
+) -> Result<(), ChainError> {
+    // Domain-required fields: absent = keep, value = validate + replace.
+    if let Some(symbol) = &req.symbol {
+        params.symbol = symbol.clone();
+    }
+
+    if let Some(steps) = req.steps {
+        if steps < 1 {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "must be at least 1".to_string(),
+            });
+        }
+        if steps > *MAX_STEPS {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_STEPS, steps),
+            });
+        }
+        params.steps = steps;
+    }
+
+    if let Some(initial_price) = req.initial_price {
+        params.initial_price = positive_field("initial_price", initial_price)?;
+    }
+
+    if let Some(days_to_expiration) = req.days_to_expiration {
+        params.days_to_expiration = positive_field("days_to_expiration", days_to_expiration)?;
+    }
+
+    if let Some(volatility) = req.volatility {
+        params.volatility = positive_field("volatility", volatility)?;
+    }
+
+    if let Some(risk_free_rate) = req.risk_free_rate {
+        params.risk_free_rate = decimal_field("risk_free_rate", risk_free_rate)?;
+    }
+
+    if let Some(dividend_yield) = req.dividend_yield {
+        params.dividend_yield = positive_field("dividend_yield", dividend_yield)?;
+    }
+
+    if let Some(method) = &req.method {
+        params.method = method.clone().try_into()?;
+    }
+
+    if let Some(time_frame) = req.time_frame {
+        params.time_frame = validation::time_frame_field("time_frame", time_frame)?;
+    }
+
+    // Domain-optional fields: absent = keep, null = clear, value = validate + replace.
+    match &req.chain_size {
+        Patch::Absent => {}
+        Patch::Null => params.chain_size = None,
+        Patch::Value(chain_size) => {
+            let chain_size = *chain_size;
+            if chain_size > *MAX_CHAIN_SIZE {
+                return Err(ChainError::Validation {
+                    field: "chain_size".to_string(),
+                    reason: format!("must not exceed {}, got {}", *MAX_CHAIN_SIZE, chain_size),
+                });
+            }
+            params.chain_size = Some(chain_size);
+        }
+    }
+
+    match &req.strike_interval {
+        Patch::Absent => {}
+        Patch::Null => params.strike_interval = None,
+        Patch::Value(value) => {
+            params.strike_interval = Some(strictly_positive_field("strike_interval", *value)?);
+        }
+    }
+
+    match &req.skew_slope {
+        Patch::Absent => {}
+        Patch::Null => params.skew_slope = None,
+        Patch::Value(value) => params.skew_slope = Some(decimal_field("skew_slope", *value)?),
+    }
+
+    match &req.smile_curve {
+        Patch::Absent => {}
+        Patch::Null => params.smile_curve = None,
+        Patch::Value(value) => params.smile_curve = Some(decimal_field("smile_curve", *value)?),
+    }
+
+    match &req.spread {
+        Patch::Absent => {}
+        Patch::Null => params.spread = None,
+        Patch::Value(value) => params.spread = Some(positive_field("spread", *value)?),
+    }
+
+    // Seed keeps the effective-seed invariant: it is never cleared to None. A
+    // null seed means "give me a fresh random seed" rather than "clear it".
+    match &req.seed {
+        Patch::Absent => {}
+        Patch::Null => params.seed = Some(rand::rng().random()),
+        Patch::Value(seed) => params.seed = Some(*seed),
+    }
+
+    Ok(())
 }
 
 #[utoipa::path(
@@ -429,6 +559,21 @@ pub(crate) async fn replace_session(
     params(
         ("sessionid" = String, Query, description = "ID of the session to update")
     ),
+    request_body(
+        content = UpdateSessionRequest,
+        description = "Partial update. Optional fields are tri-state: omit a key to keep the \
+            current value, send `null` to clear it, or send a value to replace it. \
+            `seed: null` re-seeds the session with a fresh random seed (the seed is never \
+            cleared, preserving reproducibility).",
+        example = r#"
+                    {
+                      "volatility": 0.3,
+                      "skew_slope": -0.15,
+                      "smile_curve": null,
+                      "seed": null
+                    }
+                    "#
+    ),
     responses(
         (status = 200, description = "Session updated", body = SessionResponse),
         (status = 404, description = "Session not found"),
@@ -468,116 +613,13 @@ pub(crate) async fn update_session(
         Err(error) => return map_error(error),
     };
 
-    // Create a new SimulationParameters object with updated values
+    // Create a new SimulationParameters object with updated values. The merge applies the
+    // tri-state PATCH semantics (absent = keep, null = clear, value = replace) and validates
+    // every user-supplied numeric with the same helpers as the create/replace conversions, so
+    // a bad float yields a 400 instead of panicking during the PATCH merge.
     let mut updated_params = current_session.parameters.clone();
-
-    // Update only the fields that are provided in the request. Every user-supplied
-    // numeric is validated with the same helpers as the create/replace conversions, so a
-    // bad float yields a 400 instead of panicking during the PATCH merge.
-    if let Some(symbol) = &json_req.symbol {
-        updated_params.symbol = symbol.clone();
-    }
-
-    if let Some(steps) = json_req.steps {
-        if steps < 1 {
-            return map_error(ChainError::Validation {
-                field: "steps".to_string(),
-                reason: "must be at least 1".to_string(),
-            });
-        }
-        if steps > *MAX_STEPS {
-            return map_error(ChainError::Validation {
-                field: "steps".to_string(),
-                reason: format!("must not exceed {}, got {}", *MAX_STEPS, steps),
-            });
-        }
-        updated_params.steps = steps;
-    }
-
-    if let Some(initial_price) = json_req.initial_price {
-        updated_params.initial_price = match positive_field("initial_price", initial_price) {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(days_to_expiration) = json_req.days_to_expiration {
-        updated_params.days_to_expiration =
-            match positive_field("days_to_expiration", days_to_expiration) {
-                Ok(value) => value,
-                Err(error) => return map_error(error),
-            };
-    }
-
-    if let Some(volatility) = json_req.volatility {
-        updated_params.volatility = match positive_field("volatility", volatility) {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(risk_free_rate) = json_req.risk_free_rate {
-        updated_params.risk_free_rate = match decimal_field("risk_free_rate", risk_free_rate) {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(dividend_yield) = json_req.dividend_yield {
-        updated_params.dividend_yield = match positive_field("dividend_yield", dividend_yield) {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(method) = &json_req.method {
-        updated_params.method = match method.clone().try_into() {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(time_frame) = json_req.time_frame {
-        updated_params.time_frame = match validation::time_frame_field("time_frame", time_frame) {
-            Ok(value) => value,
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(chain_size) = json_req.chain_size {
-        if chain_size > *MAX_CHAIN_SIZE {
-            return map_error(ChainError::Validation {
-                field: "chain_size".to_string(),
-                reason: format!("must not exceed {}, got {}", *MAX_CHAIN_SIZE, chain_size),
-            });
-        }
-        updated_params.chain_size = Some(chain_size);
-    }
-
-    if let Some(strike_interval) = json_req.strike_interval {
-        updated_params.strike_interval =
-            match strictly_positive_field("strike_interval", strike_interval) {
-                Ok(value) => Some(value),
-                Err(error) => return map_error(error),
-            };
-    }
-
-    if let Some(smile_curve) = json_req.smile_curve {
-        updated_params.smile_curve = match decimal_field("smile_curve", smile_curve) {
-            Ok(value) => Some(value),
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(spread) = json_req.spread {
-        updated_params.spread = match positive_field("spread", spread) {
-            Ok(value) => Some(value),
-            Err(error) => return map_error(error),
-        };
-    }
-
-    if let Some(seed) = json_req.seed {
-        updated_params.seed = Some(seed);
+    if let Err(error) = apply_update(&mut updated_params, &json_req.0) {
+        return map_error(error);
     }
 
     // Update the session with new parameters
@@ -705,5 +747,216 @@ mod tests_advance_step_query {
         let q: AdvanceStepQuery = serde_json::from_str(r#"{"sessionid":"abc","expected_step":3}"#)
             .expect("query must parse");
         assert_eq!(q.expected_step, Some(3));
+    }
+}
+
+#[cfg(test)]
+mod tests_apply_update {
+    use super::*;
+    use optionstratlib::simulation::WalkType;
+    use optionstratlib::utils::TimeFrame;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+
+    /// Base parameters with every optional field populated, so a `Null` patch has
+    /// something to clear and an `Absent` patch has something to preserve.
+    fn base_params() -> SimulationParameters {
+        SimulationParameters {
+            symbol: "AAPL".to_string(),
+            steps: 20,
+            initial_price: pos_or_panic!(100.0),
+            days_to_expiration: pos_or_panic!(30.0),
+            volatility: pos_or_panic!(0.2),
+            risk_free_rate: dec!(0.03),
+            dividend_yield: Positive::ZERO,
+            method: WalkType::Brownian {
+                dt: pos_or_panic!(1.0 / 252.0),
+                drift: Decimal::ZERO,
+                volatility: pos_or_panic!(0.2),
+            },
+            time_frame: TimeFrame::Day,
+            chain_size: Some(30),
+            strike_interval: Some(pos_or_panic!(5.0)),
+            skew_slope: Some(dec!(-0.2)),
+            smile_curve: Some(dec!(0.4)),
+            spread: Some(pos_or_panic!(0.02)),
+            seed: Some(42),
+        }
+    }
+
+    /// An update request that touches nothing (all required fields `None`, all
+    /// optional fields `Patch::Absent`).
+    fn empty_update() -> UpdateSessionRequest {
+        UpdateSessionRequest {
+            symbol: None,
+            steps: None,
+            initial_price: None,
+            days_to_expiration: None,
+            volatility: None,
+            risk_free_rate: None,
+            dividend_yield: None,
+            method: None,
+            time_frame: None,
+            chain_size: Patch::Absent,
+            strike_interval: Patch::Absent,
+            skew_slope: Patch::Absent,
+            smile_curve: Patch::Absent,
+            spread: Patch::Absent,
+            seed: Patch::Absent,
+        }
+    }
+
+    #[test]
+    fn test_apply_update_absent_preserves_all_fields() {
+        let mut params = base_params();
+        let before = params.clone();
+
+        apply_update(&mut params, &empty_update()).expect("empty update succeeds");
+
+        assert_eq!(params.symbol, before.symbol);
+        assert_eq!(params.steps, before.steps);
+        assert_eq!(params.chain_size, before.chain_size);
+        assert_eq!(params.strike_interval, before.strike_interval);
+        assert_eq!(params.skew_slope, before.skew_slope);
+        assert_eq!(params.smile_curve, before.smile_curve);
+        assert_eq!(params.spread, before.spread);
+        assert_eq!(params.seed, before.seed);
+    }
+
+    #[test]
+    fn test_apply_update_null_clears_each_optional_field() {
+        let mut params = base_params();
+        let req = UpdateSessionRequest {
+            chain_size: Patch::Null,
+            strike_interval: Patch::Null,
+            skew_slope: Patch::Null,
+            smile_curve: Patch::Null,
+            spread: Patch::Null,
+            ..empty_update()
+        };
+
+        apply_update(&mut params, &req).expect("null update succeeds");
+
+        assert_eq!(params.chain_size, None);
+        assert_eq!(params.strike_interval, None);
+        assert_eq!(params.skew_slope, None);
+        assert_eq!(params.smile_curve, None);
+        assert_eq!(params.spread, None);
+        // Seed was left absent, so it is preserved (never cleared).
+        assert_eq!(params.seed, Some(42));
+    }
+
+    #[test]
+    fn test_apply_update_value_replaces_optional_fields() {
+        let mut params = base_params();
+        let req = UpdateSessionRequest {
+            chain_size: Patch::Value(25),
+            strike_interval: Patch::Value(2.5),
+            skew_slope: Patch::Value(-0.15),
+            smile_curve: Patch::Value(0.6),
+            spread: Patch::Value(0.03),
+            ..empty_update()
+        };
+
+        apply_update(&mut params, &req).expect("value update succeeds");
+
+        assert_eq!(params.chain_size, Some(25));
+        assert_eq!(params.strike_interval, Some(pos_or_panic!(2.5)));
+        assert_eq!(params.skew_slope, Some(dec!(-0.15)));
+        assert_eq!(params.smile_curve, Some(dec!(0.6)));
+        assert_eq!(params.spread, Some(pos_or_panic!(0.03)));
+    }
+
+    #[test]
+    fn test_apply_update_skew_slope_is_now_patchable() {
+        // Regression for #20: skew_slope was previously unreachable via PATCH.
+        let mut params = base_params();
+        params.skew_slope = None;
+
+        let req = UpdateSessionRequest {
+            skew_slope: Patch::Value(-0.3),
+            ..empty_update()
+        };
+        apply_update(&mut params, &req).expect("skew_slope patch succeeds");
+        assert_eq!(params.skew_slope, Some(dec!(-0.3)));
+
+        // And it can be cleared again.
+        let clear = UpdateSessionRequest {
+            skew_slope: Patch::Null,
+            ..empty_update()
+        };
+        apply_update(&mut params, &clear).expect("skew_slope clear succeeds");
+        assert_eq!(params.skew_slope, None);
+    }
+
+    #[test]
+    fn test_apply_update_invalid_value_is_validation_error() {
+        let mut params = base_params();
+        let req = UpdateSessionRequest {
+            spread: Patch::Value(-1.0),
+            ..empty_update()
+        };
+
+        match apply_update(&mut params, &req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "spread"),
+            other => panic!("expected Validation error for spread, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_apply_update_invalid_skew_slope_is_validation_error() {
+        let mut params = base_params();
+        let req = UpdateSessionRequest {
+            skew_slope: Patch::Value(f64::NAN),
+            ..empty_update()
+        };
+
+        match apply_update(&mut params, &req) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "skew_slope"),
+            other => panic!("expected Validation error for skew_slope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_apply_update_seed_value_sets_seed() {
+        let mut params = base_params();
+        let req = UpdateSessionRequest {
+            seed: Patch::Value(777),
+            ..empty_update()
+        };
+
+        apply_update(&mut params, &req).expect("seed value update succeeds");
+        assert_eq!(params.seed, Some(777));
+    }
+
+    #[test]
+    fn test_apply_update_seed_null_regenerates_fresh_seed() {
+        // A null seed must NOT clear the seed (the effective-seed invariant keeps it
+        // Some); it re-seeds with a fresh random value. Retry a few times so a random
+        // collision with the previous seed does not flake the test.
+        let old_seed = 42u64;
+        let mut changed = false;
+        for _ in 0..3 {
+            let mut params = base_params();
+            let req = UpdateSessionRequest {
+                seed: Patch::Null,
+                ..empty_update()
+            };
+            apply_update(&mut params, &req).expect("seed null update succeeds");
+
+            assert!(
+                params.seed.is_some(),
+                "seed must stay Some to preserve reproducibility"
+            );
+            if params.seed != Some(old_seed) {
+                changed = true;
+                break;
+            }
+        }
+        assert!(
+            changed,
+            "seed null should produce a fresh seed different from the previous one"
+        );
     }
 }

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod handlers;
 pub(crate) mod limits;
 mod middleware;
 pub(crate) mod models;
+pub(crate) mod patch;
 pub(crate) mod requests;
 pub(crate) mod responses;
 mod routes;

--- a/src/api/rest/patch.rs
+++ b/src/api/rest/patch.rs
@@ -1,0 +1,168 @@
+//! Tri-state PATCH field wrapper for partial-update request DTOs.
+//!
+//! A plain `Option<T>` cannot distinguish "field absent from the JSON body"
+//! from "field present but explicitly `null`" — serde maps both to `None`. A
+//! PATCH endpoint needs all three states:
+//!
+//! - **absent** → keep the current value unchanged;
+//! - **null** → clear the value back to `None`;
+//! - **value** → replace with the supplied value.
+//!
+//! [`Patch<T>`] carries that distinction:
+//!
+//! - Field *absence* is expressed with `#[serde(default)]` on the field, which
+//!   deserializes to [`Patch::Absent`] (the `Default`).
+//! - An explicit JSON `null` deserializes to [`Patch::Null`].
+//! - Any other value deserializes to [`Patch::Value`].
+//!
+//! On serialize, [`Patch::Absent`] fields are omitted with
+//! `#[serde(skip_serializing_if = "Patch::is_absent")]`, [`Patch::Null`]
+//! serializes as `null`, and [`Patch::Value`] as the inner value.
+//!
+//! For the OpenAPI surface, fields typed `Patch<T>` are annotated
+//! `#[schema(value_type = Option<T>)]` so the documented shape is the familiar
+//! nullable value — the tri-state semantics are described in each field's doc.
+
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+/// Tri-state wrapper distinguishing an absent JSON key, an explicit `null`, and
+/// a present value in a partial-update (PATCH) request body.
+///
+/// See the [module documentation](self) for how each state maps to serde and to
+/// the PATCH merge semantics (absent = keep, null = clear, value = replace).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum Patch<T> {
+    /// The field was absent from the request body — keep the current value.
+    #[default]
+    Absent,
+    /// The field was present and explicitly `null` — clear the value to `None`.
+    Null,
+    /// The field was present with a value — replace the current value.
+    Value(T),
+}
+
+impl<T> Patch<T> {
+    /// Returns `true` when the field was absent from the request body.
+    ///
+    /// Used as the `skip_serializing_if` predicate so absent fields are omitted
+    /// from the serialized JSON.
+    #[must_use]
+    #[inline]
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Patch::Absent)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Patch<T>
+where
+    T: Deserialize<'de>,
+{
+    /// Deserializes a *present* key into [`Patch::Null`] (JSON `null`) or
+    /// [`Patch::Value`] (any other value).
+    ///
+    /// Field absence is handled upstream by `#[serde(default)]` on the field,
+    /// which yields [`Patch::Absent`]; this impl is only reached when the key is
+    /// present, so it never produces `Absent`.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<T>::deserialize(deserializer).map(|opt| match opt {
+            None => Patch::Null,
+            Some(value) => Patch::Value(value),
+        })
+    }
+}
+
+impl<T> Serialize for Patch<T>
+where
+    T: Serialize,
+{
+    /// Serializes [`Patch::Value`] as the inner value and both [`Patch::Null`]
+    /// and [`Patch::Absent`] as JSON `null`.
+    ///
+    /// [`Patch::Absent`] is expected to be filtered out by
+    /// `#[serde(skip_serializing_if = "Patch::is_absent")]`; if it is reached
+    /// anyway, `null` is the closest neutral encoding.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Patch::Absent | Patch::Null => serializer.serialize_none(),
+            Patch::Value(value) => serializer.serialize_some(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Holder {
+        #[serde(default, skip_serializing_if = "Patch::is_absent")]
+        value: Patch<f64>,
+    }
+
+    #[test]
+    fn test_patch_deserialize_absent_key_is_absent() {
+        let holder: Holder = serde_json::from_str("{}").expect("empty object deserializes");
+        assert_eq!(holder.value, Patch::Absent);
+    }
+
+    #[test]
+    fn test_patch_deserialize_explicit_null_is_null() {
+        let holder: Holder =
+            serde_json::from_value(json!({ "value": null })).expect("null deserializes");
+        assert_eq!(holder.value, Patch::Null);
+    }
+
+    #[test]
+    fn test_patch_deserialize_value_is_value() {
+        let holder: Holder =
+            serde_json::from_value(json!({ "value": 1.5 })).expect("value deserializes");
+        assert_eq!(holder.value, Patch::Value(1.5));
+    }
+
+    #[test]
+    fn test_patch_serialize_absent_is_omitted() {
+        let holder = Holder {
+            value: Patch::Absent,
+        };
+        let json = serde_json::to_value(&holder).expect("serializes");
+        assert_eq!(json, json!({}));
+    }
+
+    #[test]
+    fn test_patch_serialize_null_is_null() {
+        let holder = Holder { value: Patch::Null };
+        let json = serde_json::to_value(&holder).expect("serializes");
+        assert_eq!(json, json!({ "value": null }));
+    }
+
+    #[test]
+    fn test_patch_serialize_value_is_value() {
+        let holder = Holder {
+            value: Patch::Value(2.5),
+        };
+        let json = serde_json::to_value(&holder).expect("serializes");
+        assert_eq!(json, json!({ "value": 2.5 }));
+    }
+
+    #[test]
+    fn test_patch_default_is_absent() {
+        assert_eq!(Patch::<u64>::default(), Patch::Absent);
+        assert!(Patch::<u64>::default().is_absent());
+    }
+
+    #[test]
+    fn test_patch_is_absent_only_for_absent() {
+        assert!(Patch::<u64>::Absent.is_absent());
+        assert!(!Patch::<u64>::Null.is_absent());
+        assert!(!Patch::Value(1u64).is_absent());
+    }
+}

--- a/src/api/rest/requests.rs
+++ b/src/api/rest/requests.rs
@@ -1,4 +1,5 @@
 use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+use crate::api::rest::patch::Patch;
 use crate::session::SimulationParameters;
 use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
@@ -136,22 +137,39 @@ pub struct UpdateSessionRequest {
     /// - `time_frame` (`TimeFrame`): The time frame for the simulation intervals, such as daily, weekly, or hourly.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_frame: Option<ApiTimeFrame>,
-    /// - `chain_size` (`Option<usize>`): The optional size of the option chain being simulated. If `None`, this is not specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chain_size: Option<usize>,
-    /// - `strike_interval` (`Option<Positive>`): The optional interval between strike prices for options. If `None`, this is not specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub strike_interval: Option<f64>,
-    /// - `smile_curve` (`Option<Decimal>`): An optional factor that adjusts the skew of the distribution. For example, it can be used to bias option pricing.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub smile_curve: Option<f64>,
-    /// - `spread` (`Option<Positive>`): An optional parameter to specify the spread value. If `None`, no spread is applied.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub spread: Option<f64>,
-    /// - `seed` (`Option<u64>`): An optional RNG seed for the session's stochastic walk.
-    ///   Providing a value makes regenerated steps reproducible.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub seed: Option<u64>,
+    /// - `chain_size` (`Option<usize>`): The size of the option chain being simulated.
+    ///   Tri-state: **absent** keeps the current value, **null** clears it, a **value** replaces it.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<usize>)]
+    pub chain_size: Patch<usize>,
+    /// - `strike_interval` (`Option<Positive>`): The interval between strike prices for options.
+    ///   Tri-state: **absent** keeps the current value, **null** clears it, a **value** replaces it.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<f64>)]
+    pub strike_interval: Patch<f64>,
+    /// - `skew_slope` (`Option<Decimal>`): A factor that adjusts the slope of the volatility distribution.
+    ///   Tri-state: **absent** keeps the current value, **null** clears it, a **value** replaces it.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<f64>)]
+    pub skew_slope: Patch<f64>,
+    /// - `smile_curve` (`Option<Decimal>`): A factor that adjusts the skew of the volatility distribution.
+    ///   Tri-state: **absent** keeps the current value, **null** clears it, a **value** replaces it.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<f64>)]
+    pub smile_curve: Patch<f64>,
+    /// - `spread` (`Option<Positive>`): The bid-ask spread factor.
+    ///   Tri-state: **absent** keeps the current value, **null** clears it, a **value** replaces it.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<f64>)]
+    pub spread: Patch<f64>,
+    /// - `seed` (`Option<u64>`): The RNG seed driving the session's stochastic walk.
+    ///   Tri-state: **absent** keeps the current seed, a **value** replaces it, and **null**
+    ///   re-seeds the session with a fresh random seed. The effective seed is never cleared —
+    ///   `SimulationParameters.seed` stays `Some` so the session remains reproducible and the
+    ///   seed is always reported back in the session response.
+    #[serde(default, skip_serializing_if = "Patch::is_absent")]
+    #[schema(value_type = Option<u64>)]
+    pub seed: Patch<u64>,
 }
 
 impl fmt::Display for UpdateSessionRequest {
@@ -648,6 +666,8 @@ mod tests {
 
         #[test]
         fn test_update_session_request_partial_update() {
+            use crate::api::rest::patch::Patch;
+
             let update_req = UpdateSessionRequest {
                 symbol: Some("GOOGL".to_string()),
                 steps: None,
@@ -658,16 +678,133 @@ mod tests {
                 dividend_yield: None,
                 method: None,
                 time_frame: None,
-                chain_size: None,
-                strike_interval: None,
-                smile_curve: None,
-                spread: None,
-                seed: None,
+                chain_size: Patch::Absent,
+                strike_interval: Patch::Absent,
+                skew_slope: Patch::Absent,
+                smile_curve: Patch::Absent,
+                spread: Patch::Absent,
+                seed: Patch::Absent,
             };
 
             assert_eq!(update_req.symbol, Some("GOOGL".to_string()));
             assert_eq!(update_req.volatility, Some(0.3));
             assert!(update_req.initial_price.is_none());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_update_session_request_tristate {
+    use super::*;
+    use crate::api::rest::patch::Patch;
+    use serde_json::{from_str, json, to_value};
+
+    #[test]
+    fn test_deserialize_absent_optional_fields_are_absent() {
+        // A body that touches only a required field leaves every optional
+        // (tri-state) field Absent — meaning "keep the current value".
+        let json = r#"{ "volatility": 0.3 }"#;
+        let req: UpdateSessionRequest = from_str(json).expect("partial body deserializes");
+
+        assert_eq!(req.volatility, Some(0.3));
+        assert_eq!(req.chain_size, Patch::Absent);
+        assert_eq!(req.strike_interval, Patch::Absent);
+        assert_eq!(req.skew_slope, Patch::Absent);
+        assert_eq!(req.smile_curve, Patch::Absent);
+        assert_eq!(req.spread, Patch::Absent);
+        assert_eq!(req.seed, Patch::Absent);
+    }
+
+    #[test]
+    fn test_deserialize_explicit_null_optional_fields_are_null() {
+        // Explicit JSON null on each optional field is the "clear" signal.
+        let json = r#"{
+            "chain_size": null,
+            "strike_interval": null,
+            "skew_slope": null,
+            "smile_curve": null,
+            "spread": null,
+            "seed": null
+        }"#;
+        let req: UpdateSessionRequest = from_str(json).expect("null body deserializes");
+
+        assert_eq!(req.chain_size, Patch::Null);
+        assert_eq!(req.strike_interval, Patch::Null);
+        assert_eq!(req.skew_slope, Patch::Null);
+        assert_eq!(req.smile_curve, Patch::Null);
+        assert_eq!(req.spread, Patch::Null);
+        assert_eq!(req.seed, Patch::Null);
+    }
+
+    #[test]
+    fn test_deserialize_valued_optional_fields_are_value() {
+        // A present value is the "replace" signal, including the new skew_slope.
+        let json = r#"{
+            "chain_size": 25,
+            "strike_interval": 5.0,
+            "skew_slope": -0.15,
+            "smile_curve": 0.4,
+            "spread": 0.02,
+            "seed": 99
+        }"#;
+        let req: UpdateSessionRequest = from_str(json).expect("valued body deserializes");
+
+        assert_eq!(req.chain_size, Patch::Value(25));
+        assert_eq!(req.strike_interval, Patch::Value(5.0));
+        assert_eq!(req.skew_slope, Patch::Value(-0.15));
+        assert_eq!(req.smile_curve, Patch::Value(0.4));
+        assert_eq!(req.spread, Patch::Value(0.02));
+        assert_eq!(req.seed, Patch::Value(99));
+    }
+
+    #[test]
+    fn test_serialize_absent_fields_are_omitted() {
+        let req = UpdateSessionRequest {
+            symbol: None,
+            steps: None,
+            initial_price: None,
+            days_to_expiration: None,
+            volatility: None,
+            risk_free_rate: None,
+            dividend_yield: None,
+            method: None,
+            time_frame: None,
+            chain_size: Patch::Absent,
+            strike_interval: Patch::Absent,
+            skew_slope: Patch::Absent,
+            smile_curve: Patch::Absent,
+            spread: Patch::Absent,
+            seed: Patch::Absent,
+        };
+
+        let value = to_value(&req).expect("serializes");
+        assert_eq!(value, json!({}));
+    }
+
+    #[test]
+    fn test_serialize_null_and_value_fields() {
+        let req = UpdateSessionRequest {
+            symbol: None,
+            steps: None,
+            initial_price: None,
+            days_to_expiration: None,
+            volatility: None,
+            risk_free_rate: None,
+            dividend_yield: None,
+            method: None,
+            time_frame: None,
+            chain_size: Patch::Value(25),
+            strike_interval: Patch::Absent,
+            skew_slope: Patch::Null,
+            smile_curve: Patch::Absent,
+            spread: Patch::Absent,
+            seed: Patch::Null,
+        };
+
+        let value = to_value(&req).expect("serializes");
+        assert_eq!(
+            value,
+            json!({ "chain_size": 25, "skew_slope": null, "seed": null })
+        );
     }
 }


### PR DESCRIPTION
## Summary

The PATCH representation could not express valid state changes: it had no
`skew_slope` field at all, and serde collapsed both "key absent" and JSON
`null` into `None`, which the handler read as "keep" — so optional parameters
(`chain_size`, `strike_interval`, `smile_curve`, `spread`, `seed`) could never
be cleared. PATCH now uses a tri-state representation: absent = keep, null =
clear, value = replace.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 9**
- **Base branch:** `stack/8-6-patch-total-steps`
- **Stacked on:** #30 · **Blocks:** the next PR in the stack (#19)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- New `Patch<T>` (`Absent | Null | Value(T)`, manual serde, no new deps):
  absence via `#[serde(default)]`, null → `Null`, value → `Value`;
  `Absent` omitted on serialize.
- `UpdateSessionRequest`: domain-optional fields become `Patch<T>` and
  **`skew_slope` is now patchable** (new field). Domain-required fields stay
  `Option<T>` (absent = keep).
- Extracted, unit-testable `apply_update(&mut SimulationParameters,
  &UpdateSessionRequest)` merge: `Absent` keeps, `Null` clears, `Value`
  validates (reusing the #10 validators + bounds) and replaces.
  `seed: null` re-seeds with a fresh random seed (documented) — the
  effective-seed invariant (`parameters.seed` always `Some`) is preserved.
- utoipa: per-field `#[schema(value_type = Option<T>)]` (avoids generic-name
  `$ref` collisions in utoipa 5) + tri-state docs + a PATCH request example
  showing all three states.

## Contract impact

Additive / wire-backward-compatible: omitting fields and sending values
behave exactly as before. New opt-in behaviors: explicit `null` clears an
optional field (previously a no-op), `skew_slope` newly accepted, `seed: null`
re-seeds. IronCondor does not consume the PATCH DTO (checked) — semver-minor.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 313 + 2 passed, 0 failed (21 new tests)
- [x] Serde tri-state round-trips per field (absent/null/value, both directions)
- [x] Merge semantics: absent preserves, null clears each optional, value replaces + validates, invalid → `Validation`, seed-null regenerates (collision-tolerant assert)
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] Effective-seed invariant preserved; conversion boundary discipline intact
- [x] No `.unwrap()` / `.expect()` on request paths; `tracing` only
- [x] No new dependencies; no `unsafe`

Closes #20
