### PR TITLE
Hermetic default test suite with opt-in Mongo integration (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,32 @@ jobs:
         env:
           LOGLEVEL: WARN
 
-  integration_mongodb:
-    name: Integration (MongoDB)
+  integration_live_services:
+    name: Integration (live services)
     runs-on: ubuntu-latest
     services:
+      # Credentials must match the code's env-driven config defaults
+      # (MONGODB_URI / REDIS_* / CLICKHOUSE_* in src/infrastructure/config/*),
+      # so the ignored live tests authenticate successfully and can ASSERT
+      # success instead of tolerating connection failures.
       mongodb:
         image: mongo:7
+        env:
+          MONGO_INITDB_ROOT_USERNAME: admin
+          MONGO_INITDB_ROOT_PASSWORD: password
         ports:
           - 27017:27017
+      redis:
+        image: redis:7.4
+        ports:
+          - 6379:6379
+      clickhouse:
+        image: clickhouse/clickhouse-server:24.8
+        env:
+          CLICKHOUSE_USER: admin
+          CLICKHOUSE_PASSWORD: password
+        ports:
+          - 8123:8123
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -59,3 +77,4 @@ jobs:
       - run: cargo test --workspace -- --ignored
         env:
           LOGLEVEL: WARN
+          MONGODB_URI: mongodb://admin:password@localhost:27017

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,18 @@ jobs:
   run_tests:
     name: Tests
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Hermetic default suite: no external services required.
+      - run: cargo test --workspace
+        env:
+          LOGLEVEL: WARN
+
+  integration_mongodb:
+    name: Integration (MongoDB)
+    runs-on: ubuntu-latest
     services:
       mongodb:
         image: mongo:7
@@ -43,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      # Live-service tests are #[ignore]d in the default suite; run them here.
+      - run: cargo test --workspace -- --ignored
         env:
           LOGLEVEL: WARN

--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -154,7 +154,11 @@ mod tests {
     use std::sync::Arc;
     use tokio::test;
 
+    /// Live integration test: requires a running MongoDB. Opt in with
+    /// `cargo test -- --ignored` (CI runs it in the dedicated Integration job
+    /// with a mongo service container).
     #[test]
+    #[ignore = "requires live MongoDB on localhost:27017; run with -- --ignored"]
     async fn test_mongodb_client_initialization() {
         // Test that we can create a new MongoDB client
         let config = MongoDBConfig {
@@ -174,6 +178,24 @@ mod tests {
 
         let client = client_result.unwrap();
         assert_eq!(client.get_config().database, "test_db");
+    }
+
+    /// Hermetic replacement for the connection test: exercises config
+    /// construction and URI parsing without pinging a server.
+    #[test]
+    async fn test_client_options_parse_without_server() {
+        let config = MongoDBConfig {
+            uri: "mongodb://localhost:27017".to_string(),
+            database: "test_db".to_string(),
+            steps_collection: "test_steps".to_string(),
+            events_collection: "test_events".to_string(),
+            timeout: 5,
+        };
+
+        let options = mongodb::options::ClientOptions::parse(&config.uri).await;
+        assert!(options.is_ok(), "a well-formed URI must parse");
+        assert_eq!(config.database, "test_db");
+        assert_eq!(config.timeout, 5);
     }
 
     /// Regression for issue #17: with an unavailable server, `new` must fail
@@ -203,7 +225,12 @@ mod tests {
         );
     }
 
+    /// Live integration test: exercises `init_mongodb` against the default
+    /// (env-driven) configuration. Even though it tolerates a missing server,
+    /// the failure path burns the full configured server-selection timeout
+    /// (30s by default), so it is opt-in with the rest of the live tests.
     #[test]
+    #[ignore = "exercises a live MongoDB via env config; run with -- --ignored"]
     async fn test_init_mongodb() {
         // Test the init_mongodb function
         let result = crate::infrastructure::repositories::mongo_repo::init_mongodb().await;

--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -226,26 +226,17 @@ mod tests {
     }
 
     /// Live integration test: exercises `init_mongodb` against the default
-    /// (env-driven) configuration. Even though it tolerates a missing server,
-    /// the failure path burns the full configured server-selection timeout
-    /// (30s by default), so it is opt-in with the rest of the live tests.
+    /// (env-driven) configuration and ASSERTS success. The environment must
+    /// provide a reachable MongoDB whose credentials match `MONGODB_URI` (the
+    /// CI integration job provisions admin/password on its service container);
+    /// tolerating `Err` here would let the job stay green without validating
+    /// initialization at all.
     #[test]
-    #[ignore = "exercises a live MongoDB via env config; run with -- --ignored"]
+    #[ignore = "requires a live MongoDB matching MONGODB_URI; run with -- --ignored"]
     async fn test_init_mongodb() {
-        // Test the init_mongodb function
-        let result = crate::infrastructure::repositories::mongo_repo::init_mongodb().await;
-
-        // This might fail if MongoDB is not running, which is expected in CI environments
-        match result {
-            Ok(repo) => {
-                // If it succeeded, verify we got a repository
-                assert!(Arc::strong_count(&repo) >= 1);
-            }
-            Err(e) => {
-                // In CI, we expect this to fail with a connection error
-                println!("MongoDB initialization failed (expected in CI): {:?}", e);
-                // We don't assert because this is expected to fail in environments without MongoDB
-            }
-        }
+        let repo = crate::infrastructure::repositories::mongo_repo::init_mongodb()
+            .await
+            .expect("init_mongodb must succeed against the provisioned live MongoDB");
+        assert!(Arc::strong_count(&repo) >= 1);
     }
 }


### PR DESCRIPTION
## Summary

`cargo test --workspace` on a clean checkout required a live MongoDB on
`localhost:27017`: one test hard-asserted a successful connection (failing
after ~30s of server selection without it), making the documented default
test command environment-dependent and slow. The default suite is now
hermetic and fast; live-service tests are opt-in.

## Stack

- **Stack:** #15 → #13 → #7 → #10 → #21 → #5 → #4 → #6 → #20 → #19 → #8 → #9 → #11 → #12 → #14 → #17 → #18 → #16 → #22 — **this is PR 17**
- **Base branch:** `stack/16-17-mongo-timeout`
- **Stacked on:** #38 · **Blocks:** the next PR in the stack (#16)
- The diff is cumulative until the lower PRs merge — review against the base branch.

## Changes

- `test_mongodb_client_initialization` and `test_init_mongodb` are
  `#[ignore]`d with explanatory reasons (the latter tolerated absence but
  burned the full 30s server-selection timeout in hermetic runs); run them
  with `cargo test --workspace -- --ignored`.
- New hermetic test covering config construction + URI parsing without a ping.
- CI split: the "Tests" job drops the mongo service and runs the hermetic
  default suite; a new **"Integration (MongoDB)"** job keeps the `mongo:7`
  service container and runs `cargo test --workspace -- --ignored`.
- `CLAUDE.md` documents the hermetic-default / opt-in-integration split.

## Testing

- [x] Hermetic proof: with NO services running, `LOGLEVEL=WARN cargo test --workspace` → 334 + 2 passed, 0 failed, 2 ignored, in ~1s (was 1 failure + ~30s wait)
- [x] Integration proof: with mongo up, `-- --ignored` → live tests pass
- [x] clippy `-D warnings` + fmt clean

Closes #18
