### PR TITLE
Deterministic OHLCV aggregation via argMin/argMax (#14)

### DIFF
--- a/src/infrastructure/clickhouse/client.rs
+++ b/src/infrastructure/clickhouse/client.rs
@@ -584,4 +584,96 @@ mod tests {
         assert_eq!(typical_prices[0], expected_typical_1);
         assert_eq!(typical_prices[1], expected_typical_2);
     }
+
+    /// Live-ClickHouse fixture for issue #14 acceptance: rows are inserted in a
+    /// SHUFFLED (non-chronological) order as separate inserts, so each row lands in
+    /// its own part and an `any(open)`/`any(close)` aggregation would be free to pick
+    /// a mid-interval row. The hourly aggregate must nevertheless report the
+    /// chronologically first open, last close, max high, min low and summed volume —
+    /// which only holds with the timestamp-aware `argMin`/`argMax` aggregates.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_hourly_aggregation_deterministic_against_live_clickhouse() {
+        let client = ClickHouseClient::new(ClickHouseConfig::default())
+            .expect("failed to build ClickHouse client");
+
+        client
+            .client
+            .query(
+                "CREATE TABLE IF NOT EXISTS ohlcv (\
+                 symbol String, timestamp DateTime, \
+                 open Float32, high Float32, low Float32, close Float32, \
+                 volume UInt64) \
+                 ENGINE = MergeTree ORDER BY (symbol, timestamp)",
+            )
+            .execute()
+            .await
+            .expect("failed to ensure ohlcv table");
+
+        // Unique symbol per run keeps concurrent/repeated executions independent.
+        let symbol = format!("OCSTEST{}", &uuid::Uuid::new_v4().simple().to_string()[..8]);
+
+        // One hourly bucket (2021-01-01 10:00 UTC). Chronological truth:
+        // open 100.0 at 10:00, close 107.0 at 10:59, high 110.0, low 95.0, volume 60.
+        // Inserted SHUFFLED (10:30, 10:59, 10:00), one insert per row, so each row
+        // sits in its own part and part order disagrees with timestamp order.
+        let base = 1_609_495_200_i64; // 2021-01-01 10:00:00 UTC
+        let rows: [(i64, f32, f32, f32, f32, u64); 3] = [
+            (base + 30 * 60, 102.0, 110.0, 95.0, 103.0, 20),
+            (base + 59 * 60, 104.0, 108.0, 100.0, 107.0, 30),
+            (base, 100.0, 105.0, 99.0, 101.0, 10),
+        ];
+        for (ts, open, high, low, close, volume) in rows {
+            client
+                .client
+                .query(
+                    "INSERT INTO ohlcv \
+                     (symbol, timestamp, open, high, low, close, volume) \
+                     VALUES (?, FROM_UNIXTIME(?), ?, ?, ?, ?, ?)",
+                )
+                .bind(symbol.as_str())
+                .bind(ts)
+                .bind(open)
+                .bind(high)
+                .bind(low)
+                .bind(close)
+                .bind(volume)
+                .execute()
+                .await
+                .expect("failed to insert fixture row");
+        }
+
+        let start = Utc
+            .timestamp_opt(base, 0)
+            .single()
+            .expect("valid fixture timestamp");
+        let data = client
+            .fetch_ohlcv_data(&symbol, &TimeFrame::Hour, &start, 10)
+            .await
+            .expect("failed to fetch aggregated OHLCV data");
+
+        // Best-effort cleanup before asserting, so a failed assert does not leak rows.
+        let _ = client
+            .client
+            .query("DELETE FROM ohlcv WHERE symbol = ?")
+            .bind(symbol.as_str())
+            .execute()
+            .await;
+
+        assert_eq!(data.len(), 1, "three minute rows form one hourly bucket");
+        let bucket = &data[0];
+        assert_eq!(
+            bucket.open,
+            pos_or_panic!(100.0),
+            "open is the row with the EARLIEST timestamp"
+        );
+        assert_eq!(
+            bucket.close,
+            pos_or_panic!(107.0),
+            "close is the row with the LATEST timestamp"
+        );
+        assert_eq!(bucket.high, pos_or_panic!(110.0));
+        assert_eq!(bucket.low, pos_or_panic!(95.0));
+        assert_eq!(bucket.volume, 60);
+    }
 }

--- a/src/infrastructure/clickhouse/client.rs
+++ b/src/infrastructure/clickhouse/client.rs
@@ -141,16 +141,19 @@ fn timeframe_query_template(timeframe: &TimeFrame) -> Result<String, ChainError>
         }
     };
 
-    // Query with aggregation for larger timeframes
+    // Query with aggregation for larger timeframes. Open/close use the
+    // timestamp-aware argMin/argMax aggregates: ClickHouse's any() picks an
+    // arbitrary row per group, so opens/closes would be nondeterministic and
+    // depend on insertion/part order.
     Ok(format!(
         "WITH intervals AS (
             SELECT
                 symbol,
                 toStartOfInterval(timestamp, INTERVAL {}) as interval_start,
-                any(open) as open,
+                argMin(open, timestamp) as open,
                 max(high) as high,
                 min(low) as low,
-                any(close) as close,
+                argMax(close, timestamp) as close,
                 sum(volume) as volume
             FROM ohlcv
             WHERE symbol = ? \
@@ -461,6 +464,33 @@ mod tests {
         assert!(sql.contains("LIMIT ?"));
         assert!(!sql.contains("EVIL'--"));
         assert!(!sql.contains('\''));
+    }
+
+    /// Regression for issue #14: open/close must come from timestamp-aware
+    /// aggregates. ClickHouse's `any()` returns an arbitrary row per group, so
+    /// aggregated candles would be nondeterministic across insertion/part order.
+    #[test]
+    fn test_timeframe_query_template_aggregates_are_deterministic() {
+        for tf in [
+            TimeFrame::Hour,
+            TimeFrame::Day,
+            TimeFrame::Week,
+            TimeFrame::Month,
+        ] {
+            let sql = timeframe_query_template(&tf).unwrap();
+            assert!(
+                sql.contains("argMin(open, timestamp) as open"),
+                "{tf:?}: open must be the earliest row in the interval"
+            );
+            assert!(
+                sql.contains("argMax(close, timestamp) as close"),
+                "{tf:?}: close must be the latest row in the interval"
+            );
+            assert!(
+                !sql.contains("any("),
+                "{tf:?}: nondeterministic any() must not appear"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Aggregated OHLCV candles (hour/day/week/month) selected `any(open)` and
`any(close)` — ClickHouse's `any()` returns an ARBITRARY row per group, so
opens/closes were nondeterministic and depended on insertion/part order:
identical database contents could feed different inputs into historical
simulations. The aggregates are now timestamp-aware.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 15**
- **Base branch:** `stack/14-12-seeded-historical`
- **Stacked on:** #36 · **Blocks:** the next PR in the stack (#17)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- `timeframe_query_template` non-minute branch: `any(open)` →
  `argMin(open, timestamp)`, `any(close)` → `argMax(close, timestamp)` —
  open is the earliest row in the interval, close the latest, stable across
  insertion order. `high`/`low`/`volume` already used order-independent
  aggregates.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 334 + 2 passed, 0 failed
- [x] Regression test across Hour/Day/Week/Month: template contains the
  timestamp-aware aggregates and NO `any(` remains
- [x] clippy `-D warnings` + fmt clean

Live-ClickHouse fixture verification (shuffled insertion order) noted as a
gated integration follow-up — the hermetic suite asserts the generated SQL.

Closes #14
