### PR TITLE
Pass the Redis timeouts through the stack file

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -133,6 +133,11 @@ services:
       REDIS_USER: ${REDIS_USER}
       REDIS_PASSWORD: ${REDIS_PASSWORD-password}
       REDIS_HOST: ${REDIS_HOST-redis}
+      # Whole seconds, must parse as an integer >= 1: src/infrastructure/config
+      # /redis.rs falls back to these same defaults (30 / 5) on 0, on a
+      # non-numeric value, or when unset, warning as it does so.
+      REDIS_TIMEOUT: ${REDIS_TIMEOUT-30}
+      REDIS_CONNECT_TIMEOUT: ${REDIS_CONNECT_TIMEOUT-5}
     ports:
       - "7070:7070"
     networks:


### PR DESCRIPTION
## Summary

`RedisConfig::default` reads `REDIS_TIMEOUT` (default 30s) and
`REDIS_CONNECT_TIMEOUT` (default 5s) in `src/infrastructure/config/redis.rs`,
but the `backend` service in `Docker/docker-compose.yml` never forwarded them.
Setting either one in Portainer's stack environment — or in the shell before
`make deploy` — did nothing: the variable reached the compose interpolation but
never the container, so the process always used the compiled defaults.

## Changes

- `Docker/docker-compose.yml`: the backend environment block gains
  `REDIS_TIMEOUT: ${REDIS_TIMEOUT-30}` and
  `REDIS_CONNECT_TIMEOUT: ${REDIS_CONNECT_TIMEOUT-5}`, the same defaults the
  code applies, so the deployed values are visible in the stack file and
  overridable at deploy time. A comment records the accepted range: whole
  seconds, integer >= 1 — `parse_timeout_secs` falls back to the default (with a
  warning) on `0`, on a non-numeric value, or when unset, because a zero timeout
  would let a hung server hold a worker forever.

## Testing

- [x] `docker compose -f Docker/docker-compose.yml config` resolves
      `REDIS_TIMEOUT: "30"` and `REDIS_CONNECT_TIMEOUT: "5"` by default
- [x] `REDIS_TIMEOUT=90 docker compose ... config` resolves `REDIS_TIMEOUT: "90"`

No code change, so no test-suite impact.