### PR TITLE
Make the compose stack deploy on a swarm unchanged

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -4,31 +4,55 @@ version: '3.8'
 #
 #   docker compose -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml up -d
 #
-# which is what `make deploy` runs. It adds the two admin UIs and publishes the
-# infrastructure ports on the host so the integration tests
-# (`cargo test --workspace -- --ignored`) and a psql/redis-cli/mongosh session
-# can reach them.
+# which is what `make deploy` runs. It restores everything the base file leaves
+# out because swarm rejects or ignores it:
+#
+#   - the network driver: `bridge`, since `overlay` needs a swarm manager;
+#   - `container_name`, `restart` and `depends_on`, which `docker stack deploy`
+#     drops with an "Ignoring unsupported options" warning;
+#   - the ClickHouse `ulimits` (a swarm sets nofile through the daemon's
+#     default-ulimits, not through the stack file);
+#   - the two admin UIs and the infrastructure ports on the host, so the
+#     integration tests (`cargo test --workspace -- --ignored`) and a
+#     redis-cli/mongosh session can reach them.
 #
 # NEVER include this file in `docker stack deploy` (make deploy-swarm): compose
-# profiles are not supported there, the UIs ship default admin/password
-# credentials, and under the routing mesh every published port answers on every
-# node of the cluster.
+# profiles are not supported there, and the UIs ship default admin/password
+# credentials.
 #
 # Images are pinned by immutable digest, same policy as the base file (#22).
 
 services:
   redis:
+    container_name: redis
+    restart: unless-stopped
     ports:
       - "6379:6379"
 
   mongodb:
+    container_name: mongodb
+    restart: unless-stopped
     ports:
       - "27017:27017"
 
   clickhouse:
+    container_name: clickhouse
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
     ports:
       - "8123:8123"   # HTTP interface
       - "9000:9000"   # Native client (TCP)
+
+  backend:
+    container_name: backend
+    restart: unless-stopped
+    depends_on:
+      - redis
+      - mongodb
+      - clickhouse
 
   # MongoDB Express for web-based MongoDB management (optional)
   mongo-express:
@@ -63,3 +87,8 @@ services:
       - optionchain-network
     depends_on:
       - redis
+
+networks:
+  optionchain-network:
+    # Overrides the base file's overlay: a local engine is not a swarm manager.
+    driver: bridge

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -29,10 +29,13 @@ version: '3.8'
 #     `make deploy` / `make deploy-swarm` pass OPTIONCHAIN_VERSION so the
 #     deployed tag always matches the manifest. `docker stack deploy` does NOT
 #     read .env, so export the overrides in the shell.
-#   - The network driver defaults to `bridge` for local compose runs and must
-#     be `overlay` under swarm (make deploy-swarm sets it).
-#   - Swarm ignores `container_name`, `depends_on` and `restart`; the `deploy`
-#     blocks carry the equivalent policy and compose ignores those instead.
+#   - The network is `overlay`, the only scope swarm accepts for services. The
+#     dev override swaps it for `bridge` on a non-swarm engine.
+#   - Nothing swarm ignores is declared here: `container_name`, `restart`,
+#     `depends_on` and `ulimits` live in the dev override, and the `deploy`
+#     blocks carry the equivalent restart policy. Keeping them out is what
+#     stops `docker stack deploy` (and Portainer) from printing "Ignoring
+#     unsupported options" on every deploy.
 #   - Only `backend` publishes a port. The infrastructure services are reachable
 #     over the stack network alone; under the routing mesh a published port
 #     would answer on EVERY node of the cluster.
@@ -44,7 +47,6 @@ services:
   # Redis service configuration
   redis:
     image: redis:7.4@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
-    container_name: redis
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-password}
     volumes:
       - redis-data:/data
@@ -57,7 +59,6 @@ services:
       retries: 5
     environment:
       - TZ=UTC
-    restart: unless-stopped
     deploy:
       replicas: 1
       restart_policy:
@@ -67,7 +68,6 @@ services:
   # MongoDB service configuration
   mongodb:
     image: mongo:7.0@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703
-    container_name: mongodb
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
@@ -82,7 +82,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    restart: unless-stopped
     deploy:
       replicas: 1
       restart_policy:
@@ -91,18 +90,12 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.8@sha256:1ffa82edee000a42c09313bd9f1293d94c570aee74babc1b3ca9983a35fa597b
-    container_name: clickhouse
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-default}
     volumes:
       - clickhouse_data:/var/lib/clickhouse
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144
-    restart: unless-stopped
     networks:
       - optionchain-network
     deploy:
@@ -116,8 +109,6 @@ services:
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
     image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.1.0}
-    container_name: backend
-    restart: unless-stopped
     deploy:
       replicas: 1
       restart_policy:
@@ -142,10 +133,6 @@ services:
       REDIS_USER: ${REDIS_USER}
       REDIS_PASSWORD: ${REDIS_PASSWORD-password}
       REDIS_HOST: ${REDIS_HOST-redis}
-    depends_on:
-      - redis
-      - mongodb
-      - clickhouse
     ports:
       - "7070:7070"
     networks:
@@ -153,8 +140,14 @@ services:
 
 networks:
   optionchain-network:
-    # bridge for a local compose run, overlay under swarm (make deploy-swarm).
-    driver: ${OPTIONCHAIN_NETWORK_DRIVER:-bridge}
+    # overlay is MANDATORY under swarm: a bridge network is node-scoped and
+    # `docker stack deploy` refuses it with "cannot be used with services. Only
+    # networks scoped to the swarm can be used". The default therefore targets
+    # swarm - including deploys driven by Portainer, which passes no
+    # environment - and docker-compose.dev.yml overrides it back to bridge for
+    # a local, non-swarm engine.
+    driver: overlay
+    attachable: true
 
 volumes:
   redis-data:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ deploy:
 # the dev override (admin UIs with default credentials, published infra ports).
 .PHONY: deploy-swarm
 deploy-swarm:
-	OPTIONCHAIN_VERSION=$(VERSION) OPTIONCHAIN_NETWORK_DRIVER=overlay \
+	OPTIONCHAIN_VERSION=$(VERSION) \
 		docker stack deploy --with-registry-auth -c Docker/docker-compose.yml $(PROJECT_NAME)
 
 # Default target


### PR DESCRIPTION
## Summary

Follow-up to #52, which merged before this fix was pushed. Deploying
`Docker/docker-compose.yml` to a swarm through Portainer failed:

```
failed to create service simulator_mongodb: Error response from daemon: The
network simulator_optionchain-network cannot be used with services. Only
networks scoped to the swarm can be used, such as those created with the
overlay driver.
```

The driver was `${OPTIONCHAIN_NETWORK_DRIVER:-bridge}`, and a Portainer-driven
deploy passes no environment, so it resolved to `bridge` — which is node-scoped
and rejected for services. The same deploy also printed `Ignoring unsupported
options: restart` and `Ignoring deprecated options: container_name`.

## Changes

- `Docker/docker-compose.yml`: the network is now `driver: overlay` with
  `attachable: true`, no variable involved — the swarm path is the default, so a
  deploy that passes no environment (Portainer, a plain `docker stack deploy`)
  works unchanged.
- `Docker/docker-compose.dev.yml`: overrides the driver back to `bridge` for a
  local, non-swarm engine, and takes over every key swarm drops —
  `container_name`, `restart`, `depends_on`, and the ClickHouse `ulimits` (a
  swarm sets `nofile` through the daemon's `default-ulimits`, not through the
  stack file). The `deploy.restart_policy` blocks in the base file already carry
  the restart semantics.
- `Makefile`: `deploy-swarm` no longer exports `OPTIONCHAIN_NETWORK_DRIVER`.

## Testing

- [x] `docker stack config -c Docker/docker-compose.yml` renders the stack with
      **zero** "Ignoring unsupported/deprecated options" warnings (it was the
      source of the two warnings above) and resolves the network to
      `driver: overlay`
- [x] `docker compose -f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml config`
      still resolves to `driver: bridge`, the six services, the container names,
      `restart: unless-stopped`, the ClickHouse `nofile` limits and the six
      published ports
- [ ] A real `docker stack deploy` — needs the image to exist first, see below

## Note

`backend` points at `ghcr.io/joaquinbejar/optionchain-simulator:0.1.0`, which is
not published yet: the workflow from #52 only fires on a Cargo.toml version bump
on `main`, and that has not happened since it merged. Until then the service
cannot pull. Either bump the version, or run `make docker-push` from a
workstation. If the package stays private, the swarm node needs a registry login
plus `--with-registry-auth` (which `make deploy-swarm` already passes).