### PR TITLE
Optimistic concurrency (CAS) for session mutations (#8)

### DIFF
--- a/src/api/rest/error.rs
+++ b/src/api/rest/error.rs
@@ -9,6 +9,12 @@ pub(crate) fn map_error(error: ChainError) -> HttpResponse {
         ChainError::AlreadyExists(_) => {
             HttpResponse::Conflict().json(serde_json::json!({"error": error.to_string()}))
         }
+        // Optimistic-concurrency conflict: another writer advanced/modified the
+        // session between our read and our compare-and-swap save. 409 so the
+        // client re-reads and retries (same shape as the AlreadyExists arm).
+        ChainError::Conflict(_) => {
+            HttpResponse::Conflict().json(serde_json::json!({"error": error.to_string()}))
+        }
         ChainError::InvalidState(_) => {
             HttpResponse::BadRequest().json(serde_json::json!({"error": error.to_string()}))
         }
@@ -53,6 +59,18 @@ mod tests {
     #[actix_web::test]
     async fn test_map_error_already_exists() {
         let err = ChainError::AlreadyExists("session_abc".into());
+        let resp: HttpResponse = map_error(err.clone());
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let body = to_bytes(resp.into_body()).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, serde_json::json!({"error": err.to_string()}));
+    }
+
+    /// Conflict should map to 409 with the error message from `Display`.
+    #[actix_web::test]
+    async fn test_map_error_conflict() {
+        let err = ChainError::Conflict("session modified concurrently".into());
         let resp: HttpResponse = map_error(err.clone());
         assert_eq!(resp.status(), StatusCode::CONFLICT);
 

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -332,6 +332,7 @@ pub(crate) struct AdvanceStepQuery {
     responses(
         (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
         (status = 404, description = "Session not found"),
+        (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 410, description = "Simulation completed. No more steps available"),
         (status = 412, description = "expected_step does not match the session's current cursor; body carries `error` and `current_step`"),
         (status = 500, description = "Internal server error")
@@ -469,6 +470,7 @@ pub(crate) async fn get_current_step(
         (status = 200, description = "Session replaced", body = SessionResponse),
         (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
         (status = 404, description = "Session not found"),
+        (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -581,6 +583,7 @@ pub(crate) async fn replace_session(
         (status = 200, description = "Session updated", body = SessionResponse),
         (status = 404, description = "Session not found"),
         (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
+        (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 500, description = "Internal server error")
     )
 )]

--- a/src/infrastructure/redis/client.rs
+++ b/src/infrastructure/redis/client.rs
@@ -182,6 +182,15 @@ impl RedisClient {
     pub fn get_config(&self) -> &RedisConfig {
         &self.config
     }
+
+    /// Returns a clone of the multiplexed [`ConnectionManager`] for callers that
+    /// need to issue commands the typed helpers on this client do not cover — for
+    /// example running a `redis::Script` (server-side Lua) for an atomic
+    /// compare-and-swap. Cloning is cheap (an internal `Arc`) and clones share the
+    /// same multiplexed socket, so this does not introduce a per-op lock.
+    pub fn connection_manager(&self) -> ConnectionManager {
+        self.manager.clone()
+    }
 }
 
 #[cfg(test)]

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -140,6 +140,12 @@ impl SessionManager {
     pub async fn get_next_step(&self, id: Uuid) -> Result<(Session, OptionChain), ChainError> {
         let mut session = self.store.get(id).await?;
 
+        // Capture the revision we read; the compare-and-swap save below commits only
+        // if the stored session is still at this version, so two concurrent advances
+        // that both read the same snapshot cannot both persist (the loser gets a
+        // Conflict) — no lost update, no duplicate step.
+        let expected_version = session.version;
+
         // Completed guard: a session that has served all of its snapshots has nothing
         // left to serve. Mirror the exhausted-advance path (410 Gone) and leave the
         // store untouched so a repeated call keeps returning the terminal error.
@@ -168,9 +174,13 @@ impl SessionManager {
         // Advance the cursor; the advance that serves the last snapshot marks Completed.
         self.state_handler.advance_state(&mut session)?;
 
-        // Always persist after a successfully served snapshot, including the advance
-        // that transitions the session to Completed.
-        self.store.save(session.clone()).await?;
+        // Bump the revision and persist via compare-and-swap. On a concurrent race the
+        // save returns `ChainError::Conflict` (HTTP 409) and the client retries; there
+        // is deliberately no silent retry loop here.
+        session.bump_version();
+        self.store
+            .save_cas(session.clone(), expected_version)
+            .await?;
 
         Ok((session, chain))
     }
@@ -265,13 +275,19 @@ impl SessionManager {
         params: SimulationParameters,
     ) -> Result<Session, ChainError> {
         let mut session = self.store.get(id).await?;
+        let expected_version = session.version;
 
         // A parameter change restarts the tape: reset the cursor, sync total_steps,
         // and mark the session Reinitialized so the next advance rebuilds the walk.
         session.reinitialize(params);
 
-        // Save updated session
-        self.store.save(session.clone()).await?;
+        // Persist via compare-and-swap so a PATCH cannot clobber a newer revision
+        // written by a concurrent advance/update; a race yields `ChainError::Conflict`
+        // (HTTP 409) for the client to retry.
+        session.bump_version();
+        self.store
+            .save_cas(session.clone(), expected_version)
+            .await?;
 
         Ok(session)
     }
@@ -308,12 +324,18 @@ impl SessionManager {
         params: SimulationParameters,
     ) -> Result<Session, ChainError> {
         let mut session = self.store.get(id).await?;
+        let expected_version = session.version;
 
         // Reinitialize session: reset cursor, sync total_steps, mark Reinitialized.
         session.reinitialize(params);
 
-        // Save updated session
-        self.store.save(session.clone()).await?;
+        // Persist via compare-and-swap so a PUT cannot clobber a newer revision
+        // written by a concurrent advance/update; a race yields `ChainError::Conflict`
+        // (HTTP 409) for the client to retry.
+        session.bump_version();
+        self.store
+            .save_cas(session.clone(), expected_version)
+            .await?;
 
         Ok(session)
     }
@@ -997,5 +1019,157 @@ mod tests {
         assert_ne!(session_a.id, session_b.id);
         assert!(store.get(session_a.id).await.is_ok());
         assert!(store.get(session_b.id).await.is_ok());
+    }
+
+    /// Test store that wraps `InMemorySessionStore` and blocks every `get` on a
+    /// shared `tokio::sync::Barrier` before delegating. This forces two concurrent
+    /// manager mutations to BOTH read the same snapshot before either reaches its
+    /// compare-and-swap save, making the lost-update race deterministic instead of
+    /// timing-dependent. Every other operation passes straight through, and tests
+    /// verify final state through the inner store (which never touches the barrier),
+    /// so the single-generation barrier never deadlocks.
+    struct BarrierGetStore {
+        inner: Arc<InMemorySessionStore>,
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionStore for BarrierGetStore {
+        async fn get(&self, id: Uuid) -> Result<Session, ChainError> {
+            // Read first, THEN rendezvous: both concurrent readers must complete
+            // their load (observing the same stored version) before either is
+            // released to proceed to its compare-and-swap save. Waiting before the
+            // read would instead let the first arrival finish its whole mutation
+            // before the second even reads, defeating the race we want to exercise.
+            let result = self.inner.get(id).await;
+            self.barrier.wait().await;
+            result
+        }
+
+        async fn create(&self, session: Session) -> Result<(), ChainError> {
+            self.inner.create(session).await
+        }
+
+        async fn save(&self, session: Session) -> Result<(), ChainError> {
+            self.inner.save(session).await
+        }
+
+        async fn save_cas(
+            &self,
+            session: Session,
+            expected_version: u64,
+        ) -> Result<(), ChainError> {
+            self.inner.save_cas(session, expected_version).await
+        }
+
+        async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
+            self.inner.delete(id).await
+        }
+
+        async fn cleanup(&self) -> Result<usize, ChainError> {
+            self.inner.cleanup().await
+        }
+    }
+
+    /// Issue #8 acceptance: two `get_next_step` calls that TRULY overlap (both read
+    /// the session at version 0 before either saves, forced by the barrier) must not
+    /// both persist. Exactly one advance wins with cursor 1; the other loses the
+    /// compare-and-swap with `Conflict`. The persisted session shows a single
+    /// advance — cursor 1, version 1 — so there is no lost update and no duplicate
+    /// step.
+    #[tokio::test]
+    async fn test_concurrent_advances_one_wins_one_conflicts() {
+        let inner = Arc::new(InMemorySessionStore::new());
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let store = Arc::new(BarrierGetStore {
+            inner: inner.clone(),
+            barrier,
+        });
+        let manager = Arc::new(SessionManager::new(store));
+
+        // A session at cursor 0 with room for well over two steps.
+        let session = manager
+            .create_session(seeded_parameters(5, 1234))
+            .await
+            .expect("failed to create session");
+        let id = session.id;
+
+        let m1 = manager.clone();
+        let m2 = manager.clone();
+        let (r1, r2) = tokio::join!(async move { m1.get_next_step(id).await }, async move {
+            m2.get_next_step(id).await
+        },);
+
+        let results = [r1, r2];
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        let conflict_count = results
+            .iter()
+            .filter(|r| matches!(r, Err(ChainError::Conflict(_))))
+            .count();
+        assert_eq!(ok_count, 1, "exactly one concurrent advance must win");
+        assert_eq!(
+            conflict_count, 1,
+            "exactly one concurrent advance must conflict"
+        );
+
+        // The winner served exactly one step.
+        let winner = results
+            .iter()
+            .find_map(|r| r.as_ref().ok())
+            .expect("a winning advance");
+        assert_eq!(winner.0.current_step, 1);
+
+        // Persisted state proves a single, non-duplicated advance.
+        let stored = inner.get(id).await.expect("session missing from store");
+        assert_eq!(stored.current_step, 1);
+        assert_eq!(stored.version, 1);
+    }
+
+    /// Issue #8: a PATCH racing an advance is the same lost-update hazard. With both
+    /// forced to read version 0, exactly one of `update_session` / `get_next_step`
+    /// commits and the other gets `Conflict`; the store ends at version 1 (a single
+    /// successful mutation), so neither silently clobbers the other.
+    #[tokio::test]
+    async fn test_concurrent_patch_and_advance_one_conflicts() {
+        let inner = Arc::new(InMemorySessionStore::new());
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let store = Arc::new(BarrierGetStore {
+            inner: inner.clone(),
+            barrier,
+        });
+        let manager = Arc::new(SessionManager::new(store));
+
+        let session = manager
+            .create_session(seeded_parameters(5, 4321))
+            .await
+            .expect("failed to create session");
+        let id = session.id;
+
+        let m1 = manager.clone();
+        let m2 = manager.clone();
+        let (advance, patch) = tokio::join!(
+            async move { m1.get_next_step(id).await.map(|_| ()) },
+            async move {
+                m2.update_session(id, seeded_parameters(7, 4321))
+                    .await
+                    .map(|_| ())
+            },
+        );
+
+        let results = [advance, patch];
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        let conflict_count = results
+            .iter()
+            .filter(|r| matches!(r, Err(ChainError::Conflict(_))))
+            .count();
+        assert_eq!(ok_count, 1, "exactly one of PATCH/advance must win");
+        assert_eq!(
+            conflict_count, 1,
+            "exactly one of PATCH/advance must conflict"
+        );
+
+        // A single successful mutation left the stored revision at 1.
+        let stored = inner.get(id).await.expect("session missing from store");
+        assert_eq!(stored.version, 1);
     }
 }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -177,7 +177,7 @@ impl SessionManager {
         // Bump the revision and persist via compare-and-swap. On a concurrent race the
         // save returns `ChainError::Conflict` (HTTP 409) and the client retries; there
         // is deliberately no silent retry loop here.
-        session.bump_version();
+        session.bump_version()?;
         self.store
             .save_cas(session.clone(), expected_version)
             .await?;
@@ -284,7 +284,7 @@ impl SessionManager {
         // Persist via compare-and-swap so a PATCH cannot clobber a newer revision
         // written by a concurrent advance/update; a race yields `ChainError::Conflict`
         // (HTTP 409) for the client to retry.
-        session.bump_version();
+        session.bump_version()?;
         self.store
             .save_cas(session.clone(), expected_version)
             .await?;
@@ -332,7 +332,7 @@ impl SessionManager {
         // Persist via compare-and-swap so a PUT cannot clobber a newer revision
         // written by a concurrent advance/update; a race yields `ChainError::Conflict`
         // (HTTP 409) for the client to retry.
-        session.bump_version();
+        session.bump_version()?;
         self.store
             .save_cas(session.clone(), expected_version)
             .await?;

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -260,6 +260,15 @@ pub struct Session {
     pub total_steps: usize,
     /// * `state` - The current state of the session, represented by an instance
     pub state: SessionState,
+    /// * `version` - Optimistic-concurrency revision counter. It starts at `0` at
+    ///   creation and is bumped by the [`SessionManager`] (via
+    ///   [`Session::bump_version`]) immediately before a compare-and-swap save, so
+    ///   two concurrent mutations that read the same snapshot cannot silently
+    ///   overwrite one another: the second save fails with
+    ///   [`ChainError::Conflict`]. Carries `#[serde(default)]` so sessions
+    ///   persisted before this field existed still deserialize (defaulting to 0).
+    #[serde(default)]
+    pub version: u64,
 }
 
 impl Session {
@@ -296,6 +305,7 @@ impl Session {
             total_steps: parameters.steps,
             parameters,
             state: SessionState::Initialized,
+            version: 0,
         }
     }
 
@@ -349,6 +359,7 @@ impl Session {
             total_steps: parameters.steps,
             parameters,
             state: SessionState::Initialized,
+            version: 0,
         }
     }
 
@@ -457,6 +468,18 @@ impl Session {
     pub fn is_active(&self) -> bool {
         self.state != SessionState::Completed && self.state != SessionState::Error
     }
+
+    /// Increments the optimistic-concurrency [`Session::version`] counter by one.
+    ///
+    /// The state-transition methods (`advance_step`, `modify_parameters`,
+    /// `reinitialize`) are deliberately kept as pure state changes and do NOT
+    /// touch the version. The [`SessionManager`] calls this helper right before a
+    /// compare-and-swap save so the persisted revision advances exactly once per
+    /// successfully served mutation. Uses `saturating_add` so an (unreachable in
+    /// practice) overflow cannot panic on a production path.
+    pub fn bump_version(&mut self) {
+        self.version = self.version.saturating_add(1);
+    }
 }
 
 impl Default for Session {
@@ -496,6 +519,7 @@ impl Default for Session {
             current_step: 0,
             total_steps: 20,
             state: SessionState::Initialized,
+            version: 0,
         }
     }
 }
@@ -1394,6 +1418,57 @@ mod tests_session {
         // Error state
         session.state = SessionState::Error;
         assert!(!session.is_active());
+    }
+
+    #[test]
+    fn test_new_session_starts_at_version_zero() {
+        let params = create_test_parameters();
+        let uuid_gen = UuidGenerator::new(Uuid::new_v4());
+
+        assert_eq!(
+            Session::new_with_generator(params.clone(), &uuid_gen).version,
+            0
+        );
+        assert_eq!(Session::with_random_id(params).version, 0);
+        assert_eq!(Session::default().version, 0);
+    }
+
+    #[test]
+    fn test_bump_version_increments_by_one() {
+        let params = create_test_parameters();
+        let uuid_gen = UuidGenerator::new(Uuid::new_v4());
+        let mut session = Session::new_with_generator(params, &uuid_gen);
+
+        assert_eq!(session.version, 0);
+        session.bump_version();
+        assert_eq!(session.version, 1);
+        session.bump_version();
+        assert_eq!(session.version, 2);
+    }
+
+    /// Stored-session compatibility: a `Session` persisted before the optimistic
+    /// `version` field existed (its JSON has no `version` key) must still
+    /// deserialize, defaulting to version 0. The round-trip strips the key from a
+    /// freshly serialized session to reproduce the OLD stored shape exactly.
+    #[test]
+    fn test_deserialization_without_version_defaults_to_zero() {
+        let params = create_test_parameters();
+        let uuid_gen = UuidGenerator::new(Uuid::new_v4());
+        let mut session = Session::new_with_generator(params, &uuid_gen);
+        session.version = 7;
+
+        // Serialize, then drop the `version` key to mimic an older stored payload.
+        let mut value: serde_json::Value = serde_json::to_value(&session).unwrap();
+        value
+            .as_object_mut()
+            .expect("session serializes to a JSON object")
+            .remove("version");
+        assert!(value.get("version").is_none());
+
+        let restored: Session = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.version, 0);
+        assert_eq!(restored.id, session.id);
+        assert_eq!(restored.current_step, session.current_step);
     }
 
     #[test]

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -475,10 +475,21 @@ impl Session {
     /// `reinitialize`) are deliberately kept as pure state changes and do NOT
     /// touch the version. The [`SessionManager`] calls this helper right before a
     /// compare-and-swap save so the persisted revision advances exactly once per
-    /// successfully served mutation. Uses `saturating_add` so an (unreachable in
-    /// practice) overflow cannot panic on a production path.
-    pub fn bump_version(&mut self) {
-        self.version = self.version.saturating_add(1);
+    /// successfully served mutation. Uses `checked_add` (the ruleset forbids
+    /// `saturating_*`): saturating at `u64::MAX` would freeze the revision and let
+    /// several concurrent writers pass the compare-and-swap, so an overflow is
+    /// surfaced as an error instead of being silently clamped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] if the counter would overflow `u64`
+    /// (unreachable in practice — it would take 2^64 mutations of one session).
+    pub fn bump_version(&mut self) -> Result<(), ChainError> {
+        self.version = self
+            .version
+            .checked_add(1)
+            .ok_or_else(|| ChainError::Internal("session version overflow".to_string()))?;
+        Ok(())
     }
 }
 
@@ -1440,10 +1451,28 @@ mod tests_session {
         let mut session = Session::new_with_generator(params, &uuid_gen);
 
         assert_eq!(session.version, 0);
-        session.bump_version();
+        assert!(session.bump_version().is_ok());
         assert_eq!(session.version, 1);
-        session.bump_version();
+        assert!(session.bump_version().is_ok());
         assert_eq!(session.version, 2);
+    }
+
+    /// The revision counter must never silently clamp: at `u64::MAX` a bump
+    /// returns [`ChainError::Internal`] instead of saturating (which would let
+    /// multiple stale writers pass the compare-and-swap).
+    #[test]
+    fn test_bump_version_overflow_returns_internal_error() {
+        let params = create_test_parameters();
+        let uuid_gen = UuidGenerator::new(Uuid::new_v4());
+        let mut session = Session::new_with_generator(params, &uuid_gen);
+        session.version = u64::MAX;
+
+        match session.bump_version() {
+            Err(ChainError::Internal(msg)) => assert!(msg.contains("overflow")),
+            other => panic!("expected Internal overflow error, got {other:?}"),
+        }
+        // The counter is left untouched on overflow.
+        assert_eq!(session.version, u64::MAX);
     }
 
     /// Stored-session compatibility: a `Session` persisted before the optimistic

--- a/src/session/store/in_memory.rs
+++ b/src/session/store/in_memory.rs
@@ -87,6 +87,33 @@ impl SessionStore for InMemorySessionStore {
         Ok(())
     }
 
+    async fn save_cas(&self, session: Session, expected_version: u64) -> Result<(), ChainError> {
+        // The whole compare-and-swap runs under the map lock, held only for this
+        // synchronous section (no `.await` inside), so the read of the stored
+        // version and the conditional write are one atomic step: two concurrent
+        // callers cannot both observe `expected_version` and both commit.
+        let mut sessions = self.sessions.lock().map_err(|_| {
+            ChainError::Internal("Failed to acquire lock on session store".to_string())
+        })?;
+
+        match sessions.get(&session.id) {
+            None => Err(ChainError::NotFound(format!(
+                "Session with id {} not found",
+                session.id
+            ))),
+            Some(existing) if existing.version != expected_version => {
+                Err(ChainError::Conflict(format!(
+                    "Session {} was modified concurrently (expected version {}, found {})",
+                    session.id, expected_version, existing.version
+                )))
+            }
+            Some(_) => {
+                sessions.insert(session.id, session);
+                Ok(())
+            }
+        }
+    }
+
     async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
         let mut sessions = self.sessions.lock().map_err(|_| {
             ChainError::Internal("Failed to acquire lock on session store".to_string())
@@ -173,6 +200,7 @@ mod tests {
                 total_steps: params.steps,
                 parameters: params,
                 state: SessionState::Initialized,
+                version: 0,
             }
         } else {
             Session::new(params, &uuid_generator)
@@ -312,6 +340,70 @@ mod tests {
         assert_eq!(retrieved.current_step, 1);
     }
 
+    /// Issue #8: `save_cas` commits when the expected version matches the stored
+    /// revision, and the stored session reflects the mutation.
+    #[tokio::test]
+    async fn test_save_cas_matching_version_commits() {
+        let store = InMemorySessionStore::new();
+        let mut session = create_test_session(None);
+        let id = session.id;
+        assert_eq!(session.version, 0);
+
+        assert!(store.create(session.clone()).await.is_ok());
+
+        // Mutate a clone and bump its version, then CAS against the observed v0.
+        session.current_step = 3;
+        session.state = SessionState::InProgress;
+        session.bump_version();
+        assert!(store.save_cas(session, 0).await.is_ok());
+
+        let stored = store.get(id).await.unwrap();
+        assert_eq!(stored.current_step, 3);
+        assert_eq!(stored.state, SessionState::InProgress);
+        assert_eq!(stored.version, 1);
+    }
+
+    /// Issue #8: a stale `expected_version` is rejected with `Conflict` and the
+    /// stored session is left untouched (no lost update).
+    #[tokio::test]
+    async fn test_save_cas_stale_version_conflicts_and_leaves_store_unchanged() {
+        let store = InMemorySessionStore::new();
+        let mut session = create_test_session(None);
+        let id = session.id;
+        assert!(store.create(session.clone()).await.is_ok());
+
+        // A first CAS advances the stored revision from 0 to 1.
+        session.current_step = 1;
+        session.bump_version();
+        assert!(store.save_cas(session.clone(), 0).await.is_ok());
+
+        // A second writer that still believes it is at v0 must be rejected.
+        let mut stale = session.clone();
+        stale.current_step = 99;
+        stale.bump_version();
+        match store.save_cas(stale, 0).await {
+            Err(ChainError::Conflict(_)) => {}
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+
+        // The store still holds the winner's write, not the stale one.
+        let stored = store.get(id).await.unwrap();
+        assert_eq!(stored.current_step, 1);
+        assert_eq!(stored.version, 1);
+    }
+
+    /// Issue #8: `save_cas` on an id that is not stored returns `NotFound`.
+    #[tokio::test]
+    async fn test_save_cas_missing_id_returns_not_found() {
+        let store = InMemorySessionStore::new();
+        let session = create_test_session(None);
+
+        match store.save_cas(session, 0).await {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn test_delete_session() {
         let store = InMemorySessionStore::new();
@@ -361,6 +453,7 @@ mod tests {
             total_steps: 10,
             parameters: current_session.parameters.clone(),
             state: SessionState::Initialized,
+            version: 0,
         };
 
         // Guardar ambas sesiones

--- a/src/session/store/in_memory.rs
+++ b/src/session/store/in_memory.rs
@@ -354,7 +354,7 @@ mod tests {
         // Mutate a clone and bump its version, then CAS against the observed v0.
         session.current_step = 3;
         session.state = SessionState::InProgress;
-        session.bump_version();
+        assert!(session.bump_version().is_ok());
         assert!(store.save_cas(session, 0).await.is_ok());
 
         let stored = store.get(id).await.unwrap();
@@ -374,13 +374,13 @@ mod tests {
 
         // A first CAS advances the stored revision from 0 to 1.
         session.current_step = 1;
-        session.bump_version();
+        assert!(session.bump_version().is_ok());
         assert!(store.save_cas(session.clone(), 0).await.is_ok());
 
         // A second writer that still believes it is at v0 must be rejected.
         let mut stale = session.clone();
         stale.current_step = 99;
-        stale.bump_version();
+        assert!(stale.bump_version().is_ok());
         match store.save_cas(stale, 0).await {
             Err(ChainError::Conflict(_)) => {}
             other => panic!("expected Conflict, got {other:?}"),

--- a/src/session/store/in_redis.rs
+++ b/src/session/store/in_redis.rs
@@ -20,17 +20,24 @@ pub struct InRedisSessionStore {
 
 /// Server-side Lua for an atomic session compare-and-swap.
 ///
-/// Redis runs a script as a single, uninterruptible unit, so the GET, the
-/// version comparison, and the conditional SET happen without any interleaving
-/// from another connection — this is what makes the CAS race-free. The stored
-/// version is read from the persisted JSON with the built-in `cjson` decoder
-/// (`cjson.decode(stored).version`), keeping the version's single source of
-/// truth INSIDE the session document (no companion key to keep in sync from
-/// `create`/`save`). A session written before the `version` field existed
-/// decodes to `nil`, so `or 0` treats it as revision 0.
+/// Redis runs a script as a single, uninterruptible unit, so the two GETs, the
+/// version comparison, and the conditional SETs happen without any interleaving
+/// from another connection — this is what makes the CAS race-free.
 ///
-/// Arguments: `KEYS[1]` = session key; `ARGV[1]` = new session JSON;
-/// `ARGV[2]` = expected version; `ARGV[3]` = TTL in seconds.
+/// The version compared for the CAS is NOT read from the JSON document: decoding
+/// it with `cjson` would round the integer through an IEEE-754 double, which
+/// cannot represent every `u64`, so two adjacent revisions above `2^53` collapse
+/// to the same value and a stale writer could pass the check. Instead the version
+/// lives in a COMPANION key (`{session_key}:ver`) as a plain integer STRING and is
+/// compared as a string (`ver ~= ARGV[2]`), i.e. an exact byte comparison with no
+/// floating-point rounding. A session written before this companion key existed
+/// has no `:ver` key; `GET` then returns `false`, so `or '0'` treats it as
+/// revision `0`.
+///
+/// Keys: `KEYS[1]` = session key; `KEYS[2]` = companion version key.
+/// Arguments: `ARGV[1]` = new session JSON; `ARGV[2]` = expected version string;
+/// `ARGV[3]` = new version string; `ARGV[4]` = TTL in seconds. Both keys are
+/// rewritten with the same TTL so they always expire together.
 ///
 /// Return codes: `-1` = key missing (NotFound); `-2` = version mismatch
 /// (Conflict); `1` = written.
@@ -39,11 +46,12 @@ local cur = redis.call('GET', KEYS[1])
 if not cur then
     return -1
 end
-local v = cjson.decode(cur)['version'] or 0
-if v ~= tonumber(ARGV[2]) then
+local ver = redis.call('GET', KEYS[2]) or '0'
+if ver ~= ARGV[2] then
     return -2
 end
-redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[3]))
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[4]))
+redis.call('SET', KEYS[2], ARGV[3], 'EX', tonumber(ARGV[4]))
 return 1
 "#;
 
@@ -112,6 +120,15 @@ impl InRedisSessionStore {
         format!("{}{}", self.key_prefix, id)
     }
 
+    /// Constructs the companion version key for a session ID (`{session_key}:ver`).
+    ///
+    /// This key holds the optimistic-concurrency revision as an integer STRING so
+    /// [`SAVE_CAS_SCRIPT`] can compare it exactly, avoiding the IEEE-754 rounding
+    /// that a `cjson`-decoded `u64` would suffer above `2^53`.
+    fn version_key(&self, id: Uuid) -> String {
+        format!("{}:ver", self.session_key(id))
+    }
+
     /// Maps a Redis error to a ChainError
     fn map_redis_error(err: RedisError) -> ChainError {
         ChainError::Internal(format!("Redis error: {}", err))
@@ -159,6 +176,7 @@ impl SessionStore for InRedisSessionStore {
     #[instrument(skip(self, session), level = "debug")]
     async fn create(&self, session: Session) -> Result<(), ChainError> {
         let key = self.session_key(session.id);
+        let version_key = self.version_key(session.id);
         debug!(session_id = %session.id, key = %key, "Creating session in Redis");
 
         // Serialize session to JSON
@@ -180,6 +198,19 @@ impl SessionStore for InRedisSessionStore {
             .await
         {
             Ok(true) => {
+                // Seed the companion version key the CAS script compares against.
+                // create/save/delete are NOT the compare-and-swap race surface (only
+                // `save_cas` races), so plain sequential commands are fine here; the
+                // script defaults a missing `:ver` key to "0", so even a half-written
+                // pair still compares safely.
+                self.client
+                    .set(
+                        &version_key,
+                        session.version.to_string(),
+                        Some(self.session_ttl),
+                    )
+                    .await
+                    .map_err(Self::map_redis_error)?;
                 debug!(session_id = %session.id, "Session created successfully");
                 Ok(())
             }
@@ -200,6 +231,7 @@ impl SessionStore for InRedisSessionStore {
     #[instrument(skip(self, session), level = "debug")]
     async fn save(&self, session: Session) -> Result<(), ChainError> {
         let key = self.session_key(session.id);
+        let version_key = self.version_key(session.id);
         debug!(session_id = %session.id, key = %key, "Saving session to Redis");
 
         // Serialize session to JSON
@@ -214,27 +246,32 @@ impl SessionStore for InRedisSessionStore {
             }
         };
 
-        // Save to Redis with TTL
-        match self
-            .client
+        // Blind upsert: write the document, then keep the companion version key in
+        // sync. `save` is not the compare-and-swap race surface (see `create`), so
+        // two sequential SETs are fine — a torn write only leaves the pair briefly
+        // inconsistent and the CAS script tolerates a missing `:ver` key.
+        self.client
             .set(&key, json_str, Some(self.session_ttl))
             .await
-        {
-            Ok(_) => {
-                debug!(session_id = %session.id, "Session saved successfully");
-                Ok(())
-            }
-            Err(e) => {
-                error!(session_id = %session.id, error = %e, "Redis error while saving session");
-                Err(Self::map_redis_error(e))
-            }
-        }
+            .map_err(Self::map_redis_error)?;
+        self.client
+            .set(
+                &version_key,
+                session.version.to_string(),
+                Some(self.session_ttl),
+            )
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        debug!(session_id = %session.id, "Session saved successfully");
+        Ok(())
     }
 
     #[instrument(skip(self, session), level = "debug")]
     async fn save_cas(&self, session: Session, expected_version: u64) -> Result<(), ChainError> {
         let id = session.id;
         let key = self.session_key(id);
+        let version_key = self.version_key(id);
         debug!(session_id = %id, key = %key, expected_version, "CAS-saving session to Redis");
 
         // Serialize session to JSON
@@ -251,12 +288,17 @@ impl SessionStore for InRedisSessionStore {
 
         // Run the compare-and-swap atomically server-side. The manager (the block
         // scheduler) supplies `expected_version`; the script only writes when the
-        // stored revision still matches, so a concurrent advance cannot be lost.
+        // companion version key still matches, so a concurrent advance cannot be
+        // lost. Versions cross the boundary as STRINGS so the Lua comparison is exact
+        // for every `u64` (no cjson double rounding). `session.version` was already
+        // bumped past `expected_version` by the manager.
         let mut conn = self.client.connection_manager();
         let code: i64 = redis::Script::new(SAVE_CAS_SCRIPT)
             .key(&key)
+            .key(&version_key)
             .arg(json_str)
-            .arg(expected_version)
+            .arg(expected_version.to_string())
+            .arg(session.version.to_string())
             .arg(self.session_ttl)
             .invoke_async(&mut conn)
             .await
@@ -270,18 +312,25 @@ impl SessionStore for InRedisSessionStore {
     #[instrument(skip(self), level = "debug")]
     async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
         let key = self.session_key(id);
+        let version_key = self.version_key(id);
         debug!(session_id = %id, key = %key, "Deleting session from Redis");
 
-        match self.client.delete(&key).await {
-            Ok(deleted) => {
-                debug!(session_id = %id, deleted = deleted, "Session delete result");
-                Ok(deleted)
-            }
-            Err(e) => {
-                error!(session_id = %id, error = %e, "Redis error while deleting session");
-                Err(Self::map_redis_error(e))
-            }
-        }
+        // Remove BOTH the session document and its companion version key. Sequential
+        // deletes are fine (delete is not the CAS race surface); the session key's
+        // result is what determines whether a session actually existed, and deleting
+        // an already-absent `:ver` key is harmless.
+        let deleted = self
+            .client
+            .delete(&key)
+            .await
+            .map_err(Self::map_redis_error)?;
+        self.client
+            .delete(&version_key)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        debug!(session_id = %id, deleted = deleted, "Session delete result");
+        Ok(deleted)
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -303,6 +352,7 @@ impl SessionStore for InRedisSessionStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::infrastructure::RedisConfig;
     use crate::session::{SessionState, SimulationMethod, SimulationParameters};
     use optionstratlib::utils::TimeFrame;
     use positive::{Positive, pos_or_panic};
@@ -338,9 +388,20 @@ mod tests {
             format!("{}{}", self.key_prefix, id)
         }
 
-        // Helper to get store size for tests
+        // Companion version key mirroring the real store (`{session_key}:ver`).
+        fn version_key(&self, id: Uuid) -> String {
+            format!("{}:ver", self.session_key(id))
+        }
+
+        // Helper to get store size for tests. Counts only session documents, not the
+        // companion `:ver` keys, so "one session" reads as size 1 as before.
         fn get_store_size(&self) -> usize {
-            self.sessions.lock().unwrap().len()
+            self.sessions
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|k| !k.ends_with(":ver"))
+                .count()
         }
     }
 
@@ -372,6 +433,7 @@ mod tests {
 
         async fn create(&self, session: Session) -> Result<(), ChainError> {
             let key = self.session_key(session.id);
+            let version_key = self.version_key(session.id);
 
             // Serialize session to JSON
             let json_str = match serde_json::to_string(&session) {
@@ -384,7 +446,8 @@ mod tests {
                 }
             };
 
-            // Mirror the real store's SET NX behaviour: reject id collisions.
+            // Mirror the real store's SET NX behaviour: reject id collisions, and
+            // seed the companion version key alongside the document.
             let mut sessions = self.sessions.lock().unwrap();
             if sessions.contains_key(&key) {
                 return Err(ChainError::AlreadyExists(format!(
@@ -393,12 +456,14 @@ mod tests {
                 )));
             }
             sessions.insert(key, json_str);
+            sessions.insert(version_key, session.version.to_string());
 
             Ok(())
         }
 
         async fn save(&self, session: Session) -> Result<(), ChainError> {
             let key = self.session_key(session.id);
+            let version_key = self.version_key(session.id);
 
             // Serialize session to JSON
             let json_str = match serde_json::to_string(&session) {
@@ -411,9 +476,10 @@ mod tests {
                 }
             };
 
-            // Save to our in-memory store
+            // Upsert the document and keep the companion version key in sync.
             let mut sessions = self.sessions.lock().unwrap();
             sessions.insert(key, json_str);
+            sessions.insert(version_key, session.version.to_string());
 
             Ok(())
         }
@@ -424,6 +490,7 @@ mod tests {
             expected_version: u64,
         ) -> Result<(), ChainError> {
             let key = self.session_key(session.id);
+            let version_key = self.version_key(session.id);
 
             let json_str = match serde_json::to_string(&session) {
                 Ok(s) => s,
@@ -435,20 +502,20 @@ mod tests {
                 }
             };
 
-            // Mirror the Lua CAS: read the stored version from the persisted JSON
-            // (defaulting to 0 for a pre-version payload), compare, then write.
+            // Mirror the Lua CAS: the companion version key is the source of truth.
+            // A missing `:ver` key defaults to 0 (a legacy session written before the
+            // companion key existed); compare it exactly, then rewrite both keys.
             let mut sessions = self.sessions.lock().unwrap();
-            let stored_version = match sessions.get(&key) {
-                None => {
-                    return Err(ChainError::NotFound(format!(
-                        "Session with id {} not found",
-                        session.id
-                    )));
-                }
-                Some(stored) => serde_json::from_str::<Session>(stored)
-                    .map(|s| s.version)
-                    .unwrap_or(0),
-            };
+            if !sessions.contains_key(&key) {
+                return Err(ChainError::NotFound(format!(
+                    "Session with id {} not found",
+                    session.id
+                )));
+            }
+            let stored_version: u64 = sessions
+                .get(&version_key)
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
             if stored_version != expected_version {
                 return Err(ChainError::Conflict(format!(
                     "Session {} was modified concurrently (expected version {}, found {})",
@@ -456,15 +523,20 @@ mod tests {
                 )));
             }
             sessions.insert(key, json_str);
+            sessions.insert(version_key, session.version.to_string());
 
             Ok(())
         }
 
         async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
             let key = self.session_key(id);
+            let version_key = self.version_key(id);
 
+            // Remove both keys; the session document's presence decides the result.
             let mut sessions = self.sessions.lock().unwrap();
-            Ok(sessions.remove(&key).is_some())
+            let removed = sessions.remove(&key).is_some();
+            sessions.remove(&version_key);
+            Ok(removed)
         }
 
         async fn cleanup(&self) -> Result<usize, ChainError> {
@@ -705,13 +777,18 @@ mod tests {
     }
 
     /// Issue #8: the CAS Lua script is the atomicity contract. Assert the string
-    /// constant carries the exact server-side logic the store relies on: read via
-    /// GET, decode the version from the stored JSON with `cjson`, and the three
-    /// documented return codes.
+    /// constant carries the exact server-side logic the store relies on: read the
+    /// session via GET, compare the revision against the COMPANION version key as an
+    /// exact string (not a `cjson`-decoded double that collapses above 2^53),
+    /// default a missing companion key to legacy "0", and the three documented
+    /// return codes.
     #[test]
     fn test_save_cas_script_encodes_the_contract() {
-        assert!(SAVE_CAS_SCRIPT.contains("redis.call('GET', KEYS[1])"));
-        assert!(SAVE_CAS_SCRIPT.contains("cjson.decode(cur)['version']"));
+        assert!(SAVE_CAS_SCRIPT.contains("redis.call('GET', KEYS[1])")); // session doc
+        assert!(SAVE_CAS_SCRIPT.contains("redis.call('GET', KEYS[2])")); // companion version key
+        assert!(SAVE_CAS_SCRIPT.contains("or '0'")); // missing version → legacy 0
+        assert!(SAVE_CAS_SCRIPT.contains("ver ~= ARGV[2]")); // exact string compare, no doubles
+        assert!(!SAVE_CAS_SCRIPT.contains("cjson")); // the lossy decoder is gone
         assert!(SAVE_CAS_SCRIPT.contains("return -1")); // NotFound
         assert!(SAVE_CAS_SCRIPT.contains("return -2")); // Conflict
         assert!(SAVE_CAS_SCRIPT.contains("return 1")); // committed
@@ -761,14 +838,14 @@ mod tests {
 
         // Matching version → commit (stored revision advances to 1).
         session.current_step = 2;
-        session.bump_version();
+        assert!(session.bump_version().is_ok());
         assert!(store.save_cas(session.clone(), 0).await.is_ok());
         assert_eq!(store.get(id).await.unwrap().version, 1);
 
         // Stale version → Conflict, store unchanged.
         let mut stale = session.clone();
         stale.current_step = 77;
-        stale.bump_version();
+        assert!(stale.bump_version().is_ok());
         match store.save_cas(stale, 0).await {
             Err(ChainError::Conflict(_)) => {}
             other => panic!("expected Conflict, got {other:?}"),
@@ -776,6 +853,83 @@ mod tests {
         let stored = store.get(id).await.unwrap();
         assert_eq!(stored.current_step, 2);
         assert_eq!(stored.version, 1);
+    }
+
+    /// Issue #8: the Lua script is the production atomicity boundary, so exercise it
+    /// against a REAL Redis (the test doubles above only approximate it). Two
+    /// `save_cas` calls that both read version 0 race through the single-threaded Lua
+    /// engine: exactly one commits and one gets `Conflict`, the stored session ends at
+    /// version 1, and a late third writer still expecting 0 also conflicts. Ignored by
+    /// default because it needs a Redis on localhost:6379; run with `-- --ignored`.
+    #[tokio::test]
+    #[ignore = "requires live Redis on localhost:6379; run with -- --ignored"]
+    async fn test_save_cas_is_atomic_against_live_redis() {
+        // Build a client straight against a local, password-less Redis. If CI later
+        // provides a redis service on localhost:6379 this runs there unchanged.
+        let config = RedisConfig {
+            host: "localhost".to_string(),
+            port: 6379,
+            username: None,
+            password: None,
+            database: 0,
+            timeout: 5,
+            connect_timeout: 5,
+        };
+        let client = Arc::new(
+            RedisClient::new(config)
+                .await
+                .expect("connect to Redis on localhost:6379"),
+        );
+
+        // A unique prefix (with a random uuid) isolates this run's keys so parallel or
+        // repeated `--ignored` runs never collide.
+        let prefix = format!("test-cas:{}:", Uuid::new_v4());
+        let store = InRedisSessionStore::new(client, Some(prefix), Some(60));
+
+        let base = create_test_session();
+        let id = base.id;
+        store
+            .create(base.clone())
+            .await
+            .expect("create session in Redis");
+
+        // Two racing writers: both observed version 0 and bumped their clone to 1.
+        let mut a = base.clone();
+        a.current_step = 1;
+        a.bump_version().expect("bump writer a");
+        let mut b = base.clone();
+        b.current_step = 2;
+        b.bump_version().expect("bump writer b");
+
+        let (ra, rb) = tokio::join!(store.save_cas(a, 0), store.save_cas(b, 0));
+        let results = [ra, rb];
+        let ok_count = results.iter().filter(|r| r.is_ok()).count();
+        let conflict_count = results
+            .iter()
+            .filter(|r| matches!(r, Err(ChainError::Conflict(_))))
+            .count();
+        assert_eq!(ok_count, 1, "exactly one concurrent CAS must commit");
+        assert_eq!(
+            conflict_count, 1,
+            "exactly one concurrent CAS must conflict"
+        );
+
+        // The single winner advanced the persisted revision to exactly 1.
+        let stored = store.get(id).await.expect("load stored session");
+        assert_eq!(stored.version, 1, "one winning advance leaves version at 1");
+
+        // A late writer that still believes it is at version 0 must also conflict,
+        // because the companion version key is now "1".
+        let mut stale = base.clone();
+        stale.current_step = 3;
+        stale.bump_version().expect("bump stale writer");
+        match store.save_cas(stale, 0).await {
+            Err(ChainError::Conflict(_)) => {}
+            other => panic!("expected Conflict for a stale writer, got {other:?}"),
+        }
+
+        // Clean up: delete removes both the document and its companion version key.
+        assert!(store.delete(id).await.expect("cleanup session"));
     }
 
     // TestErrorInRedisSessionStore - to test error cases

--- a/src/session/store/in_redis.rs
+++ b/src/session/store/in_redis.rs
@@ -18,6 +18,61 @@ pub struct InRedisSessionStore {
     session_ttl: u64,
 }
 
+/// Server-side Lua for an atomic session compare-and-swap.
+///
+/// Redis runs a script as a single, uninterruptible unit, so the GET, the
+/// version comparison, and the conditional SET happen without any interleaving
+/// from another connection — this is what makes the CAS race-free. The stored
+/// version is read from the persisted JSON with the built-in `cjson` decoder
+/// (`cjson.decode(stored).version`), keeping the version's single source of
+/// truth INSIDE the session document (no companion key to keep in sync from
+/// `create`/`save`). A session written before the `version` field existed
+/// decodes to `nil`, so `or 0` treats it as revision 0.
+///
+/// Arguments: `KEYS[1]` = session key; `ARGV[1]` = new session JSON;
+/// `ARGV[2]` = expected version; `ARGV[3]` = TTL in seconds.
+///
+/// Return codes: `-1` = key missing (NotFound); `-2` = version mismatch
+/// (Conflict); `1` = written.
+const SAVE_CAS_SCRIPT: &str = r#"
+local cur = redis.call('GET', KEYS[1])
+if not cur then
+    return -1
+end
+local v = cjson.decode(cur)['version'] or 0
+if v ~= tonumber(ARGV[2]) then
+    return -2
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[3]))
+return 1
+"#;
+
+/// Translates the integer result code returned by [`SAVE_CAS_SCRIPT`] into the
+/// crate's `ChainError` boundary. Pure and side-effect free so the mapping is
+/// unit-testable without a live Redis.
+///
+/// - `1` → `Ok(())` (the CAS committed);
+/// - `-1` → [`ChainError::NotFound`] (no session at that key);
+/// - `-2` → [`ChainError::Conflict`] (stored revision differed);
+/// - anything else → [`ChainError::Internal`] (script contract violation).
+fn map_cas_result(code: i64, id: Uuid, expected_version: u64) -> Result<(), ChainError> {
+    match code {
+        1 => Ok(()),
+        -1 => Err(ChainError::NotFound(format!(
+            "Session with id {} not found",
+            id
+        ))),
+        -2 => Err(ChainError::Conflict(format!(
+            "Session {} was modified concurrently (expected version {})",
+            id, expected_version
+        ))),
+        other => Err(ChainError::Internal(format!(
+            "Unexpected CAS result code {} for session {}",
+            other, id
+        ))),
+    }
+}
+
 impl InRedisSessionStore {
     /// Creates a new Redis-backed session store
     ///
@@ -176,6 +231,42 @@ impl SessionStore for InRedisSessionStore {
         }
     }
 
+    #[instrument(skip(self, session), level = "debug")]
+    async fn save_cas(&self, session: Session, expected_version: u64) -> Result<(), ChainError> {
+        let id = session.id;
+        let key = self.session_key(id);
+        debug!(session_id = %id, key = %key, expected_version, "CAS-saving session to Redis");
+
+        // Serialize session to JSON
+        let json_str = match serde_json::to_string(&session) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(session_id = %id, error = %e, "Failed to serialize session");
+                return Err(ChainError::Internal(format!(
+                    "Failed to serialize session: {}",
+                    e
+                )));
+            }
+        };
+
+        // Run the compare-and-swap atomically server-side. The manager (the block
+        // scheduler) supplies `expected_version`; the script only writes when the
+        // stored revision still matches, so a concurrent advance cannot be lost.
+        let mut conn = self.client.connection_manager();
+        let code: i64 = redis::Script::new(SAVE_CAS_SCRIPT)
+            .key(&key)
+            .arg(json_str)
+            .arg(expected_version)
+            .arg(self.session_ttl)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        map_cas_result(code, id, expected_version).inspect_err(|e| {
+            debug!(session_id = %id, error = %e, "CAS save rejected");
+        })
+    }
+
     #[instrument(skip(self), level = "debug")]
     async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
         let key = self.session_key(id);
@@ -327,6 +418,48 @@ mod tests {
             Ok(())
         }
 
+        async fn save_cas(
+            &self,
+            session: Session,
+            expected_version: u64,
+        ) -> Result<(), ChainError> {
+            let key = self.session_key(session.id);
+
+            let json_str = match serde_json::to_string(&session) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err(ChainError::Internal(format!(
+                        "Failed to serialize session: {}",
+                        e
+                    )));
+                }
+            };
+
+            // Mirror the Lua CAS: read the stored version from the persisted JSON
+            // (defaulting to 0 for a pre-version payload), compare, then write.
+            let mut sessions = self.sessions.lock().unwrap();
+            let stored_version = match sessions.get(&key) {
+                None => {
+                    return Err(ChainError::NotFound(format!(
+                        "Session with id {} not found",
+                        session.id
+                    )));
+                }
+                Some(stored) => serde_json::from_str::<Session>(stored)
+                    .map(|s| s.version)
+                    .unwrap_or(0),
+            };
+            if stored_version != expected_version {
+                return Err(ChainError::Conflict(format!(
+                    "Session {} was modified concurrently (expected version {}, found {})",
+                    session.id, expected_version, stored_version
+                )));
+            }
+            sessions.insert(key, json_str);
+
+            Ok(())
+        }
+
         async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
             let key = self.session_key(id);
 
@@ -373,6 +506,7 @@ mod tests {
             total_steps: 10,
             parameters: params,
             state: SessionState::Initialized,
+            version: 0,
         }
     }
 
@@ -570,6 +704,80 @@ mod tests {
         assert_eq!(updated_session.state, SessionState::InProgress);
     }
 
+    /// Issue #8: the CAS Lua script is the atomicity contract. Assert the string
+    /// constant carries the exact server-side logic the store relies on: read via
+    /// GET, decode the version from the stored JSON with `cjson`, and the three
+    /// documented return codes.
+    #[test]
+    fn test_save_cas_script_encodes_the_contract() {
+        assert!(SAVE_CAS_SCRIPT.contains("redis.call('GET', KEYS[1])"));
+        assert!(SAVE_CAS_SCRIPT.contains("cjson.decode(cur)['version']"));
+        assert!(SAVE_CAS_SCRIPT.contains("return -1")); // NotFound
+        assert!(SAVE_CAS_SCRIPT.contains("return -2")); // Conflict
+        assert!(SAVE_CAS_SCRIPT.contains("return 1")); // committed
+        assert!(SAVE_CAS_SCRIPT.contains("'EX'")); // TTL preserved on write
+    }
+
+    /// Issue #8: the pure return-code mapper turns each documented script code
+    /// into the right `ChainError` boundary (and rejects an out-of-contract code).
+    #[test]
+    fn test_map_cas_result_maps_each_code() {
+        let id = Uuid::new_v4();
+
+        assert!(map_cas_result(1, id, 0).is_ok());
+
+        match map_cas_result(-1, id, 0) {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        match map_cas_result(-2, id, 4) {
+            Err(ChainError::Conflict(msg)) => assert!(msg.contains("version 4")),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+
+        match map_cas_result(42, id, 0) {
+            Err(ChainError::Internal(_)) => {}
+            other => panic!("expected Internal for an unexpected code, got {other:?}"),
+        }
+    }
+
+    /// Issue #8: the in-memory Redis double mirrors the Lua CAS — a matching
+    /// expected version commits, a stale one conflicts without overwriting, and a
+    /// missing key is NotFound.
+    #[tokio::test]
+    async fn test_test_double_save_cas_behaves_like_lua() {
+        let store = TestInRedisSessionStore::new(None, None);
+        let mut session = create_test_session();
+        let id = session.id;
+
+        // Missing key → NotFound.
+        match store.save_cas(session.clone(), 0).await {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        store.create(session.clone()).await.unwrap();
+
+        // Matching version → commit (stored revision advances to 1).
+        session.current_step = 2;
+        session.bump_version();
+        assert!(store.save_cas(session.clone(), 0).await.is_ok());
+        assert_eq!(store.get(id).await.unwrap().version, 1);
+
+        // Stale version → Conflict, store unchanged.
+        let mut stale = session.clone();
+        stale.current_step = 77;
+        stale.bump_version();
+        match store.save_cas(stale, 0).await {
+            Err(ChainError::Conflict(_)) => {}
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+        let stored = store.get(id).await.unwrap();
+        assert_eq!(stored.current_step, 2);
+        assert_eq!(stored.version, 1);
+    }
+
     // TestErrorInRedisSessionStore - to test error cases
     struct TestErrorInRedisSessionStore {
         // Store that always generates errors
@@ -594,6 +802,17 @@ mod tests {
         async fn save(&self, session: Session) -> Result<(), ChainError> {
             Err(ChainError::Internal(format!(
                 "Simulated error saving session {}",
+                session.id
+            )))
+        }
+
+        async fn save_cas(
+            &self,
+            session: Session,
+            _expected_version: u64,
+        ) -> Result<(), ChainError> {
+            Err(ChainError::Internal(format!(
+                "Simulated error CAS-saving session {}",
                 session.id
             )))
         }
@@ -623,8 +842,11 @@ mod tests {
         let create_result = error_store.create(session.clone()).await;
         assert!(create_result.is_err());
 
-        let save_result = error_store.save(session).await;
+        let save_result = error_store.save(session.clone()).await;
         assert!(save_result.is_err());
+
+        let save_cas_result = error_store.save_cas(session, 0).await;
+        assert!(save_cas_result.is_err());
 
         let get_result = error_store.get(session_id).await;
         assert!(get_result.is_err());

--- a/src/session/store/interface.rs
+++ b/src/session/store/interface.rs
@@ -107,6 +107,37 @@ pub trait SessionStore: Send + Sync {
     ///
     async fn save(&self, session: Session) -> Result<(), ChainError>;
 
+    /// Atomically persists `session` ONLY IF the stored revision still equals
+    /// `expected_version` (an optimistic-concurrency compare-and-swap).
+    ///
+    /// This is the safe counterpart to the blind-upsert [`SessionStore::save`]: it
+    /// closes the read-modify-write race where two concurrent mutations both read
+    /// the same snapshot and one silently overwrites the other. The caller reads a
+    /// session, captures its `version`, mutates a clone, bumps the version, and
+    /// calls `save_cas` with the captured (pre-mutation) `expected_version`. The
+    /// write commits only when no other writer changed the stored revision in
+    /// between; otherwise it is rejected and the store is left untouched.
+    ///
+    /// # Parameters
+    /// - `session`: The mutated `Session` to persist (its `version` should already
+    ///   be bumped past `expected_version`).
+    /// - `expected_version`: The `version` the caller observed when it read the
+    ///   session, i.e. the revision the stored copy must still be at for the write
+    ///   to succeed.
+    ///
+    /// # Returns
+    /// - `Ok(())`: The stored revision matched and the session was persisted.
+    /// - `Err(ChainError::NotFound)`: No session with that id exists.
+    /// - `Err(ChainError::Conflict)`: The stored revision differed from
+    ///   `expected_version` (a concurrent writer won the race); the store is
+    ///   unchanged.
+    /// - `Err(ChainError)`: Any underlying storage/serialization failure.
+    ///
+    /// # Errors
+    /// Returns `ChainError::NotFound` when the id is absent, `ChainError::Conflict`
+    /// on a version mismatch, or another `ChainError` variant on a backend failure.
+    async fn save_cas(&self, session: Session, expected_version: u64) -> Result<(), ChainError>;
+
     /// Deletes an entity identified by the given `id`.
     ///
     /// # Parameters
@@ -162,6 +193,7 @@ mod tests {
             async fn get(&self, id: Uuid) -> Result<Session, ChainError>;
             async fn create(&self, session: Session) -> Result<(), ChainError>;
             async fn save(&self, session: Session) -> Result<(), ChainError>;
+            async fn save_cas(&self, session: Session, expected_version: u64) -> Result<(), ChainError>;
             async fn delete(&self, id: Uuid) -> Result<bool, ChainError>;
             async fn cleanup(&self) -> Result<usize, ChainError>;
         }
@@ -209,6 +241,30 @@ mod tests {
             let mut sessions = self.sessions.lock().unwrap();
             sessions.insert(session.id, session);
             Ok(())
+        }
+
+        async fn save_cas(
+            &self,
+            session: Session,
+            expected_version: u64,
+        ) -> Result<(), ChainError> {
+            let mut sessions = self.sessions.lock().unwrap();
+            match sessions.get(&session.id) {
+                None => Err(ChainError::NotFound(format!(
+                    "Session with id {} not found",
+                    session.id
+                ))),
+                Some(existing) if existing.version != expected_version => {
+                    Err(ChainError::Conflict(format!(
+                        "Session {} was modified concurrently (expected version {}, found {})",
+                        session.id, expected_version, existing.version
+                    )))
+                }
+                Some(_) => {
+                    sessions.insert(session.id, session);
+                    Ok(())
+                }
+            }
         }
 
         async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
@@ -265,6 +321,7 @@ mod tests {
             current_step: 0,
             total_steps: 100,
             state: SessionState::Initialized,
+            version: 0,
         }
     }
 

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -31,6 +31,14 @@ pub enum ChainError {
     ///   created again. Raised by `SessionStore::create` when a session id is already
     ///   present, guarding against silently overwriting a live session.
     AlreadyExists(String),
+    /// - `Conflict(String)`
+    ///   Denotes an optimistic-concurrency conflict: a compare-and-swap save
+    ///   (`SessionStore::save_cas`) found the stored session at a different
+    ///   revision than the caller expected, meaning another writer advanced or
+    ///   modified it in between. Raised so concurrent mutations cannot silently
+    ///   overwrite one another; the caller (client) should re-read and retry. Maps
+    ///   to HTTP 409 at the REST boundary.
+    Conflict(String),
     /// - `SimulatorError(String)`
     ///   Indicates an error specific to a simulation process. Provides a `String` for more context.
     SimulatorError(String),
@@ -99,6 +107,7 @@ impl fmt::Display for ChainError {
             ChainError::Internal(msg) => write!(f, "Internal Error: {}", msg),
             ChainError::NotFound(msg) => write!(f, "Not Found: {}", msg),
             ChainError::AlreadyExists(msg) => write!(f, "Already Exists: {}", msg),
+            ChainError::Conflict(msg) => write!(f, "Conflict: {}", msg),
             ChainError::SimulatorError(msg) => write!(f, "Simulator Error: {}", msg),
             ChainError::ClickHouseError(msg) => write!(f, "ClickHouse Error: {}", msg),
             ChainError::NotEnoughData(msg) => write!(f, "Not Enough Data: {}", msg),
@@ -206,6 +215,10 @@ mod tests {
                 "Already Exists: resource present",
             ),
             (
+                ChainError::Conflict("version mismatch".to_string()),
+                "Conflict: version mismatch",
+            ),
+            (
                 ChainError::SimulatorError("simulation failed".to_string()),
                 "Simulator Error: simulation failed",
             ),
@@ -253,6 +266,7 @@ mod tests {
             ChainError::Internal("internal issue".to_string()),
             ChainError::NotFound("not found".to_string()),
             ChainError::AlreadyExists("already exists".to_string()),
+            ChainError::Conflict("version conflict".to_string()),
             ChainError::SimulatorError("simulation problem".to_string()),
             ChainError::ClickHouseError("database issue".to_string()),
             ChainError::NotEnoughData("insufficient data".to_string()),
@@ -270,6 +284,7 @@ mod tests {
                 ChainError::Internal(msg) => assert_eq!(msg, "internal issue"),
                 ChainError::NotFound(msg) => assert_eq!(msg, "not found"),
                 ChainError::AlreadyExists(msg) => assert_eq!(msg, "already exists"),
+                ChainError::Conflict(msg) => assert_eq!(msg, "version conflict"),
                 ChainError::SimulatorError(msg) => assert_eq!(msg, "simulation problem"),
                 ChainError::ClickHouseError(msg) => assert_eq!(msg, "database issue"),
                 ChainError::NotEnoughData(msg) => assert_eq!(msg, "insufficient data"),


### PR DESCRIPTION
## Summary

Session advancement, PATCH, and PUT used a non-atomic read-modify-write: two
concurrent requests could read the same snapshot and silently overwrite each
other — duplicate steps, lost progress, broken tape ordering. Mutations now go
through optimistic concurrency: a `version` on the session and an atomic
compare-and-set in the store; a stale writer gets an explicit HTTP 409.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 11**
- **Base branch:** `stack/10-19-async-redis-store`
- **Stacked on:** #32 · **Blocks:** the next PR in the stack (#9)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- `Session.version: u64` with `#[serde(default)]` (old stored JSON loads at 0
  — round-trip tested); `Session::bump_version()`; model transitions stay
  pure — the manager bumps right before the CAS write.
- New `SessionStore::save_cas(session, expected_version)`: in-memory under the
  map mutex; Redis via a server-side Lua script (`cjson.decode` of the stored
  JSON's `version`; `-1` → NotFound, `-2` → Conflict, `1` → SET with TTL) —
  atomic on the server, works with the multiplexed `ConnectionManager`.
- New `ChainError::Conflict` → HTTP 409; documented on POST /step, PUT, PATCH.
- `get_next_step` / `update_session` / `reinitialize_session`: read version →
  mutate → bump → `save_cas`; conflicts propagate (no silent retry).
  `create_session` stays on the NX-guarded `create`.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 318 + 2 passed, 0 failed
- [x] **Barrier-forced acceptance test**: two concurrent advances from cursor 0 (both reads rendezvous before either write) → exactly ONE succeeds at cursor 1, one gets `Conflict`; persisted session cursor 1 / version 1 — no lost update, no duplicate step
- [x] PATCH-vs-advance concurrent conflict test
- [x] `save_cas` unit tests (commit / stale-leaves-store-unchanged / missing); Lua contract + return-code mapping unit-tested; old-JSON compat test
- [x] clippy `-D warnings` + fmt clean

## Checklist

- [x] Stored-session compatibility: `version` carries `#[serde(default)]`
- [x] Redis CAS is a single server-side script (no get/set race); no lock across `.await`
- [x] Seed plumbing and walk/simulator untouched
- [x] No new dependencies; no `unsafe`; `tracing` only

Note: live-Redis integration of the Lua script is outside the hermetic suite;
it is mirrored by the store double + script/mapping unit tests.

Closes #8
