### PR TITLE
Publish the Docker image to GHCR and deploy the stack from it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# The build context is the repository root (see Docker/docker-compose.yml and
+# .github/workflows/docker-publish.yml). Keep it small: the image build only
+# needs the sources, the manifests and the Makefile.
+.git
+.github
+target
+**/target
+Docker/docker-compose.yml
+*.md
+!README.md
+.idea
+.run
+.env
+.local

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,118 @@
+name: Docker image
+
+# Publishes the service image to GitHub Packages (GHCR) exactly when the
+# `[package] version` in Cargo.toml changes on main - i.e. on the release
+# "chore: bump version" commit, not on every push. The path filter is only a
+# cheap pre-filter; the authoritative check compares the version at HEAD with
+# the version at the first parent.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+  # Manual escape hatch: republish the current Cargo.toml version (e.g. after a
+  # failed run) without touching the version.
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  version:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      bumped: ${{ steps.check.outputs.bumped }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # HEAD and its first parent: enough to diff the manifest version.
+          fetch-depth: 2
+
+      - name: Compare [package] version with the previous commit
+        id: check
+        run: |
+          set -euo pipefail
+
+          # Reads `version` from the [package] table only, ignoring the
+          # versions declared in [workspace.dependencies].
+          package_version() {
+            awk '
+              /^\[package\]/ { in_pkg = 1; next }
+              /^\[/          { in_pkg = 0 }
+              in_pkg && /^version[[:space:]]*=/ {
+                gsub(/[",]/, "", $3); print $3; exit
+              }
+            ' "$1"
+          }
+
+          new="$(package_version Cargo.toml)"
+          if [ -z "$new" ]; then
+            echo "::error::could not read [package] version from Cargo.toml"
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch: publishing version ${new}"
+            bumped=true
+          elif git rev-parse --verify --quiet HEAD^ >/dev/null; then
+            git show HEAD^:Cargo.toml > /tmp/previous-Cargo.toml
+            old="$(package_version /tmp/previous-Cargo.toml)"
+            echo "previous=${old:-<none>} current=${new}"
+            if [ "$old" = "$new" ]; then
+              bumped=false
+            else
+              bumped=true
+            fi
+          else
+            # No parent commit to compare against (initial commit): treat the
+            # version as new.
+            echo "no parent commit; treating ${new} as a bump"
+            bumped=true
+          fi
+
+          echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
+          echo "version=${new}" >> "$GITHUB_OUTPUT"
+          echo "### Version ${new} (bumped: ${bumped})" >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Build and push image
+    needs: version
+    if: needs.version.outputs.bumped == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # metadata-action lowercases the image name, which GHCR requires
+          # (the repository is OptionChain-Simulator).
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ needs.version.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,28 +1,34 @@
-FROM rust:1.96.1-bookworm as builder
+# Base images are pinned by IMMUTABLE digest (issue #22), same policy as
+# Docker/docker-compose.yml: the tag is a readable prefix, the digest is what
+# the engine actually resolves. Re-resolve with
+# `docker buildx imagetools inspect <image:tag>` when bumping, and bump the
+# tag and the digest together.
+FROM rust:1.97.1-alpine3.24@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    pkg-config \
-    curl \
-    libfontconfig1-dev \
-    libfreetype6-dev \
-    libexpat1-dev \
-    libpng-dev \
-    libjpeg-dev \
-    && rm -rf /var/lib/apt/lists/*
+# build-base pulls gcc + musl-dev (the `ring` C sources need them) and make,
+# which drives the `make release` target below. curl is REQUIRED: the
+# utoipa-swagger-ui build script shells out to it to download the Swagger UI
+# bundle, and panics with "`curl` command not found" otherwise. No
+# fontconfig/freetype stack: the dependency tree carries no native image or
+# font libraries.
+RUN apk add --no-cache build-base curl
 
 WORKDIR /app
 
 COPY . .
 
+# The rust:alpine host target is x86_64-unknown-linux-musl, which links
+# statically by default, so the release binary is self-contained.
 RUN make release
 
-FROM debian:bookworm-slim
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+# Root certificates for the outbound TLS connections (ClickHouse, MongoDB,
+# Redis when configured over TLS).
+RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 
-COPY --from=builder /usr/lib /usr/lib
-COPY --from=builder /lib /lib
 COPY --from=builder /app/target/release/optionchain_simulator /app/
 
 EXPOSE 7070

--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -1,0 +1,65 @@
+version: '3.8'
+
+# Workstation-only override for Docker/docker-compose.yml:
+#
+#   docker compose -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml up -d
+#
+# which is what `make deploy` runs. It adds the two admin UIs and publishes the
+# infrastructure ports on the host so the integration tests
+# (`cargo test --workspace -- --ignored`) and a psql/redis-cli/mongosh session
+# can reach them.
+#
+# NEVER include this file in `docker stack deploy` (make deploy-swarm): compose
+# profiles are not supported there, the UIs ship default admin/password
+# credentials, and under the routing mesh every published port answers on every
+# node of the cluster.
+#
+# Images are pinned by immutable digest, same policy as the base file (#22).
+
+services:
+  redis:
+    ports:
+      - "6379:6379"
+
+  mongodb:
+    ports:
+      - "27017:27017"
+
+  clickhouse:
+    ports:
+      - "8123:8123"   # HTTP interface
+      - "9000:9000"   # Native client (TCP)
+
+  # MongoDB Express for web-based MongoDB management (optional)
+  mongo-express:
+    image: mongo-express:1.0.2@sha256:1b23d7976f0210dbec74045c209e52fbb26d29b2e873d6c6fa3d3f0ae32c2a64
+    container_name: mongo-express
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    environment:
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGO_USERNAME:-admin}
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGO_PASSWORD:-password}
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+      - ME_CONFIG_BASICAUTH_USERNAME=${MONGOEXPRESS_USERNAME:-admin}
+      - ME_CONFIG_BASICAUTH_PASSWORD=${MONGOEXPRESS_PASSWORD:-password}
+    networks:
+      - optionchain-network
+    depends_on:
+      - mongodb
+
+  # Redis Commander for web-based Redis management (optional)
+  redis-commander:
+    image: rediscommander/redis-commander:redis-commander-210@sha256:25f93c06111f8614e3ecc8df5c563272bb465459a2e08e7f5364b5fe4c14f87f
+    container_name: redis-commander
+    restart: unless-stopped
+    ports:
+      - "8082:8081"
+    environment:
+      - REDIS_HOSTS=local:redis:6379:0:${REDIS_PASSWORD:-password}
+      - HTTP_USER=${REDIS_COMMANDER_USER:-admin}
+      - HTTP_PASSWORD=${REDIS_COMMANDER_PASSWORD:-password}
+    networks:
+      - optionchain-network
+    depends_on:
+      - redis

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -10,6 +10,21 @@ version: '3.8'
 # its digest with imagetools inspect, update tag and digest together, run
 # the stack locally (make deploy) against the health checks, and record the
 # tested combination in the PR. Never drop the digest or use :latest.
+#
+# SWARM: this file deploys unchanged with `docker stack deploy` (make
+# deploy-swarm). Consequences of that:
+#   - `backend` pulls the PUBLISHED image, it is never built here. The tag is
+#     the crate version, defaulting to the current Cargo.toml version;
+#     `make deploy` / `make deploy-swarm` pass OPTIONCHAIN_VERSION so the
+#     deployed tag always matches the manifest. `docker stack deploy` does NOT
+#     read .env, so export the overrides in the shell.
+#   - The network driver defaults to `bridge` for local compose runs and must
+#     be `overlay` under swarm (make deploy-swarm sets it).
+#   - Swarm ignores `container_name`, `depends_on` and `restart`; the `deploy`
+#     blocks carry the equivalent policy and compose ignores those instead.
+#   - The infrastructure services keep node-local volumes, so a multi-node
+#     swarm must either constrain them to one node or point the backend at
+#     managed Redis/MongoDB/ClickHouse instances via the env vars below.
 
 services:
   # Redis service configuration
@@ -109,11 +124,20 @@ services:
       - optionchain-network
 
   backend:
-    build:
-      context: ..
-      dockerfile: Docker/Dockerfile
+    # Published by .github/workflows/docker-publish.yml on every Cargo.toml
+    # version bump, or by `make docker-push` from a workstation. Bump the
+    # default tag in the same PR that bumps the crate version.
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.1.0}
     container_name: backend
     restart: unless-stopped
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+      update_config:
+        order: start-first
+        failure_action: rollback
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}
@@ -141,7 +165,8 @@ services:
       
 networks:
   optionchain-network:
-    driver: bridge
+    # bridge for a local compose run, overlay under swarm (make deploy-swarm).
+    driver: ${OPTIONCHAIN_NETWORK_DRIVER:-bridge}
 
 volumes:
   redis-data:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3.8'
 
+# Deployable stack: the four services the binary actually needs. Redis and
+# MongoDB are HARD requirements (src/main.rs propagates their connection errors
+# with `?`, so the process exits without them); ClickHouse is optional
+# (src/domain/simulator.rs logs the failure and runs with database_repo: None,
+# which only degrades the Historical source).
+#
+# The admin UIs (mongo-express, redis-commander) and the host-published
+# infrastructure ports live in docker-compose.dev.yml, NOT here: `docker stack
+# deploy` does not support compose profiles, so anything present in this file
+# reaches the swarm, and those UIs ship default admin/password credentials.
+#
 # Service images are pinned by IMMUTABLE digest (image: name:tag@sha256:...)
 # so a redeploy can never silently pull a different build (issue #22). The
 # tag is kept as a readable prefix only; the digest is what the engine
@@ -22,6 +33,9 @@ version: '3.8'
 #     be `overlay` under swarm (make deploy-swarm sets it).
 #   - Swarm ignores `container_name`, `depends_on` and `restart`; the `deploy`
 #     blocks carry the equivalent policy and compose ignores those instead.
+#   - Only `backend` publishes a port. The infrastructure services are reachable
+#     over the stack network alone; under the routing mesh a published port
+#     would answer on EVERY node of the cluster.
 #   - The infrastructure services keep node-local volumes, so a multi-node
 #     swarm must either constrain them to one node or point the backend at
 #     managed Redis/MongoDB/ClickHouse instances via the env vars below.
@@ -32,8 +46,6 @@ services:
     image: redis:7.4@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
     container_name: redis
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-password}
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     networks:
@@ -46,13 +58,16 @@ services:
     environment:
       - TZ=UTC
     restart: unless-stopped
-  
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+
   # MongoDB service configuration
   mongodb:
     image: mongo:7.0@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703
     container_name: mongodb
-    ports:
-      - "27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
@@ -68,47 +83,15 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
 
-  # MongoDB Express for web-based MongoDB management (optional)
-  mongo-express:
-    image: mongo-express:1.0.2@sha256:1b23d7976f0210dbec74045c209e52fbb26d29b2e873d6c6fa3d3f0ae32c2a64
-    container_name: mongo-express
-    restart: unless-stopped
-    ports:
-      - "8081:8081"
-    environment:
-      - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGO_USERNAME:-admin}
-      - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGO_PASSWORD:-password}
-      - ME_CONFIG_MONGODB_SERVER=mongodb
-      - ME_CONFIG_BASICAUTH_USERNAME=${MONGOEXPRESS_USERNAME:-admin}
-      - ME_CONFIG_BASICAUTH_PASSWORD=${MONGOEXPRESS_PASSWORD:-password}
-    networks:
-      - optionchain-network
-    depends_on:
-      - mongodb
-
-  # Redis Commander for web-based Redis management (optional)
-  redis-commander:
-    image: rediscommander/redis-commander:redis-commander-210@sha256:25f93c06111f8614e3ecc8df5c563272bb465459a2e08e7f5364b5fe4c14f87f
-    container_name: redis-commander
-    restart: unless-stopped
-    ports:
-      - "8082:8081"
-    environment:
-      - REDIS_HOSTS=local:redis:6379:0:${REDIS_PASSWORD:-password}
-      - HTTP_USER=${REDIS_COMMANDER_USER:-admin}
-      - HTTP_PASSWORD=${REDIS_COMMANDER_PASSWORD:-password}
-    networks:
-      - optionchain-network
-    depends_on:
-      - redis
-        
   clickhouse:
     image: clickhouse/clickhouse-server:24.8@sha256:1ffa82edee000a42c09313bd9f1293d94c570aee74babc1b3ca9983a35fa597b
     container_name: clickhouse
-    ports:
-      - "8123:8123"   # HTTP interface
-      - "9000:9000"   # Native client (TCP)
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}
@@ -122,6 +105,11 @@ services:
     restart: unless-stopped
     networks:
       - optionchain-network
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
 
   backend:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
@@ -162,7 +150,7 @@ services:
       - "7070:7070"
     networks:
       - optionchain-network
-      
+
 networks:
   optionchain-network:
     # bridge for a local compose run, overlay under swarm (make deploy-swarm).

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,16 @@ docker-push: docker-build
 	docker push $(IMAGE_NAME):latest
 	@echo "pushed $(IMAGE_NAME):$(VERSION) and :latest"
 
+# Local stack: the deployable services plus the dev override (admin UIs and
+# host-published infrastructure ports).
 .PHONY: deploy
 deploy:
-	OPTIONCHAIN_VERSION=$(VERSION) docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml up --pull always --force-recreate -d
+	OPTIONCHAIN_VERSION=$(VERSION) docker compose -p $(PROJECT_NAME) \
+		-f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml \
+		up --pull always --force-recreate -d
 
-# Same stack on a swarm manager: overlay network, no build context.
+# Same stack on a swarm manager: overlay network, no build context, and never
+# the dev override (admin UIs with default credentials, published infra ports).
 .PHONY: deploy-swarm
 deploy-swarm:
 	OPTIONCHAIN_VERSION=$(VERSION) OPTIONCHAIN_NETWORK_DRIVER=overlay \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,36 @@ CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ZIP_NAME = OptionChain-Simulator.zip
 PROJECT_NAME := optionchain-simulator
 
+# Container image coordinates. VERSION is read from the [package] table of
+# Cargo.toml (the versions in [workspace.dependencies] are skipped), so the
+# published tag can never drift from the crate version.
+REGISTRY ?= ghcr.io
+IMAGE_NAME ?= $(REGISTRY)/joaquinbejar/optionchain-simulator
+VERSION := $(shell awk '/^\[package\]/ { in_pkg = 1; next } /^\[/ { in_pkg = 0 } in_pkg && /^version[[:space:]]*=/ { gsub(/[",]/, "", $$3); print $$3; exit }' Cargo.toml)
+
+# Build the release image for the version in Cargo.toml.
+.PHONY: docker-build
+docker-build:
+	@test -n "$(VERSION)" || (echo "could not read [package] version from Cargo.toml"; exit 1)
+	docker build -f Docker/Dockerfile -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
+
+# Build and push that image to the registry. Requires a prior
+# `docker login $(REGISTRY)` with a token carrying write:packages.
+.PHONY: docker-push
+docker-push: docker-build
+	docker push $(IMAGE_NAME):$(VERSION)
+	docker push $(IMAGE_NAME):latest
+	@echo "pushed $(IMAGE_NAME):$(VERSION) and :latest"
+
 .PHONY: deploy
 deploy:
-	docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml up --build  --force-recreate -d
+	OPTIONCHAIN_VERSION=$(VERSION) docker compose -p $(PROJECT_NAME) -f Docker/docker-compose.yml up --pull always --force-recreate -d
+
+# Same stack on a swarm manager: overlay network, no build context.
+.PHONY: deploy-swarm
+deploy-swarm:
+	OPTIONCHAIN_VERSION=$(VERSION) OPTIONCHAIN_NETWORK_DRIVER=overlay \
+		docker stack deploy --with-registry-auth -c Docker/docker-compose.yml $(PROJECT_NAME)
 
 # Default target
 .PHONY: all


### PR DESCRIPTION
## Summary

The repository built a Docker image locally (`Docker/Dockerfile`, used by the
compose stack) but never published it, so consumers had no released artifact to
pull and the compose stack could not be deployed to a swarm (swarm cannot build,
it only pulls). This publishes the image to GitHub Packages on every crate
version bump, moves the image to Alpine on the requested toolchain, and turns
the compose file into a swarm-deployable stack that pulls the published tag.

## Changes

### Publish

- `.github/workflows/docker-publish.yml` (new). Triggers on `push` to `main`
  with `paths: Cargo.toml` as a cheap pre-filter; the authoritative check
  compares the `[package] version` at `HEAD` against `HEAD^` (awk scoped to the
  `[package]` table, so the versions in `[workspace.dependencies]` are ignored)
  and only then builds. Publishes `ghcr.io/joaquinbejar/optionchain-simulator`
  with two tags, `X.Y.Z` and `latest`, using `permissions: packages: write` with
  the built-in `GITHUB_TOKEN` and GHA build cache. `workflow_dispatch` is a
  manual escape hatch to republish the current version after a failed run.
- `Makefile`: `VERSION` is parsed from the `[package]` table of `Cargo.toml`, so
  the tag can never drift from the crate version. `make docker-build` builds
  `Docker/Dockerfile` as `:$(VERSION)` and `:latest`; `make docker-push` builds
  and pushes both to `$(REGISTRY)` (default `ghcr.io`, needs a prior
  `docker login` with `write:packages`).

### Image

- `Docker/Dockerfile`: builder `rust:1.97.1-alpine3.24`, runtime `alpine:3.24`,
  both pinned by immutable digest following the `docker-compose.yml` policy
  (#22). The `rust:alpine` host target is `x86_64-unknown-linux-musl` and links
  statically, so the runtime stage no longer copies `/usr/lib` and `/lib` out of
  the builder — just the binary plus `ca-certificates`. Build dependencies
  shrink to `build-base` (gcc/musl-dev for `ring`, and make) plus `curl`: the
  fontconfig/freetype/png/jpeg stack is gone because the dependency tree no
  longer carries native image or font libraries, but `curl` is required — the
  `utoipa-swagger-ui` build script shells out to it and panics with
  ``failed to download Swagger UI: `curl` command not found`` otherwise.
- `.dockerignore` (new): the build context is the repository root, so exclude
  `.git`, `.github` and `target/`.

### Deploy

- `Docker/docker-compose.yml`: `backend` drops `build:` and pulls
  `ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.1.0}` —
  the default tracks the current Cargo.toml version and is bumped in the same PR
  as the crate version. Every service gains a `deploy` block (replicas,
  `restart_policy`, and `start-first` updates with rollback for the backend)
  because swarm ignores `restart`, `depends_on` and `container_name`. The
  network driver becomes `${OPTIONCHAIN_NETWORK_DRIVER:-bridge}`: bridge for a
  local compose run, overlay under swarm.
- The file is now the **deployable stack only**, which is what the code
  requires: Redis and MongoDB are hard dependencies (`src/main.rs` propagates
  `RedisClient::new` and `init_mongodb` errors with `?`), ClickHouse is optional
  (`src/domain/simulator.rs` logs the failure and continues with
  `database_repo: None`, degrading only the `Historical` source). Only the
  backend publishes a port — under the routing mesh a published infrastructure
  port answers on every node of the cluster.
- `Docker/docker-compose.dev.yml` (new) is the workstation override holding
  what the service never touches: `mongo-express` and `redis-commander` (which
  ship default `admin/password` credentials) plus the host-published
  infrastructure ports the `--ignored` integration tests and a
  `redis-cli`/`mongosh` session need. It must never reach a swarm — compose
  profiles are not supported by `docker stack deploy`, so separate files are the
  only way to keep it out.
- `make deploy` layers both files and no longer passes `--build` (it pulls the
  published tag, passing `OPTIONCHAIN_VERSION`); `make deploy-swarm` runs
  `docker stack deploy --with-registry-auth` with the overlay driver against the
  base file alone.

## Testing

- [x] `actionlint .github/workflows/docker-publish.yml` — clean
- [x] Version-bump detection: the awk parser returns `0.1.0` from the current
      `Cargo.toml` (and ignores `[workspace.dependencies]`)
- [x] Base image tags exist and the digests are the ones pinned
      (`docker buildx imagetools inspect`)
- [x] `docker build -f Docker/Dockerfile .` succeeds on the Alpine base. The
      first attempt failed with ``failed to download Swagger UI: `curl` command
      not found``, which is why `curl` is installed. Result: 59.9 MB image
      (arm64 workstation build), `/app/optionchain_simulator` statically linked
      (`ldd` reports "Not a valid dynamic program").
- [x] Container smoke test: starts and reaches the Redis connection step, i.e.
      the musl binary runs on the bare `alpine:3.24` runtime. It then blocks on
      the connect timeout because no infrastructure was up — expected.
- [x] `docker compose config`: the base file resolves to four services with a
      single published port (7070) and is valid with both the default bridge
      driver and `OPTIONCHAIN_NETWORK_DRIVER=overlay`; layering the dev override
      adds `mongo-express` / `redis-commander` and republishes 6379, 27017,
      8123, 9000, 8081, 8082.
- [x] `make -n docker-push` / `make -n deploy-swarm` expand to version `0.1.0`

## Notes

- The image is linux/amd64 only in CI. Multi-arch via QEMU would make every
  release build far slower; worth a follow-up with native arm64 runners if
  needed.
- The first push creates the package as private; it has to be flipped to public
  once in the repository's Packages settings if it should be pullable
  anonymously.
- Not verified end to end: an actual `docker stack deploy` on a swarm, and the
  published-package pull — both need the workflow to have run on `main` at least
  once.
- The infrastructure services keep node-local volumes, so a multi-node swarm
  needs placement constraints or managed Redis/MongoDB/ClickHouse endpoints via
  the backend env vars.