### PR TITLE
Bound Mongo server selection with the configured timeout (#17)

### DIFF
--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -38,7 +38,14 @@ impl MongoDBClient {
         })?;
 
         client_options.app_name = Some("OptionChain-Simulator".to_string());
-        client_options.connect_timeout = Some(std::time::Duration::from_secs(config.timeout));
+        // `config.timeout` (MONGODB_TIMEOUT, seconds) bounds BOTH phases of
+        // reaching a server: the TCP connect AND server selection. Without the
+        // latter, the startup ping against an unavailable server waits for the
+        // driver's default server-selection timeout (~30s) regardless of the
+        // configured value.
+        let timeout = std::time::Duration::from_secs(config.timeout);
+        client_options.connect_timeout = Some(timeout);
+        client_options.server_selection_timeout = Some(timeout);
 
         let client = mongodb::Client::with_options(client_options).map_err(|e| {
             ChainError::Internal(redact_userinfo(&format!(
@@ -167,6 +174,33 @@ mod tests {
 
         let client = client_result.unwrap();
         assert_eq!(client.get_config().database, "test_db");
+    }
+
+    /// Regression for issue #17: with an unavailable server, `new` must fail
+    /// within the configured timeout instead of the driver's ~30s default
+    /// server-selection timeout. Hermetic — asserts the FAILURE is fast
+    /// (port 1 on localhost refuses connections; server selection retries
+    /// until the configured bound).
+    #[test]
+    async fn test_unavailable_server_fails_within_configured_timeout() {
+        let config = MongoDBConfig {
+            uri: "mongodb://localhost:1".to_string(),
+            database: "test_db".to_string(),
+            steps_collection: "test_steps".to_string(),
+            events_collection: "test_events".to_string(),
+            timeout: 1,
+        };
+
+        let start = std::time::Instant::now();
+        let result = MongoDBClient::new(config).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "connection to a closed port must fail");
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "startup failure took {elapsed:?}; the 1s configured timeout must \
+             bound server selection, not the ~30s driver default"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`MONGODB_TIMEOUT` was applied only as the TCP `connect_timeout`; the startup
ping still waited on the driver's DEFAULT server-selection timeout (~30s), so
with MongoDB unavailable the service (where Mongo is mandatory at boot) and
the tests blocked ~30 seconds regardless of the configured 5. The configured
timeout now bounds server selection too.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 16**
- **Base branch:** `stack/15-14-ohlcv-argminmax`
- **Stacked on:** #37 · **Blocks:** the next PR in the stack (#18)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- `MongoDBClient::new` sets `server_selection_timeout` alongside
  `connect_timeout`, both from `config.timeout` (`MONGODB_TIMEOUT`, seconds).
  Doc comment states exactly which phases the knob bounds.

## Testing

- [x] `LOGLEVEL=WARN cargo test --workspace`: 335 + 2 passed, 0 failed
- [x] Hermetic elapsed-bound regression: `new` against `mongodb://localhost:1` with `timeout: 1` fails in well under 5s (previously ~30s)
- [x] clippy `-D warnings` + fmt clean

Closes #17
