### PR TITLE
feat(session): add deterministic v2 simulation parameters and persistence

### DIFF
--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -93,10 +93,23 @@ rather than the Rust types, and the alternative — a parallel primitive-typed
 representation in `session` — would mean two shapes, two validation paths, and a
 standing risk that they drift.
 
-What is *not* accepted is a validation bypass. The configuration types keep
-their fields private and route `Deserialize` through their validating
-constructors, so a schedule loaded from Redis is checked exactly like one built
-from a request.
+What is *not* accepted is a validation bypass. **Every** stored v2 type — the
+schedule and its rules, the simulation parameters, the simulation document —
+routes `Deserialize` through a validating constructor, so a document loaded
+from Redis is checked exactly like a request. This is not defensive
+programming for its own sake: without it a `step_interval_seconds` of `0`
+freezes the simulated clock and every snapshot silently carries the same
+instant, a `steps` past the cap drives an unbounded factor tape, and a
+sub-second `effective_start` breaks the whole-second rendering §10.2 relies on
+for byte-comparable exports. Redis is an outer layer, and a domain type does
+not trust one.
+
+The stored shapes additionally reject unknown fields. That turns the
+rolling-deploy hazard into a loud one: an old replica reading a document
+written by a newer binary fails, rather than dropping the fields it does not
+understand and writing the truncated document back with an intact revision so
+the compare-and-swap succeeds. For the same reason a `schema_version` from the
+future is refused on load.
 
 ---
 
@@ -185,10 +198,14 @@ its `target_count` expirations.
 
 ### 4.1 Schedule shape
 
-A simulation carries a `schedules` array. Each entry is one rule, serialised as
-an **internally-tagged enum on `kind`** carrying `#[serde(deny_unknown_fields)]`,
-so a field that does not belong to a rule's `kind` is a rejected request rather
-than a silently ignored one:
+A simulation carries a `schedules` array. Each entry is one **flat object
+tagged by `kind`**, with the kind-specific fields as siblings of `rule_id`.
+
+The tag and those fields are declared explicitly rather than through an
+internally-tagged enum: serde cannot combine that with `deny_unknown_fields`,
+and giving up `deny_unknown_fields` would give up both guarantees §4.4 makes —
+that an unknown field is rejected, and that a field which does not belong to
+the rule's `kind` is rejected rather than silently ignored.
 
 | field | meaning |
 |---|---|
@@ -481,11 +498,19 @@ real minutes, and must not pin three years of option contracts in memory.
 
 ### 9.1 Session retention
 
-The **idle** lifetime of a v2 session is operational and completely independent
-of the months or years its simulated clock spans. It is configurable, validated
-at startup, and applied consistently by the in-memory and Redis stores, which
-must agree on expiry and renewal semantics. v1's hard-coded one-hour Redis TTL
+The retention lifetime of a v2 session is operational and completely
+independent of the months or years its simulated clock spans. It is
+configurable, validated at startup, and applied consistently by the in-memory
+and Redis stores, which must agree on expiry and renewal semantics — one shared
+default constant rather than one per backend, because two independently-named
+defaults are how that agreement drifts. v1's hard-coded one-hour Redis TTL
 (`src/main.rs`) is unchanged; only v2 gets the knob.
+
+The window is measured from the **last write**, not the last access. §6 defines
+the snapshot endpoint as a safe peek that persists nothing, so a client that
+only ever peeks does not refresh its retention. Both backends behave the same
+way, which is the property that matters for correctness; whether a peek *should*
+refresh is a product decision for #48.
 
 ### 9.2 Cache eviction
 
@@ -636,6 +661,16 @@ the offending `field` — so a client can point a user at one input. The `412`
 body matches v1's precondition body exactly
 (`src/api/rest/handlers.rs:374-377`). Error messages never contain credentials,
 connection strings, or environment values.
+
+**One implementation note that is easy to get wrong.** A schedule rule is
+validated during deserialization, not after it, because the rule type owns its
+own invariants (§4.4). Its `ChainError::Validation` is therefore flattened into
+a serde error before any handler sees it, and actix's default JSON extractor
+would render that as a plaintext `400` with no `field`. The v2 routes must
+register a `web::JsonConfig` error handler that recovers the message into a
+`ValidationErrorResponse`; without it, the whole rule-level class of §4.4
+failures silently loses the structured `field` this section promises. That
+handler is #47's to add, and is a required part of its acceptance.
 
 ---
 

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -68,8 +68,8 @@ domain.
 
 | concern | home | visibility |
 |---|---|---|
-| expiry rules, schedule, planner (§4, §5) | `src/domain/expiry.rs` | `pub(crate)` inside the private `domain` |
-| public representation of a schedule (§4.1) | `src/session/*` | public, converts into the domain types |
+| expiry **configuration** types (§4.1) | `src/domain/expiry.rs` | `pub`, re-exported through `session` |
+| expiry **planner** — projection, dedupe, DST (§4, §5) | `src/domain/expiry.rs` | `pub(crate)`, never leaves the crate |
 | factor tape (§8) | `src/domain/factors.rs` | `pub(crate)` |
 | snapshot aggregate (§7) | `src/domain/series.rs` | `pub(crate)` |
 | v2 parameters, session, stores (§3, §12.2) | `src/session/*` | public |
@@ -77,14 +77,26 @@ domain.
 | retention knobs, metrics (§9) | `src/infrastructure/*`, `src/api/rest/limits.rs` pattern | internal |
 | every error (§11) | `src/utils/error.rs` — `ChainError` | public |
 
-The domain expiry types stay `pub(crate)` on purpose. Publishing them would put
-`chrono_tz::Tz`, `chrono::Weekday` and `chrono::NaiveTime` into this crate's
-public API, and a `chrono-tz` major bump would then be a breaking change for
-IronCondor — repeating, voluntarily, the upstream-type leak that §12.1 already
-has to carry an exception for. The session layer therefore owns the public,
-primitive-typed representation (`timezone` as a string, `expiration_time` as
-`"HH:MM:SS"`) and converts into the domain types at the same boundary that
-already does the f64 → typed conversion.
+The split matters. The **configuration** types — `ExpirationSchedule`,
+`ExpiryRule`, `ExpiryRuleKind`, `CalendarVersion` — are re-exported through
+`session`, because they are fields of the public `SimulationParametersV2` and a
+consumer building parameters in Rust needs to name them. The **planner** —
+`RollingPlanner`, `ActiveExpiry` — stays crate-internal: it is how snapshots get
+built, not part of anyone's contract.
+
+Publishing the configuration types puts `chrono_tz::Tz`, `chrono::Weekday` and
+`chrono::NaiveTime` into this crate's public API, so a `chrono-tz` major bump
+becomes a semver event here. That is accepted rather than overlooked: the crate
+already publishes `optionstratlib::WalkType`, `TimeFrame`, `Positive` and
+`Decimal` in `SimulationParameters`, IronCondor consumes the **REST** contract
+rather than the Rust types, and the alternative — a parallel primitive-typed
+representation in `session` — would mean two shapes, two validation paths, and a
+standing risk that they drift.
+
+What is *not* accepted is a validation bypass. The configuration types keep
+their fields private and route `Deserialize` through their validating
+constructors, so a schedule loaded from Redis is checked exactly like one built
+from a request.
 
 ---
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,4 +4,5 @@ pub use rest::controller::start_server;
 pub use rest::models::ListenOn;
 pub use rest::patch::Patch;
 pub use rest::requests::{CreateSessionRequest, UpdateSessionRequest};
+pub use rest::requests_v2::CreateSimulationRequest;
 pub use rest::responses::*;

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -7,6 +7,7 @@ mod middleware;
 pub(crate) mod models;
 pub(crate) mod patch;
 pub(crate) mod requests;
+pub(crate) mod requests_v2;
 pub(crate) mod responses;
 mod routes;
 pub mod swagger;

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -392,6 +392,23 @@ impl From<WalkType> for ApiWalkType {
     }
 }
 
+/// Rechecks a [`WalkType`] that did not arrive through the request path.
+///
+/// A stored simulation is an outer-layer input: the document in Redis may have
+/// been hand-edited, or written by a build whose validation differed, so a
+/// `dt` of zero can reach the walk without ever passing
+/// [`TryFrom<ApiWalkType>`]. Rather than mirror those invariants a second time
+/// in the session layer — a second exhaustive match to keep in step with
+/// upstream — this round-trips through the mirror that already exists, so the
+/// stored document is held to exactly the checks a request is.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming the offending field.
+pub(crate) fn validate_walk_type(walk: &WalkType) -> Result<(), ChainError> {
+    WalkType::try_from(ApiWalkType::from(walk.clone())).map(|_| ())
+}
+
 impl TryFrom<ApiWalkType> for WalkType {
     type Error = ChainError;
 

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -1,0 +1,274 @@
+//! Request DTOs for the v2 rolling-simulation API.
+//!
+//! Separate from [`crate::api::rest::requests`] on purpose: `/api/v1/chain` is
+//! frozen (ADR 0001 §12.1), so the rolling contract ships as its own request
+//! type rather than as new optional fields on `CreateSessionRequest`.
+//!
+//! As in v1, the DTO speaks `f64` for JSON ergonomics and the conversion into
+//! `Positive` / `Decimal` / `Tz` happens exactly once, in
+//! `TryFrom<CreateSimulationRequest> for SimulationParametersV2`
+//! (`crate::session::model_v2`).
+
+use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+use crate::domain::expiry::ExpiryRule;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use utoipa::ToSchema;
+
+/// Creates a deterministic rolling multi-expiration simulation.
+///
+/// Rejects unknown fields: a typo in a field name is a `400` naming the field
+/// rather than a silently ignored parameter that changes the tape.
+///
+/// A v2 simulation is immutable after creation, so there is no update
+/// counterpart to this type — changing any of these values means a new
+/// simulation (ADR 0001 §6).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateSimulationRequest {
+    /// Ticker symbol of the underlying being simulated.
+    pub symbol: String,
+    /// Number of steps the simulation runs for.
+    pub steps: usize,
+    /// Optional simulated start instant, RFC 3339. When omitted, one is
+    /// generated at conversion, normalised to whole-second UTC, and returned as
+    /// the effective start so the run can be replayed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = DateTime)]
+    pub start_at: Option<DateTime<Utc>>,
+    /// Fixed interval between simulated steps, in seconds. When omitted it is
+    /// derived from `time_frame`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_interval_seconds: Option<u64>,
+    /// IANA time-zone name the expiration time is expressed in, e.g.
+    /// `America/New_York`.
+    pub timezone: String,
+    /// Calendar policy version. Defaults to `weekdays_v1`, currently the only
+    /// accepted value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub calendar: Option<String>,
+    /// Local time of day every expiration expires at, `HH:MM` or `HH:MM:SS`.
+    pub expiration_time: String,
+    /// The rolling expiration rules. Each is one flat object tagged by `kind`;
+    /// see ADR 0001 §4.1.
+    #[schema(value_type = Vec<Object>)]
+    pub schedules: Vec<ExpiryRule>,
+    /// Initial price of the underlying.
+    pub initial_price: f64,
+    /// Initial (and, for constant-volatility models, the only) volatility.
+    pub volatility: f64,
+    /// Annualised risk-free rate, as a decimal fraction.
+    pub risk_free_rate: f64,
+    /// Annualised dividend yield, as a decimal fraction.
+    pub dividend_yield: f64,
+    /// The stochastic model driving the underlying path.
+    pub method: ApiWalkType,
+    /// Time frame the stochastic model is scaled by. Distinct from
+    /// `step_interval_seconds`, which drives the simulated clock.
+    pub time_frame: ApiTimeFrame,
+    /// Number of strikes per chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_size: Option<usize>,
+    /// Interval between strikes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strike_interval: Option<f64>,
+    /// Slope of the volatility skew.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skew_slope: Option<f64>,
+    /// Curvature of the volatility smile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smile_curve: Option<f64>,
+    /// Bid-ask spread factor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread: Option<f64>,
+    /// RNG seed. When omitted one is generated and returned as the effective
+    /// seed, exactly as in v1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u64>,
+}
+
+impl fmt::Display for CreateSimulationRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let json = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reference configuration from ADR 0001 §14.1 deserializes.
+    const REFERENCE_REQUEST: &str = r#"{
+        "symbol": "SPX",
+        "steps": 500,
+        "start_at": "2026-01-05T14:30:00Z",
+        "step_interval_seconds": 86400,
+        "timezone": "America/New_York",
+        "calendar": "weekdays_v1",
+        "expiration_time": "17:00",
+        "schedules": [
+            { "rule_id": "zero_dte", "kind": "daily", "target_count": 1 },
+            { "rule_id": "weeklies", "kind": "weekly", "target_count": 3,
+              "weekdays": ["Mon", "Wed", "Fri"] },
+            { "rule_id": "monthlies", "kind": "monthly", "target_count": 12,
+              "weekday": "Fri" }
+        ],
+        "initial_price": 5000.0,
+        "volatility": 0.18,
+        "risk_free_rate": 0.04,
+        "dividend_yield": 0.012,
+        "method": { "GeometricBrownian": { "dt": 0.004, "drift": 0.05, "volatility": 0.18 } },
+        "time_frame": "Day",
+        "chain_size": 15,
+        "strike_interval": 25.0,
+        "skew_slope": -0.2,
+        "smile_curve": 0.4,
+        "spread": 0.02,
+        "seed": 42
+    }"#;
+
+    #[test]
+    fn test_reference_request_deserializes() {
+        match serde_json::from_str::<CreateSimulationRequest>(REFERENCE_REQUEST) {
+            Ok(request) => {
+                assert_eq!(request.symbol, "SPX");
+                assert_eq!(request.steps, 500);
+                assert_eq!(request.step_interval_seconds, Some(86_400));
+                assert_eq!(request.schedules.len(), 3);
+                assert_eq!(request.seed, Some(42));
+            }
+            Err(error) => panic!("the reference request must deserialize: {error}"),
+        }
+    }
+
+    /// Every optional field may be omitted.
+    #[test]
+    fn test_optional_fields_may_be_omitted() {
+        let json = r#"{
+            "symbol": "SPX",
+            "steps": 10,
+            "timezone": "America/New_York",
+            "expiration_time": "17:00",
+            "schedules": [ { "rule_id": "zero_dte", "kind": "daily", "target_count": 1 } ],
+            "initial_price": 5000.0,
+            "volatility": 0.18,
+            "risk_free_rate": 0.04,
+            "dividend_yield": 0.0,
+            "method": { "Brownian": { "dt": 0.004, "drift": 0.0, "volatility": 0.18 } },
+            "time_frame": "Day"
+        }"#;
+
+        match serde_json::from_str::<CreateSimulationRequest>(json) {
+            Ok(request) => {
+                assert!(request.start_at.is_none());
+                assert!(request.step_interval_seconds.is_none());
+                assert!(request.calendar.is_none());
+                assert!(request.seed.is_none());
+            }
+            Err(error) => panic!("must deserialize without optional fields: {error}"),
+        }
+    }
+
+    /// An unknown top-level field is rejected rather than ignored.
+    #[test]
+    fn test_unknown_field_is_rejected() {
+        let json = r#"{
+            "symbol": "SPX",
+            "steps": 10,
+            "timezone": "America/New_York",
+            "expiration_time": "17:00",
+            "schedules": [ { "rule_id": "zero_dte", "kind": "daily", "target_count": 1 } ],
+            "initial_price": 5000.0,
+            "volatility": 0.18,
+            "risk_free_rate": 0.04,
+            "dividend_yield": 0.0,
+            "method": { "Brownian": { "dt": 0.004, "drift": 0.0, "volatility": 0.18 } },
+            "time_frame": "Day",
+            "days_to_expiration": 30.0
+        }"#;
+
+        let error = match serde_json::from_str::<CreateSimulationRequest>(json) {
+            Ok(_) => panic!("an unknown field must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("days_to_expiration"),
+            "the error must name the offending field, got {error}"
+        );
+    }
+
+    /// An unknown field inside a schedule rule is rejected too.
+    #[test]
+    fn test_unknown_field_inside_a_rule_is_rejected() {
+        let json = r#"{
+            "symbol": "SPX",
+            "steps": 10,
+            "timezone": "America/New_York",
+            "expiration_time": "17:00",
+            "schedules": [
+                { "rule_id": "zero_dte", "kind": "daily", "target_count": 1, "typo": 1 }
+            ],
+            "initial_price": 5000.0,
+            "volatility": 0.18,
+            "risk_free_rate": 0.04,
+            "dividend_yield": 0.0,
+            "method": { "Brownian": { "dt": 0.004, "drift": 0.0, "volatility": 0.18 } },
+            "time_frame": "Day"
+        }"#;
+
+        assert!(serde_json::from_str::<CreateSimulationRequest>(json).is_err());
+    }
+
+    /// A field that belongs to another rule kind is rejected rather than
+    /// silently dropped.
+    #[test]
+    fn test_field_not_valid_for_the_rule_kind_is_rejected() {
+        let json = r#"{
+            "symbol": "SPX",
+            "steps": 10,
+            "timezone": "America/New_York",
+            "expiration_time": "17:00",
+            "schedules": [
+                { "rule_id": "zero_dte", "kind": "daily", "target_count": 1,
+                  "weekdays": ["Mon"] }
+            ],
+            "initial_price": 5000.0,
+            "volatility": 0.18,
+            "risk_free_rate": 0.04,
+            "dividend_yield": 0.0,
+            "method": { "Brownian": { "dt": 0.004, "drift": 0.0, "volatility": 0.18 } },
+            "time_frame": "Day"
+        }"#;
+
+        let error = match serde_json::from_str::<CreateSimulationRequest>(json) {
+            Ok(_) => panic!("weekdays on a daily rule must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("weekdays"),
+            "the error must name the offending field, got {error}"
+        );
+    }
+
+    /// The request round-trips through JSON, so a logged or echoed request
+    /// reads back identically.
+    #[test]
+    fn test_request_round_trips_through_json() {
+        let request = match serde_json::from_str::<CreateSimulationRequest>(REFERENCE_REQUEST) {
+            Ok(request) => request,
+            Err(error) => panic!("must deserialize: {error}"),
+        };
+
+        let json = request.to_string();
+        match serde_json::from_str::<CreateSimulationRequest>(&json) {
+            Ok(round_tripped) => {
+                assert_eq!(round_tripped.symbol, request.symbol);
+                assert_eq!(round_tripped.schedules, request.schedules);
+                assert_eq!(round_tripped.start_at, request.start_at);
+            }
+            Err(error) => panic!("must round-trip: {error}"),
+        }
+    }
+}

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -10,7 +10,7 @@
 //! (`crate::session::model_v2`).
 
 use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
-use crate::domain::expiry::ExpiryRule;
+use crate::session::ExpiryRule;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/src/domain/expiry.rs
+++ b/src/domain/expiry.rs
@@ -52,18 +52,23 @@
 //! exactly like one built from a request. Without that, a stored
 //! `target_count` of `1e11` would reach the projection loop.
 
-// The planner is the bottom of the v0.2.0 stack and has no in-tree caller yet:
-// issue #44 persists an `ExpirationSchedule` in the v2 session parameters and
-// #46 calls `RollingPlanner::active_at` to build each snapshot. Landing it with
-// its own tests first is what keeps every PR in the stack independently sound.
+// The planner *evaluation* half — `RollingPlanner`, `ActiveExpiry`, and their
+// helpers — has no in-tree caller yet: #46 calls `active_at` to build each
+// snapshot. The *configuration* half is already live, wired into the v2 session
+// parameters by #44.
 //
-// `expect` rather than `allow` on purpose: the moment #44 or #46 wires a caller
-// in, the expectation goes unfulfilled and CI's `-D warnings` turns it into a
-// hard error, so removing this is enforced by the compiler rather than promised
-// in a commit message.
-#![expect(
-    dead_code,
-    reason = "no in-tree caller until #44 persists the schedule and #46 calls active_at"
+// `expect` rather than `allow` on purpose: once #46 exercises the last of these
+// items the expectation goes unfulfilled, and CI's `-D warnings` turns that into
+// a hard error. Removing this line is therefore enforced by the compiler rather
+// than promised in a commit message. It is scoped to non-test builds because the
+// module's own tests already exercise the evaluation path, which would make the
+// expectation unfulfilled under `cargo test` for the wrong reason.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the planner evaluation path has no in-tree caller until #46 builds snapshots"
+    )
 )]
 
 use crate::utils::ChainError;
@@ -97,6 +102,10 @@ pub(crate) const MAX_TARGET_COUNT: usize = 256;
 /// A plain constant for now; issue #48 turns it into an `OCS_MAX_*` knob.
 pub(crate) const MAX_EXPIRATIONS_PER_SNAPSHOT: usize = 512;
 
+/// The month a `yearly` rule expires in when the request omits it — December,
+/// the conventional LEAPS expiry month.
+pub(crate) const DEFAULT_YEARLY_MONTH: u32 = 12;
+
 /// Maximum length of a `rule_id`.
 ///
 /// Rule ids are echoed as labels on every chain of every step and are joined
@@ -114,10 +123,6 @@ const DAY_SCAN_SLACK: usize = 32;
 
 /// Upper bound on how many candidate periods a monthly or yearly rule may scan.
 const PERIOD_SCAN_SLACK: usize = 2;
-
-/// The month a `yearly` rule expires in when the request omits it — December,
-/// as ADR 0001 §4.1 specifies.
-const DEFAULT_YEARLY_MONTH: u32 = 12;
 
 /// Seconds in a day, as a `Decimal`, for the fractional days-to-expiration
 /// conversion.
@@ -143,7 +148,7 @@ pub(crate) fn tzdb_version() -> &'static str {
 /// set, so a future policy can be added without silently changing the tape of
 /// a simulation created under an older one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum CalendarVersion {
+pub enum CalendarVersion {
     /// Weekends are the only ineligible days; no exchange-holiday data is
     /// consulted. See [`CalendarVersion::eligible_date`].
     #[serde(rename = "weekdays_v1")]
@@ -165,7 +170,7 @@ impl CalendarVersion {
     /// candidates onto the same date, which is why per-rule projection counts
     /// **distinct instants** (see [`RollingPlanner::project_rule`]).
     #[must_use]
-    pub(crate) fn eligible_date(self, date: NaiveDate) -> Option<NaiveDate> {
+    pub fn eligible_date(self, date: NaiveDate) -> Option<NaiveDate> {
         match self {
             CalendarVersion::WeekdaysV1 => match date.weekday() {
                 Weekday::Sat | Weekday::Sun => None,
@@ -176,7 +181,7 @@ impl CalendarVersion {
 
     /// The stable wire name of this calendar version.
     #[must_use]
-    pub(crate) fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             CalendarVersion::WeekdaysV1 => "weekdays_v1",
         }
@@ -185,13 +190,12 @@ impl CalendarVersion {
 
 /// What a rule expires on, independent of how many expirations it keeps.
 ///
-/// Serialised **internally tagged** under `kind` with `snake_case` variant
-/// names, and flattened into [`ExpiryRule`], so a stored rule reads exactly as
-/// ADR 0001 §14.2 shows it:
+/// The wire form is flat and tagged by `kind` — see [`ExpiryRuleWire`], which
+/// carries the serde derives so that `deny_unknown_fields` and per-kind field
+/// validity both hold. A stored rule reads exactly as ADR 0001 §14.2 shows it:
 /// `{"rule_id": "monthlies", "kind": "monthly", "target_count": 12, "weekday": "Fri"}`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub(crate) enum ExpiryRuleKind {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpiryRuleKind {
     /// Every eligible weekday expires — the rolling 0DTE.
     Daily,
     /// Each named weekday expires. The set is non-empty and contains no
@@ -228,7 +232,7 @@ impl ExpiryRuleKind {
     /// [`ExpirationSchedule::validate`], which knows the owning rule id and can
     /// therefore name the offending field.
     #[must_use]
-    pub(crate) fn weekly(weekdays: impl IntoIterator<Item = Weekday>) -> Self {
+    pub fn weekly(weekdays: impl IntoIterator<Item = Weekday>) -> Self {
         // `chrono::Weekday` is not `Ord`, so deduplicate and order through the
         // Monday-based index, which round-trips losslessly.
         let ordered: BTreeSet<u8> = weekdays
@@ -253,26 +257,6 @@ impl ExpiryRuleKind {
         }
     }
 
-    /// The wire tag this kind serialises under.
-    ///
-    /// Nothing calls this at runtime — it exists so that adding a variant to
-    /// [`ExpiryRuleKind`] fails to compile until [`ExpiryRuleKindTag`] gains
-    /// the matching variant. Without it the two lists drift, and a kind that
-    /// serialises fine becomes a stored schedule that cannot be read back.
-    #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "compile-time exhaustiveness link")
-    )]
-    fn tag(&self) -> ExpiryRuleKindTag {
-        match self {
-            ExpiryRuleKind::Daily => ExpiryRuleKindTag::Daily,
-            ExpiryRuleKind::Weekly { .. } => ExpiryRuleKindTag::Weekly,
-            ExpiryRuleKind::Monthly { .. } => ExpiryRuleKindTag::Monthly,
-            ExpiryRuleKind::Yearly { .. } => ExpiryRuleKindTag::Yearly,
-        }
-    }
-
     /// A short, stable description of the rule kind, used in validation
     /// messages.
     #[must_use]
@@ -290,153 +274,127 @@ impl ExpiryRuleKind {
 /// expirations it keeps available at every step.
 ///
 /// Fields are private and the constructor validates, so an out-of-range
-/// `target_count` or a malformed `rule_id` is unrepresentable. `Deserialize`
-/// goes through the same constructor (see [`ExpiryRuleWire`]), which is what
-/// makes a schedule loaded from the session store as safe as one built from a
-/// request.
+/// `target_count` or a malformed `rule_id` is unrepresentable. Both directions
+/// of serde go through [`ExpiryRuleWire`], which is what makes a schedule
+/// loaded from the session store as safe as one built from a request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "ExpiryRuleWire")]
-pub(crate) struct ExpiryRule {
+#[serde(into = "ExpiryRuleWire", try_from = "ExpiryRuleWire")]
+pub struct ExpiryRule {
     rule_id: String,
-    #[serde(flatten)]
     kind: ExpiryRuleKind,
     target_count: NonZeroUsize,
 }
 
-/// Which rule kind a wire rule names, before its kind-specific fields are
-/// checked.
+/// The wire shape of [`ExpiryRule`]: flat, tagged by `kind`, and strict.
 ///
-/// Kept in step with [`ExpiryRuleKind`] by [`ExpiryRuleKind::tag`], whose
-/// exhaustive match is what breaks the build if one list gains a variant and
-/// the other does not.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum ExpiryRuleKindTag {
-    Daily,
-    Weekly,
-    Monthly,
-    Yearly,
-}
-
-/// The deserialization shape of [`ExpiryRule`], routed through its validating
-/// constructor by `#[serde(try_from = ...)]`.
-///
-/// The kind-specific fields are listed flat and optional rather than reached
-/// through `#[serde(flatten)]` on [`ExpiryRuleKind`], because serde does not
-/// support `deny_unknown_fields` alongside `flatten` — and that rejection is
-/// exactly what ADR 0001 §4.1 specifies. Deserialising through this shape also
-/// makes a field that belongs to *another* kind, such as `weekday` on a `daily`
-/// rule, an error naming the field instead of a silently ignored key.
-///
-/// [`ExpiryRule`] still *serialises* through the flattened, internally-tagged
-/// enum, so the stored shape is untouched. What this type accepts moves in two
-/// directions: it is narrower for a stray or foreign field, and wider for a
-/// `yearly` rule that omits `month`, which now takes the
-/// [`DEFAULT_YEARLY_MONTH`] the ADR specifies instead of failing on a missing
-/// field. An explicit `null` for a foreign field is still accepted and ignored,
-/// which is what serde's own `Option` handling does.
-#[derive(Deserialize)]
+/// The kind-specific fields are declared explicitly rather than through
+/// `#[serde(flatten)]` on an internally-tagged enum. Flattening would give the
+/// same JSON but forfeits `deny_unknown_fields` — serde cannot combine the two
+/// — and with it both guarantees ADR 0001 §4.4 makes: that an unknown field is
+/// rejected, and that a field which is not valid for the rule's `kind`
+/// (`weekdays` on a `daily` rule, `month` on a `weekly` one) is rejected rather
+/// than silently ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ExpiryRuleWire {
     rule_id: String,
-    kind: ExpiryRuleKindTag,
+    kind: String,
     target_count: NonZeroUsize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     weekdays: Option<Vec<Weekday>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     weekday: Option<Weekday>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     month: Option<u32>,
+}
+
+impl From<ExpiryRule> for ExpiryRuleWire {
+    fn from(rule: ExpiryRule) -> Self {
+        let kind = rule.kind.kind_name().to_string();
+        let (weekdays, weekday, month) = match rule.kind {
+            ExpiryRuleKind::Daily => (None, None, None),
+            ExpiryRuleKind::Weekly { weekdays } => (Some(weekdays), None, None),
+            ExpiryRuleKind::Monthly { weekday } => (None, Some(weekday), None),
+            ExpiryRuleKind::Yearly { weekday, month } => (None, Some(weekday), Some(month)),
+        };
+
+        Self {
+            rule_id: rule.rule_id,
+            kind,
+            target_count: rule.target_count,
+            weekdays,
+            weekday,
+            month,
+        }
+    }
 }
 
 impl TryFrom<ExpiryRuleWire> for ExpiryRule {
     type Error = ChainError;
 
     fn try_from(wire: ExpiryRuleWire) -> Result<Self, Self::Error> {
-        // Before anything interpolates the id into an error field that a
-        // handler reflects back to the caller.
+        // Before anything interpolates the id into an error field a handler
+        // reflects back to the caller.
         validate_rule_id(&wire.rule_id)?;
-        let kind = wire.kind_from_parts()?;
-        ExpiryRule::from_parts(wire.rule_id, kind, wire.target_count)
-    }
-}
 
-impl ExpiryRuleWire {
-    /// Builds the kind, requiring the fields it owns and rejecting the ones it
-    /// does not.
-    fn kind_from_parts(&self) -> Result<ExpiryRuleKind, ChainError> {
-        let field = |name: &str| format!("schedules.{}.{name}", self.rule_id);
+        let field = |name: &str| format!("schedules.{}.{name}", wire.rule_id);
 
-        match self.kind {
-            ExpiryRuleKindTag::Daily => {
-                self.reject(&[])?;
-                Ok(ExpiryRuleKind::Daily)
-            }
-            ExpiryRuleKindTag::Weekly => {
-                self.reject(&["weekdays"])?;
-                let weekdays = self
-                    .weekdays
-                    .clone()
-                    .ok_or_else(|| ChainError::Validation {
-                        field: field("weekdays"),
-                        reason: "is required for a weekly rule".to_string(),
-                    })?;
-                Ok(ExpiryRuleKind::weekly(weekdays))
-            }
-            ExpiryRuleKindTag::Monthly => {
-                self.reject(&["weekday"])?;
-                Ok(ExpiryRuleKind::Monthly {
-                    weekday: self.require_weekday()?,
-                })
-            }
-            ExpiryRuleKindTag::Yearly => {
-                self.reject(&["weekday", "month"])?;
-                Ok(ExpiryRuleKind::Yearly {
-                    weekday: self.require_weekday()?,
-                    month: self.month.unwrap_or(DEFAULT_YEARLY_MONTH),
-                })
-            }
-        }
-    }
-
-    /// Fails when a kind-specific field outside `allowed` is present.
-    ///
-    /// A stray key is schema drift, and a schedule is persisted and replayed —
-    /// accepting it silently would let a stored simulation mean something
-    /// different from what its author wrote. The check is an allow-list over an
-    /// exhaustive destructure rather than a lookup by name, so a new
-    /// kind-specific field on this type is a compile error here instead of a
-    /// field that silently reports itself absent.
-    fn reject(&self, allowed: &[&str]) -> Result<(), ChainError> {
-        let Self {
-            rule_id: _,
-            kind: _,
-            target_count: _,
-            weekdays,
-            weekday,
-            month,
-        } = self;
-
-        let present = [
-            ("weekdays", weekdays.is_some()),
-            ("weekday", weekday.is_some()),
-            ("month", month.is_some()),
-        ];
-
-        for (name, is_present) in present {
-            if is_present && !allowed.contains(&name) {
+        // Reject a field that does not belong to this kind before building it,
+        // so a `weekdays` list on a `daily` rule is an error the client sees
+        // rather than a silently dropped intent.
+        let reject = |present: bool, name: &str| -> Result<(), ChainError> {
+            if present {
                 return Err(ChainError::Validation {
-                    field: format!("schedules.{}.{name}", self.rule_id),
-                    reason: "does not belong to this rule kind".to_string(),
+                    field: field(name),
+                    reason: format!("is not valid for a {} rule", wire.kind),
                 });
             }
-        }
-        Ok(())
-    }
+            Ok(())
+        };
 
-    /// Requires the `weekday` a monthly or yearly rule expires on.
-    fn require_weekday(&self) -> Result<Weekday, ChainError> {
-        self.weekday.ok_or_else(|| ChainError::Validation {
-            field: format!("schedules.{}.weekday", self.rule_id),
-            reason: "is required for this rule kind".to_string(),
-        })
+        let kind = match wire.kind.as_str() {
+            "daily" => {
+                reject(wire.weekdays.is_some(), "weekdays")?;
+                reject(wire.weekday.is_some(), "weekday")?;
+                reject(wire.month.is_some(), "month")?;
+                ExpiryRuleKind::Daily
+            }
+            "weekly" => {
+                reject(wire.weekday.is_some(), "weekday")?;
+                reject(wire.month.is_some(), "month")?;
+                let weekdays = wire.weekdays.ok_or_else(|| ChainError::Validation {
+                    field: field("weekdays"),
+                    reason: "is required for a weekly rule".to_string(),
+                })?;
+                ExpiryRuleKind::weekly(weekdays)
+            }
+            "monthly" => {
+                reject(wire.weekdays.is_some(), "weekdays")?;
+                reject(wire.month.is_some(), "month")?;
+                let weekday = wire.weekday.ok_or_else(|| ChainError::Validation {
+                    field: field("weekday"),
+                    reason: "is required for a monthly rule".to_string(),
+                })?;
+                ExpiryRuleKind::Monthly { weekday }
+            }
+            "yearly" => {
+                reject(wire.weekdays.is_some(), "weekdays")?;
+                let weekday = wire.weekday.ok_or_else(|| ChainError::Validation {
+                    field: field("weekday"),
+                    reason: "is required for a yearly rule".to_string(),
+                })?;
+                let month = wire.month.unwrap_or(DEFAULT_YEARLY_MONTH);
+                ExpiryRuleKind::Yearly { weekday, month }
+            }
+            other => {
+                return Err(ChainError::Validation {
+                    field: field("kind"),
+                    reason: format!("must be one of daily, weekly, monthly, yearly; got {other:?}"),
+                });
+            }
+        };
+
+        ExpiryRule::from_parts(wire.rule_id, kind, wire.target_count)
     }
 }
 
@@ -454,7 +412,7 @@ impl ExpiryRule {
     /// `schedules.<rule_id>.target_count` when the count is zero or exceeds
     /// [`MAX_TARGET_COUNT`], or `schedules.rule_id` when the id is empty, too
     /// long, or carries a character outside `[A-Za-z0-9_-]`.
-    pub(crate) fn new(
+    pub fn new(
         rule_id: impl Into<String>,
         kind: ExpiryRuleKind,
         target_count: usize,
@@ -506,20 +464,20 @@ impl ExpiryRule {
     /// The rule's stable identifier, which becomes its label on every chain it
     /// produces.
     #[must_use]
-    pub(crate) fn rule_id(&self) -> &str {
+    pub fn rule_id(&self) -> &str {
         &self.rule_id
     }
 
     /// What the rule expires on.
     #[must_use]
-    pub(crate) fn kind(&self) -> &ExpiryRuleKind {
+    pub fn kind(&self) -> &ExpiryRuleKind {
         &self.kind
     }
 
     /// How many non-expired expirations the rule keeps available, evaluated
     /// per rule and before coincident expirations are deduplicated.
     #[must_use]
-    pub(crate) fn target_count(&self) -> NonZeroUsize {
+    pub fn target_count(&self) -> NonZeroUsize {
         self.target_count
     }
 }
@@ -532,7 +490,7 @@ impl ExpiryRule {
 /// the planner can evaluate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "ExpirationScheduleWire")]
-pub(crate) struct ExpirationSchedule {
+pub struct ExpirationSchedule {
     calendar: CalendarVersion,
     timezone: Tz,
     expiration_time: NaiveTime,
@@ -577,7 +535,7 @@ impl ExpirationSchedule {
     ///
     /// Returns [`ChainError::Validation`] for the first problem found; see
     /// [`ExpirationSchedule::validate`] for the full list.
-    pub(crate) fn new(
+    pub fn new(
         calendar: CalendarVersion,
         timezone: Tz,
         expiration_time: NaiveTime,
@@ -596,25 +554,25 @@ impl ExpirationSchedule {
 
     /// The calendar policy the rules are evaluated under.
     #[must_use]
-    pub(crate) fn calendar(&self) -> CalendarVersion {
+    pub fn calendar(&self) -> CalendarVersion {
         self.calendar
     }
 
     /// The IANA zone `expiration_time` is expressed in.
     #[must_use]
-    pub(crate) fn timezone(&self) -> Tz {
+    pub fn timezone(&self) -> Tz {
         self.timezone
     }
 
     /// The **local** time of day at which every rule's expirations expire.
     #[must_use]
-    pub(crate) fn expiration_time(&self) -> NaiveTime {
+    pub fn expiration_time(&self) -> NaiveTime {
         self.expiration_time
     }
 
     /// The rules, ordered by `rule_id`.
     #[must_use]
-    pub(crate) fn rules(&self) -> &[ExpiryRule] {
+    pub fn rules(&self) -> &[ExpiryRule] {
         &self.rules
     }
 
@@ -633,7 +591,7 @@ impl ExpirationSchedule {
     /// - a `rule_id` is duplicated;
     /// - the pre-deduplication sum of `target_count` exceeds
     ///   [`MAX_EXPIRATIONS_PER_SNAPSHOT`], or overflows.
-    pub(crate) fn validate(&self) -> Result<(), ChainError> {
+    pub fn validate(&self) -> Result<(), ChainError> {
         if self.rules.is_empty() {
             return Err(ChainError::Validation {
                 field: "schedules".to_string(),
@@ -2372,28 +2330,6 @@ mod tests {
                 Err(error) => panic!("must deserialize {kind:?} from {json}: {error}"),
             }
         }
-    }
-
-    /// The wire tag and the domain kind stay in step, which is what keeps a
-    /// serialised kind readable back.
-    #[test]
-    fn test_every_kind_maps_to_its_wire_tag() {
-        assert_eq!(ExpiryRuleKind::Daily.tag(), ExpiryRuleKindTag::Daily);
-        assert_eq!(
-            ExpiryRuleKind::weekly([Weekday::Mon]).tag(),
-            ExpiryRuleKindTag::Weekly
-        );
-        assert_eq!(
-            ExpiryRuleKind::Monthly {
-                weekday: Weekday::Fri
-            }
-            .tag(),
-            ExpiryRuleKindTag::Monthly
-        );
-        assert_eq!(
-            ExpiryRuleKind::yearly(Weekday::Fri).tag(),
-            ExpiryRuleKindTag::Yearly
-        );
     }
 
     /// Construction normalises the rule order by id, so the stored schedule

--- a/src/domain/expiry.rs
+++ b/src/domain/expiry.rs
@@ -35,14 +35,18 @@
 //!
 //! # Visibility
 //!
-//! Every type here is `pub(crate)` and stays inside the private `domain`
-//! module. It is deliberately **not** part of the published crate's API: doing
-//! so would put `chrono_tz::Tz`, `chrono::Weekday` and `chrono::NaiveTime` into
-//! the public surface, and a `chrono-tz` major bump would then be a breaking
-//! change for downstream consumers such as IronCondor. Issue #44 owns the
-//! public representation — primitive-typed schedule fields on the v2 session
-//! parameters — and converts into these types at the one boundary that already
-//! does f64 → typed conversion.
+//! The module splits in two. The **configuration** types —
+//! [`ExpirationSchedule`], [`ExpiryRule`], [`ExpiryRuleKind`],
+//! [`CalendarVersion`] — are `pub` and re-exported through `session`, because
+//! they are fields of the public v2 simulation parameters and a caller building
+//! those in Rust has to name them. The **planner** — [`RollingPlanner`],
+//! [`ActiveExpiry`] — stays `pub(crate)`: it is how snapshots get built, not
+//! part of anyone's contract.
+//!
+//! Publishing the configuration types puts `chrono_tz::Tz`, `chrono::Weekday`
+//! and `chrono::NaiveTime` on the crate's public surface, so a `chrono-tz`
+//! major bump is a semver event here. ADR 0001 §2.1 records why that is
+//! accepted rather than overlooked.
 //!
 //! # Validation
 //!
@@ -51,25 +55,6 @@
 //! `#[serde(try_from = ...)]` so a schedule loaded from Redis is checked
 //! exactly like one built from a request. Without that, a stored
 //! `target_count` of `1e11` would reach the projection loop.
-
-// The planner *evaluation* half — `RollingPlanner`, `ActiveExpiry`, and their
-// helpers — has no in-tree caller yet: #46 calls `active_at` to build each
-// snapshot. The *configuration* half is already live, wired into the v2 session
-// parameters by #44.
-//
-// `expect` rather than `allow` on purpose: once #46 exercises the last of these
-// items the expectation goes unfulfilled, and CI's `-D warnings` turns that into
-// a hard error. Removing this line is therefore enforced by the compiler rather
-// than promised in a commit message. It is scoped to non-test builds because the
-// module's own tests already exercise the evaluation path, which would make the
-// expectation unfulfilled under `cargo test` for the wrong reason.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the planner evaluation path has no in-tree caller until #46 builds snapshots"
-    )
-)]
 
 use crate::utils::ChainError;
 use chrono::{DateTime, Datelike, Days, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
@@ -119,13 +104,34 @@ pub(crate) const MAX_RULE_ID_LEN: usize = 64;
 /// A weekly rule naming one weekday needs seven days per expiration; the
 /// factor of eight plus a constant leaves room for weekends and for the
 /// starting partial week without ever letting the scan run unbounded.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 const DAY_SCAN_SLACK: usize = 32;
 
 /// Upper bound on how many candidate periods a monthly or yearly rule may scan.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 const PERIOD_SCAN_SLACK: usize = 2;
 
 /// Seconds in a day, as a `Decimal`, for the fractional days-to-expiration
 /// conversion.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 const SECONDS_PER_DAY: Decimal = Decimal::from_parts(86_400, 0, 0, false, 0);
 
 /// The version of the IANA time-zone database this binary resolves local
@@ -454,6 +460,17 @@ impl ExpiryRule {
         }
         validate_rule_kind(&rule_id, &kind)?;
 
+        // Rebuild a weekly set through the normalising constructor. The REST
+        // and stored paths already go through it, but `ExpiryRuleKind` has
+        // public variants, so a Rust caller can hand us
+        // `Weekly { weekdays: vec![Fri, Mon, Mon] }` directly — and ADR 0001
+        // §14.2 makes the normalised form the replay input, so persisting an
+        // un-normalised one would be a quiet contract break.
+        let kind = match kind {
+            ExpiryRuleKind::Weekly { weekdays } => ExpiryRuleKind::weekly(weekdays),
+            other => other,
+        };
+
         Ok(Self {
             rule_id,
             kind,
@@ -728,6 +745,13 @@ fn reject_weekend(field: &str, weekday: Weekday) -> Result<(), ChainError> {
 /// One physical expiration that is alive at a given simulated instant, with
 /// every rule that asked for it.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 pub(crate) struct ActiveExpiry {
     /// The absolute expiration instant, in UTC.
     pub(crate) expires_at: DateTime<Utc>,
@@ -736,6 +760,13 @@ pub(crate) struct ActiveExpiry {
     pub(crate) labels: Vec<String>,
 }
 
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 impl ActiveExpiry {
     /// The fractional days remaining until this expiration at `simulated_at`.
     ///
@@ -790,10 +821,24 @@ impl ActiveExpiry {
 /// Pure: constructing a planner performs no I/O and evaluating it draws no
 /// randomness and reads no clock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 pub(crate) struct RollingPlanner<'a> {
     schedule: &'a ExpirationSchedule,
 }
 
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 impl<'a> RollingPlanner<'a> {
     /// Builds a planner over an already-validated schedule.
     #[must_use]
@@ -1037,6 +1082,13 @@ impl<'a> RollingPlanner<'a> {
 
 /// Builds the error a failed projection reports, naming the rule that failed.
 #[cold]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 fn projection_error(rule: &ExpiryRule, reason: String) -> ChainError {
     ChainError::Validation {
         field: format!("schedules.{}", rule.rule_id),
@@ -1048,6 +1100,13 @@ fn projection_error(rule: &ExpiryRule, reason: String) -> ChainError {
 ///
 /// Returns the failure reason rather than a `ChainError`, so the caller can
 /// attach the rule that was being projected.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 fn add_months(year: i32, month: u32, offset: u32) -> Result<(i32, u32), String> {
     let zero_based = month.checked_sub(1).ok_or("month underflows")?;
     let total = zero_based
@@ -1067,6 +1126,13 @@ fn add_months(year: i32, month: u32, offset: u32) -> Result<(i32, u32), String> 
 ///
 /// Returns the failure reason rather than a `ChainError`, so the caller can
 /// attach the rule that was being projected.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 fn add_years(year: i32, offset: u32) -> Result<i32, String> {
     let offset = i32::try_from(offset).map_err(|_| "year arithmetic overflows")?;
     year.checked_add(offset)
@@ -1078,6 +1144,13 @@ fn add_years(year: i32, offset: u32) -> Result<i32, String> {
 /// Walks back from the last day of the month to the most recent occurrence of
 /// `weekday`, so "last Friday of February 2028" lands on the 25th of a
 /// twenty-nine-day month without any special-casing.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "no in-tree caller until #46 builds snapshots from the planner"
+    )
+)]
 fn last_weekday_of_month(
     rule: &ExpiryRule,
     year: i32,

--- a/src/domain/expiry.rs
+++ b/src/domain/expiry.rs
@@ -256,7 +256,7 @@ impl ExpiryRuleKind {
     /// constructor and the `Deserialize` path agree on what "yearly without a
     /// month" means.
     #[must_use]
-    pub(crate) fn yearly(weekday: Weekday) -> Self {
+    pub fn yearly(weekday: Weekday) -> Self {
         ExpiryRuleKind::Yearly {
             weekday,
             month: DEFAULT_YEARLY_MONTH,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,4 +1,4 @@
-mod expiry;
+pub(crate) mod expiry;
 mod simulator;
 mod walker;
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -33,7 +33,7 @@ mod model;
 /// the resolved simulation parameters, the simulation document, and the
 /// conversion from the v2 request DTO. Kept apart from `model` because
 /// `/api/v1/chain` and its stored shape are frozen (ADR 0001 section 12).
-pub mod model_v2;
+mod model_v2;
 ///
 /// The `state_handler` module is responsible for managing and encapsulating all
 /// logic related to the application state. It defines functionality to manipulate,
@@ -70,12 +70,9 @@ mod store;
 pub use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, ExpiryRule, ExpiryRuleKind};
 pub use manager::SessionManager;
 pub use model::{Session, SessionState, SimulationMethod, SimulationParameters};
-pub use model_v2::{
-    MAX_STEP_INTERVAL_SECONDS, MIN_STEP_INTERVAL_SECONDS, SESSION_V2_SCHEMA_VERSION, SessionV2,
-    SimulationParametersV2,
-};
+pub use model_v2::{SESSION_V2_SCHEMA_VERSION, SessionV2, SimulationParametersV2};
 pub use store::{
-    DEFAULT_V2_IDLE_RETENTION_SECS, DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_SESSION_TTL_SECS,
-    InMemorySessionStore, InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore,
-    SessionStore, SimulationStore,
+    DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_RETENTION_SECS, InMemorySessionStore,
+    InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore, SessionStore,
+    SimulationStore,
 };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,6 +29,11 @@ mod manager;
 /// and is used effectively for encapsulating the core business data.
 ///
 mod model;
+/// The `model_v2` module defines the v2 rolling-simulation session types:
+/// the resolved simulation parameters, the simulation document, and the
+/// conversion from the v2 request DTO. Kept apart from `model` because
+/// `/api/v1/chain` and its stored shape are frozen (ADR 0001 section 12).
+pub mod model_v2;
 ///
 /// The `state_handler` module is responsible for managing and encapsulating all
 /// logic related to the application state. It defines functionality to manipulate,
@@ -62,6 +67,15 @@ mod state_handler;
 /// Users of this module should refer to its public items to utilize its functionality effectively.
 mod store;
 
+pub use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, ExpiryRule, ExpiryRuleKind};
 pub use manager::SessionManager;
 pub use model::{Session, SessionState, SimulationMethod, SimulationParameters};
-pub use store::{InMemorySessionStore, InRedisSessionStore, SessionStore};
+pub use model_v2::{
+    MAX_STEP_INTERVAL_SECONDS, MIN_STEP_INTERVAL_SECONDS, SESSION_V2_SCHEMA_VERSION, SessionV2,
+    SimulationParametersV2,
+};
+pub use store::{
+    DEFAULT_V2_IDLE_RETENTION_SECS, DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_SESSION_TTL_SECS,
+    InMemorySessionStore, InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore,
+    SessionStore, SimulationStore,
+};

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -19,6 +19,7 @@
 //!   simulation instead of mutating one.
 
 use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
+use crate::api::rest::models::validate_walk_type;
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::validation::{
     decimal_field, positive_field, strictly_positive_field, symbol_field, time_frame_field,
@@ -125,6 +126,21 @@ fn derive_step_interval_seconds(time_frame: TimeFrame) -> Result<u64, ChainError
     };
 
     Ok(seconds)
+}
+
+/// Rejects a `Positive` that is zero, naming the field.
+///
+/// `Positive` guarantees non-negative, not strictly positive, so the request
+/// path's `strictly_positive_field` check has no type-level counterpart on a
+/// value read back from the store.
+fn reject_zero(field: &str, value: Positive) -> Result<(), ChainError> {
+    if value == Positive::ZERO {
+        return Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: "must be strictly positive, got 0".to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Validates an explicitly-supplied step interval.
@@ -342,6 +358,22 @@ impl SimulationParametersV2 {
         }
         symbol_field("symbol", &self.symbol)?;
         validate_step_interval_seconds(self.step_interval_seconds)?;
+
+        // `Positive` admits zero, so the strict-positive constraints the
+        // request path enforces have to be rechecked here: a stored price or
+        // volatility of zero is a chain of zero-value options, and a stored
+        // `strike_interval` of zero collapses every strike onto one.
+        for (field, value) in [
+            ("initial_price", self.initial_price),
+            ("volatility", self.volatility),
+        ] {
+            reject_zero(field, value)?;
+        }
+        if let Some(strike_interval) = self.strike_interval {
+            reject_zero("strike_interval", strike_interval)?;
+        }
+        validate_walk_type(&self.method)?;
+
         if self.effective_start.nanosecond() != 0 {
             return Err(ChainError::Validation {
                 field: "effective_start".to_string(),
@@ -655,14 +687,48 @@ impl SessionV2 {
                 ),
             });
         }
+        self.validate_state()
+    }
+
+    /// Checks the lifecycle state against the cursor.
+    ///
+    /// A v2 simulation walks `Initialized` at cursor 0, `InProgress` while it
+    /// has snapshots left, and `Completed` once the cursor reaches the horizon.
+    /// Every other combination — `Completed` at step 0, `Initialized` halfway
+    /// through — is a document no code path can write, so accepting one would
+    /// let a corrupted or hand-edited simulation into the manager and serve
+    /// snapshots from a state the rest of the code assumes away.
+    fn validate_state(&self) -> Result<(), ChainError> {
+        let unreachable = |reason: String| ChainError::Validation {
+            field: "state".to_string(),
+            reason,
+        };
+
         match self.state {
-            SessionState::Modified | SessionState::Reinitialized => Err(ChainError::Validation {
-                field: "state".to_string(),
-                reason: format!(
+            SessionState::Modified | SessionState::Reinitialized | SessionState::Error => {
+                Err(unreachable(format!(
                     "{} is unreachable for a v2 simulation, which is immutable after creation",
                     self.state
-                ),
-            }),
+                )))
+            }
+            SessionState::Initialized if self.current_step != 0 => Err(unreachable(format!(
+                "{} requires a cursor of 0, got {}",
+                self.state, self.current_step
+            ))),
+            SessionState::Completed if self.current_step != self.total_steps => {
+                Err(unreachable(format!(
+                    "{} requires the cursor to have reached total_steps ({}), got {}",
+                    self.state, self.total_steps, self.current_step
+                )))
+            }
+            SessionState::InProgress
+                if self.current_step == 0 || self.current_step >= self.total_steps =>
+            {
+                Err(unreachable(format!(
+                    "{} requires a cursor between 1 and total_steps ({}) exclusive, got {}",
+                    self.state, self.total_steps, self.current_step
+                )))
+            }
             _ => Ok(()),
         }
     }
@@ -840,8 +906,7 @@ mod tests {
         let parameters = parameters(request);
 
         assert_eq!(parameters.effective_start.nanosecond(), 0);
-        // Reading it again yields the same value: it is stored, not recomputed.
-        assert_eq!(parameters.effective_start, parameters.effective_start);
+        // The start is stored, not recomputed: cursor 0 resolves back to it.
         match parameters.simulated_at(0) {
             Ok(at) => assert_eq!(at, parameters.effective_start),
             Err(error) => panic!("cursor 0 must resolve: {error}"),
@@ -1237,6 +1302,29 @@ mod tests {
             (r#""symbol":"SPX""#, r#""symbol":"SPX,\"x\"|y""#, "symbol"),
             // A chain size above the cap drives an unbounded strike ladder.
             (r#""chain_size":15"#, r#""chain_size":100000"#, "chain_size"),
+            // `Positive` admits zero, so these three survive the type and have
+            // to be rejected by the validator: a zero price or volatility is a
+            // chain of worthless options, and a zero interval collapses every
+            // strike onto one.
+            (
+                r#""initial_price":5000"#,
+                r#""initial_price":0"#,
+                "initial_price",
+            ),
+            (
+                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.18"#,
+                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0"#,
+                "volatility",
+            ),
+            (
+                r#""strike_interval":25"#,
+                r#""strike_interval":0"#,
+                "strike_interval",
+            ),
+            // The walk's own invariants are not re-derived here: the stored
+            // method round-trips through the same mirror the request path
+            // validates with, so a `dt` of zero is caught by that check.
+            (r#""dt":0.004"#, r#""dt":0.0"#, "dt"),
         ];
 
         for (from, to, field) in tampers {
@@ -1302,7 +1390,7 @@ mod tests {
             Err(error) => panic!("must serialize: {error}"),
         };
 
-        for state in ["Modified", "Reinitialized"] {
+        for state in ["Modified", "Reinitialized", "Error"] {
             let tampered =
                 json.replace(r#""state":"Initialized""#, &format!(r#""state":"{state}""#));
             assert_ne!(tampered, json, "the tamper for {state} must have applied");
@@ -1312,6 +1400,58 @@ mod tests {
                 Err(error) => error.to_string(),
             };
             assert!(error.contains("state"), "got {error}");
+        }
+    }
+
+    /// A state that contradicts the cursor is refused.
+    ///
+    /// `Completed` at step 0 and `Initialized` halfway through are documents no
+    /// code path writes, so accepting one would let a corrupted simulation
+    /// serve snapshots from a state the rest of the code assumes away.
+    #[test]
+    fn test_stored_simulation_rejects_a_state_the_cursor_contradicts() {
+        let mut request = reference_request();
+        request.steps = 4;
+        let simulation = SessionV2::new(parameters(request), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+
+        let contradictions = [
+            (
+                r#""current_step":0,"total_steps":4,"state":"Completed""#,
+                "Completed at step 0",
+            ),
+            (
+                r#""current_step":2,"total_steps":4,"state":"Initialized""#,
+                "Initialized mid-run",
+            ),
+            (
+                r#""current_step":0,"total_steps":4,"state":"InProgress""#,
+                "InProgress at step 0",
+            ),
+            (
+                r#""current_step":4,"total_steps":4,"state":"InProgress""#,
+                "InProgress at the horizon",
+            ),
+        ];
+
+        for (replacement, what) in contradictions {
+            let tampered = json.replace(
+                r#""current_step":0,"total_steps":4,"state":"Initialized""#,
+                replacement,
+            );
+            assert_ne!(tampered, json, "the tamper for {what} must have applied");
+
+            let error = match serde_json::from_str::<SessionV2>(&tampered) {
+                Ok(_) => panic!("{what} must be rejected"),
+                Err(error) => error.to_string(),
+            };
+            assert!(
+                error.contains("state"),
+                "{what} must name state, got {error}"
+            );
         }
     }
 

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -1,0 +1,1016 @@
+//! Session model for v2 rolling simulations.
+//!
+//! Separate from [`crate::session::model`] on purpose. `SimulationParameters`
+//! and `Session` are public, IronCondor-facing, and persisted as serde JSON, so
+//! adding rolling fields to them would be source-breaking even where serde
+//! defaults kept old documents loading. ADR 0001 §12 therefore gives v2 its own
+//! types, its own stored schema, and its own store key space, and freezes v1
+//! exactly as it is.
+//!
+//! Two properties distinguish these types from their v1 counterparts:
+//!
+//! - **The effective inputs are resolved, not optional.** After conversion the
+//!   seed, the simulated start and the step interval are concrete values, not
+//!   `Option`s that some later code path has to default again. Whatever the
+//!   request omitted is decided once, here, and echoed back so the run can be
+//!   replayed.
+//! - **The configuration is immutable.** There is no PATCH or PUT for a v2
+//!   simulation: changing any parameter changes the tape, so it creates a new
+//!   simulation instead of mutating one.
+
+use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
+use crate::api::rest::requests_v2::CreateSimulationRequest;
+use crate::api::rest::validation::{
+    decimal_field, positive_field, strictly_positive_field, symbol_field, time_frame_field,
+};
+use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
+use crate::session::model::{SessionState, SimulationMethod};
+use crate::utils::{ChainError, UuidGenerator};
+use chrono::{DateTime, NaiveTime, TimeDelta, Timelike, Utc};
+use chrono_tz::Tz;
+use optionstratlib::utils::TimeFrame;
+use positive::Positive;
+use rand::RngExt;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+/// Schema version stamped on every stored v2 session.
+///
+/// It rides with the document rather than being inferred from its shape, so a
+/// future migration can tell an old document from a new one without guessing.
+/// Bumping it is a semver event for the stored contract (ADR 0001 §12.2).
+pub const SESSION_V2_SCHEMA_VERSION: u32 = 1;
+
+/// Shortest simulated step interval, in seconds.
+pub const MIN_STEP_INTERVAL_SECONDS: u64 = 1;
+
+/// Longest simulated step interval, in seconds — one 365-day year.
+pub const MAX_STEP_INTERVAL_SECONDS: u64 = 31_536_000;
+
+/// Seconds in a 365-day year, used to derive an interval from a `Custom`
+/// time frame expressed in periods per year.
+const SECONDS_PER_YEAR: u64 = 31_536_000;
+
+/// The calendar policy accepted today. Anything else is rejected so a stored
+/// simulation can never be reinterpreted under a policy it was not created
+/// with.
+const SUPPORTED_CALENDAR: &str = "weekdays_v1";
+
+/// Derives the simulated step interval from a stochastic-model time frame.
+///
+/// `time_frame` scales the model; `step_interval_seconds` drives the simulated
+/// clock. They are allowed to differ, and this is only the default used when
+/// the request omits the interval.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `step_interval_seconds` when the
+/// frame has no usable second-length: `Microsecond` and `Millisecond` derive to
+/// less than one second, and a small `Custom` periods-per-year derives to more
+/// than a year. Both are rejected rather than silently clamped, because a
+/// clamped interval would silently change the simulated clock.
+fn derive_step_interval_seconds(time_frame: TimeFrame) -> Result<u64, ChainError> {
+    let too_small = || ChainError::Validation {
+        field: "step_interval_seconds".to_string(),
+        reason: format!(
+            "cannot be derived from time_frame {time_frame:?}: it is shorter than {MIN_STEP_INTERVAL_SECONDS} second; supply step_interval_seconds explicitly"
+        ),
+    };
+
+    let seconds = match time_frame {
+        TimeFrame::Microsecond | TimeFrame::Millisecond => return Err(too_small()),
+        TimeFrame::Second => 1,
+        TimeFrame::Minute => 60,
+        TimeFrame::Hour => 3_600,
+        TimeFrame::Day => 86_400,
+        TimeFrame::Week => 604_800,
+        TimeFrame::Month => 2_592_000,
+        TimeFrame::Quarter => 7_776_000,
+        TimeFrame::Year => SECONDS_PER_YEAR,
+        TimeFrame::Custom(periods_per_year) => {
+            let periods = periods_per_year.to_f64();
+            if periods <= 0.0 || !periods.is_finite() {
+                return Err(ChainError::Validation {
+                    field: "time_frame".to_string(),
+                    reason: format!(
+                        "custom periods per year must be finite and positive, got {periods}"
+                    ),
+                });
+            }
+            let seconds = (SECONDS_PER_YEAR as f64 / periods).round();
+            if !(MIN_STEP_INTERVAL_SECONDS as f64..=MAX_STEP_INTERVAL_SECONDS as f64)
+                .contains(&seconds)
+            {
+                return Err(ChainError::Validation {
+                    field: "step_interval_seconds".to_string(),
+                    reason: format!(
+                        "derived interval {seconds} s is outside [{MIN_STEP_INTERVAL_SECONDS}, {MAX_STEP_INTERVAL_SECONDS}]; supply step_interval_seconds explicitly"
+                    ),
+                });
+            }
+            seconds as u64
+        }
+    };
+
+    Ok(seconds)
+}
+
+/// Validates an explicitly-supplied step interval.
+fn validate_step_interval_seconds(seconds: u64) -> Result<u64, ChainError> {
+    if !(MIN_STEP_INTERVAL_SECONDS..=MAX_STEP_INTERVAL_SECONDS).contains(&seconds) {
+        return Err(ChainError::Validation {
+            field: "step_interval_seconds".to_string(),
+            reason: format!(
+                "must be within [{MIN_STEP_INTERVAL_SECONDS}, {MAX_STEP_INTERVAL_SECONDS}], got {seconds}"
+            ),
+        });
+    }
+    Ok(seconds)
+}
+
+/// Parses the local expiration time, accepting `HH:MM` and `HH:MM:SS`.
+fn parse_expiration_time(raw: &str) -> Result<NaiveTime, ChainError> {
+    NaiveTime::parse_from_str(raw, "%H:%M:%S")
+        .or_else(|_| NaiveTime::parse_from_str(raw, "%H:%M"))
+        .map_err(|_| ChainError::Validation {
+            field: "expiration_time".to_string(),
+            reason: format!("must be a local time as HH:MM or HH:MM:SS, got {raw:?}"),
+        })
+}
+
+/// Parses an IANA time-zone name.
+fn parse_timezone(raw: &str) -> Result<Tz, ChainError> {
+    Tz::from_str(raw).map_err(|_| ChainError::Validation {
+        field: "timezone".to_string(),
+        reason: format!("must be a known IANA time-zone name, got {raw:?}"),
+    })
+}
+
+/// Parses the calendar policy version.
+fn parse_calendar(raw: Option<&str>) -> Result<CalendarVersion, ChainError> {
+    match raw.unwrap_or(SUPPORTED_CALENDAR) {
+        SUPPORTED_CALENDAR => Ok(CalendarVersion::WeekdaysV1),
+        other => Err(ChainError::Validation {
+            field: "calendar".to_string(),
+            reason: format!("must be {SUPPORTED_CALENDAR}, got {other:?}"),
+        }),
+    }
+}
+
+/// Normalises an instant to whole-second UTC.
+///
+/// Truncating the sub-second part is what lets every timestamp in the API and
+/// in the exports render as `YYYY-MM-DDTHH:MM:SSZ`, which is in turn what makes
+/// a repeated export byte-comparable (ADR 0001 §3.1).
+fn to_whole_second_utc(instant: DateTime<Utc>) -> Result<DateTime<Utc>, ChainError> {
+    instant
+        .with_nanosecond(0)
+        .ok_or_else(|| ChainError::Validation {
+            field: "start_at".to_string(),
+            reason: format!("{instant} cannot be normalised to a whole second"),
+        })
+}
+
+/// The resolved parameters of a v2 rolling simulation.
+///
+/// Every field is effective: nothing here is still waiting to be defaulted. The
+/// set of fields is exactly the replay input list of ADR 0001 §8, which is what
+/// lets a client reproduce a run from the creation response alone.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SimulationParametersV2 {
+    /// Ticker symbol of the underlying.
+    pub symbol: String,
+    /// Number of steps the simulation runs for.
+    pub steps: usize,
+    /// The resolved simulated start, in whole-second UTC.
+    pub effective_start: DateTime<Utc>,
+    /// The resolved interval between simulated steps, in seconds.
+    pub step_interval_seconds: u64,
+    /// Time frame the stochastic model is scaled by.
+    pub time_frame: TimeFrame,
+    /// The normalised rolling expiration schedule.
+    pub schedule: ExpirationSchedule,
+    /// The IANA time-zone database release the expirations were resolved
+    /// against, e.g. `2025b`. A replay against a different release is still a
+    /// replay — it is just one the client can detect (ADR 0001 §8).
+    pub tzdb_version: String,
+    /// Initial price of the underlying.
+    pub initial_price: Positive,
+    /// Initial volatility.
+    pub volatility: Positive,
+    /// Annualised risk-free rate.
+    pub risk_free_rate: Decimal,
+    /// Annualised dividend yield.
+    pub dividend_yield: Positive,
+    /// The stochastic model driving the underlying path.
+    pub method: SimulationMethod,
+    /// Number of strikes per chain.
+    pub chain_size: Option<usize>,
+    /// Interval between strikes.
+    pub strike_interval: Option<Positive>,
+    /// Slope of the volatility skew.
+    pub skew_slope: Option<Decimal>,
+    /// Curvature of the volatility smile.
+    pub smile_curve: Option<Decimal>,
+    /// Bid-ask spread factor.
+    pub spread: Option<Positive>,
+    /// The effective RNG seed. Non-optional: a v2 simulation is always
+    /// reproducible, so the seed is resolved at conversion and never `None`.
+    pub seed: u64,
+}
+
+impl SimulationParametersV2 {
+    /// The simulated instant at `cursor`.
+    ///
+    /// `effective_start + cursor × step_interval`, with checked arithmetic
+    /// throughout. Never reads the wall clock, so the same parameters derive
+    /// the same instant on every call, in every process.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming `steps` when the product or
+    /// the sum leaves the representable range — an overflow is a rejected
+    /// request, never a wrapped timestamp.
+    pub fn simulated_at(&self, cursor: usize) -> Result<DateTime<Utc>, ChainError> {
+        let overflow = || ChainError::Validation {
+            field: "steps".to_string(),
+            reason: format!(
+                "simulated time overflows at cursor {cursor} with a {} s interval",
+                self.step_interval_seconds
+            ),
+        };
+
+        let cursor = i64::try_from(cursor).map_err(|_| overflow())?;
+        let interval = i64::try_from(self.step_interval_seconds).map_err(|_| overflow())?;
+        let offset = cursor.checked_mul(interval).ok_or_else(overflow)?;
+        let delta = TimeDelta::try_seconds(offset).ok_or_else(overflow)?;
+
+        self.effective_start
+            .checked_add_signed(delta)
+            .ok_or_else(overflow)
+    }
+
+    /// The simulated instant one step past the last one served, i.e. the end of
+    /// the simulated horizon.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the horizon overflows.
+    pub fn simulated_end(&self) -> Result<DateTime<Utc>, ChainError> {
+        self.simulated_at(self.steps)
+    }
+}
+
+impl fmt::Display for SimulationParametersV2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let json = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
+    type Error = ChainError;
+
+    /// Validates a client-supplied [`CreateSimulationRequest`] and resolves it
+    /// into effective parameters.
+    ///
+    /// This is the single place where the v2 REST `f64` / string boundary
+    /// becomes `Positive` / `Decimal` / `Tz` / `NaiveTime`, mirroring what
+    /// `TryFrom<CreateSessionRequest>` does for v1. Three values are *resolved*
+    /// here rather than merely converted, and all three are surfaced back to the
+    /// client so the tape can be replayed:
+    ///
+    /// - the **seed**, generated when absent, as in v1;
+    /// - the **effective start**, generated when absent and normalised to
+    ///   whole-second UTC — the only wall-clock read in a v2 simulation's whole
+    ///   life;
+    /// - the **step interval**, derived from `time_frame` when absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the first field that fails.
+    fn try_from(request: CreateSimulationRequest) -> Result<Self, Self::Error> {
+        if request.steps < 1 {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "must be at least 1".to_string(),
+            });
+        }
+        if request.steps > *MAX_STEPS {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_STEPS, request.steps),
+            });
+        }
+        if let Some(chain_size) = request.chain_size
+            && chain_size > *MAX_CHAIN_SIZE
+        {
+            return Err(ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_CHAIN_SIZE, chain_size),
+            });
+        }
+        symbol_field("symbol", &request.symbol)?;
+
+        let time_frame = time_frame_field("time_frame", request.time_frame)?;
+        let step_interval_seconds = match request.step_interval_seconds {
+            Some(seconds) => validate_step_interval_seconds(seconds)?,
+            None => derive_step_interval_seconds(time_frame)?,
+        };
+
+        // The one wall-clock read in a v2 simulation's life. Everything
+        // downstream is a function of this value and the cursor.
+        let effective_start = to_whole_second_utc(request.start_at.unwrap_or_else(Utc::now))?;
+
+        let schedule = ExpirationSchedule::new(
+            parse_calendar(request.calendar.as_deref())?,
+            parse_timezone(&request.timezone)?,
+            parse_expiration_time(&request.expiration_time)?,
+            request.schedules,
+        )?;
+
+        Ok(Self {
+            symbol: request.symbol,
+            steps: request.steps,
+            effective_start,
+            step_interval_seconds,
+            time_frame,
+            schedule,
+            tzdb_version: tzdb_version().to_string(),
+            initial_price: strictly_positive_field("initial_price", request.initial_price)?,
+            volatility: strictly_positive_field("volatility", request.volatility)?,
+            risk_free_rate: decimal_field("risk_free_rate", request.risk_free_rate)?,
+            dividend_yield: positive_field("dividend_yield", request.dividend_yield)?,
+            method: request.method.try_into()?,
+            chain_size: request.chain_size,
+            strike_interval: request
+                .strike_interval
+                .map(|value| strictly_positive_field("strike_interval", value))
+                .transpose()?,
+            skew_slope: request
+                .skew_slope
+                .map(|value| decimal_field("skew_slope", value))
+                .transpose()?,
+            smile_curve: request
+                .smile_curve
+                .map(|value| decimal_field("smile_curve", value))
+                .transpose()?,
+            spread: request
+                .spread
+                .map(|value| positive_field("spread", value))
+                .transpose()?,
+            seed: request.seed.unwrap_or_else(|| rand::rng().random()),
+        })
+    }
+}
+
+/// A v2 rolling simulation session.
+///
+/// Reuses the v1 [`SessionState`] machine, but only three of its states are
+/// reachable: `Initialized → InProgress → Completed`. A v2 simulation is
+/// immutable after creation, so `Modified` and `Reinitialized` — the PATCH and
+/// PUT branches — cannot occur.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionV2 {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// The stored-schema version this document was written under.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// When the simulation was created, in real time. Unrelated to the
+    /// simulated clock, which may span years.
+    pub created_at: SystemTime,
+    /// When the simulation was last written, in real time.
+    pub updated_at: SystemTime,
+    /// The resolved parameters. Immutable for the simulation's lifetime.
+    pub parameters: SimulationParametersV2,
+    /// The 0-based index of the next snapshot to serve.
+    pub current_step: usize,
+    /// The total number of snapshots the simulation serves.
+    pub total_steps: usize,
+    /// The lifecycle state.
+    pub state: SessionState,
+    /// Optimistic-concurrency revision, bumped immediately before every
+    /// compare-and-swap save, exactly as in v1.
+    pub version: u64,
+}
+
+/// The schema version assumed for a stored document written before the field
+/// existed. There is no such document today — v2 has shipped with the field
+/// from its first release — but defaulting keeps a future reader honest.
+fn default_schema_version() -> u32 {
+    SESSION_V2_SCHEMA_VERSION
+}
+
+impl SessionV2 {
+    /// Creates a simulation from resolved parameters.
+    #[must_use]
+    pub fn new(parameters: SimulationParametersV2, uuid_generator: &UuidGenerator) -> Self {
+        let now = SystemTime::now();
+        Self {
+            id: uuid_generator.next(),
+            schema_version: SESSION_V2_SCHEMA_VERSION,
+            created_at: now,
+            updated_at: now,
+            current_step: 0,
+            total_steps: parameters.steps,
+            parameters,
+            state: SessionState::Initialized,
+            version: 0,
+        }
+    }
+
+    /// The simulated instant of the snapshot the cursor currently points at.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the simulated clock overflows.
+    pub fn simulated_at(&self) -> Result<DateTime<Utc>, ChainError> {
+        self.parameters.simulated_at(self.current_step)
+    }
+
+    /// Whether the cursor has served every snapshot.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.current_step >= self.total_steps
+    }
+
+    /// Bumps the optimistic-concurrency revision, returning the value the
+    /// caller must pass as `expected_version` to the compare-and-swap save.
+    ///
+    /// Mirrors the v1 helper: the caller reads a simulation, captures its
+    /// `version`, mutates a clone, bumps, and saves with the captured value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the revision counter would
+    /// overflow, which is unreachable in practice but must not wrap.
+    pub fn bump_version(&mut self) -> Result<u64, ChainError> {
+        let expected = self.version;
+        self.version = self.version.checked_add(1).ok_or_else(|| {
+            ChainError::Internal(format!(
+                "version counter overflowed for simulation {}",
+                self.id
+            ))
+        })?;
+        self.updated_at = SystemTime::now();
+        Ok(expected)
+    }
+}
+
+impl fmt::Display for SessionV2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let json = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        write!(f, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind};
+    use chrono::{TimeZone, Weekday};
+    use positive::pos_or_panic;
+
+    /// The reference configuration from ADR 0001 §14.1, as a request.
+    fn reference_request() -> CreateSimulationRequest {
+        CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 500,
+            start_at: Some(instant(2026, 1, 5, 14, 30)),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: Some("weekdays_v1".to_string()),
+            expiration_time: "17:00".to_string(),
+            schedules: vec![
+                rule("zero_dte", ExpiryRuleKind::Daily, 1),
+                rule(
+                    "weeklies",
+                    ExpiryRuleKind::weekly([Weekday::Mon, Weekday::Wed, Weekday::Fri]),
+                    3,
+                ),
+                rule(
+                    "monthlies",
+                    ExpiryRuleKind::Monthly {
+                        weekday: Weekday::Fri,
+                    },
+                    12,
+                ),
+            ],
+            initial_price: 5000.0,
+            volatility: 0.18,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.012,
+            method: ApiWalkType::GeometricBrownian {
+                dt: 0.004,
+                drift: 0.05,
+                volatility: 0.18,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(15),
+            strike_interval: Some(25.0),
+            skew_slope: Some(-0.2),
+            smile_curve: Some(0.4),
+            spread: Some(0.02),
+            seed: Some(42),
+        }
+    }
+
+    fn rule(id: &str, kind: ExpiryRuleKind, count: usize) -> ExpiryRule {
+        match ExpiryRule::new(id, kind, count) {
+            Ok(rule) => rule,
+            Err(error) => panic!("test rule must be valid: {error}"),
+        }
+    }
+
+    fn instant(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Utc> {
+        match Utc
+            .with_ymd_and_hms(year, month, day, hour, minute, 0)
+            .single()
+        {
+            Some(instant) => instant,
+            None => panic!("test instant must be valid"),
+        }
+    }
+
+    fn parameters(request: CreateSimulationRequest) -> SimulationParametersV2 {
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the request must convert: {error}"),
+        }
+    }
+
+    fn generator() -> UuidGenerator {
+        match Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE) {
+            Ok(namespace) => UuidGenerator::new(namespace),
+            Err(error) => panic!("the default namespace must parse: {error}"),
+        }
+    }
+
+    // ---- resolution ------------------------------------------------------
+
+    /// The reference request converts, and every effective value is resolved.
+    #[test]
+    fn test_reference_request_converts_to_effective_parameters() {
+        let parameters = parameters(reference_request());
+
+        assert_eq!(parameters.symbol, "SPX");
+        assert_eq!(parameters.steps, 500);
+        assert_eq!(parameters.seed, 42);
+        assert_eq!(parameters.effective_start, instant(2026, 1, 5, 14, 30));
+        assert_eq!(parameters.step_interval_seconds, 86_400);
+        assert_eq!(parameters.time_frame, TimeFrame::Day);
+        assert_eq!(parameters.schedule.rules().len(), 3);
+        assert_eq!(parameters.initial_price, pos_or_panic!(5000.0));
+        assert!(!parameters.tzdb_version.is_empty());
+    }
+
+    /// An omitted seed is generated and surfaced, exactly as in v1.
+    #[test]
+    fn test_omitted_seed_is_generated_and_surfaced() {
+        let mut request = reference_request();
+        request.seed = None;
+
+        // The generated seed is random, so the observable guarantee is that a
+        // seed exists and is echoed — not that it has a particular value.
+        let first = parameters(request.clone());
+        let second = parameters(request);
+
+        assert_ne!(
+            first.seed, second.seed,
+            "two unseeded requests must not share a seed"
+        );
+    }
+
+    /// An omitted start is generated once, normalised to whole-second UTC, and
+    /// then never re-derived.
+    #[test]
+    fn test_omitted_start_is_generated_once_and_normalised() {
+        let mut request = reference_request();
+        request.start_at = None;
+
+        let parameters = parameters(request);
+
+        assert_eq!(parameters.effective_start.nanosecond(), 0);
+        // Reading it again yields the same value: it is stored, not recomputed.
+        assert_eq!(parameters.effective_start, parameters.effective_start);
+        match parameters.simulated_at(0) {
+            Ok(at) => assert_eq!(at, parameters.effective_start),
+            Err(error) => panic!("cursor 0 must resolve: {error}"),
+        }
+    }
+
+    /// A supplied start with sub-second precision is truncated, so every
+    /// timestamp renders without a fractional part.
+    #[test]
+    fn test_supplied_start_is_truncated_to_whole_seconds() {
+        let mut request = reference_request();
+        request.start_at = Some(instant(2026, 1, 5, 14, 30) + TimeDelta::milliseconds(750));
+
+        let parameters = parameters(request);
+
+        assert_eq!(parameters.effective_start, instant(2026, 1, 5, 14, 30));
+    }
+
+    /// An omitted interval is derived from the time frame.
+    #[test]
+    fn test_omitted_step_interval_is_derived_from_the_time_frame() {
+        let mut request = reference_request();
+        request.step_interval_seconds = None;
+        request.time_frame = ApiTimeFrame::Hour;
+
+        let parameters = parameters(request);
+
+        assert_eq!(parameters.step_interval_seconds, 3_600);
+    }
+
+    /// A time frame shorter than a second cannot derive an interval, and says
+    /// so rather than clamping to one second.
+    #[test]
+    fn test_sub_second_time_frame_cannot_derive_an_interval() {
+        let mut request = reference_request();
+        request.step_interval_seconds = None;
+        request.time_frame = ApiTimeFrame::Microsecond;
+
+        match SimulationParametersV2::try_from(request) {
+            Err(ChainError::Validation { field, .. }) => {
+                assert_eq!(field, "step_interval_seconds");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A custom time frame coarser than a year cannot derive an interval
+    /// either.
+    #[test]
+    fn test_custom_time_frame_beyond_a_year_cannot_derive_an_interval() {
+        let mut request = reference_request();
+        request.step_interval_seconds = None;
+        // Half a period per year is a two-year step.
+        request.time_frame = ApiTimeFrame::Custom(0.5);
+
+        match SimulationParametersV2::try_from(request) {
+            Err(ChainError::Validation { field, .. }) => {
+                assert_eq!(field, "step_interval_seconds");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A custom time frame within range derives cleanly.
+    #[test]
+    fn test_custom_time_frame_within_range_derives_an_interval() {
+        let mut request = reference_request();
+        request.step_interval_seconds = None;
+        request.time_frame = ApiTimeFrame::Custom(365.0);
+
+        let parameters = parameters(request);
+
+        assert_eq!(parameters.step_interval_seconds, 86_400);
+    }
+
+    /// An explicit interval outside the accepted range is rejected.
+    #[test]
+    fn test_out_of_range_step_interval_is_rejected() {
+        for seconds in [0, MAX_STEP_INTERVAL_SECONDS + 1] {
+            let mut request = reference_request();
+            request.step_interval_seconds = Some(seconds);
+
+            match SimulationParametersV2::try_from(request) {
+                Err(ChainError::Validation { field, .. }) => {
+                    assert_eq!(field, "step_interval_seconds");
+                }
+                other => panic!("expected a validation error for {seconds}, got {other:?}"),
+            }
+        }
+    }
+
+    // ---- the simulated clock --------------------------------------------
+
+    /// `simulated_at` is `effective_start + cursor × interval`, and never reads
+    /// the wall clock.
+    #[test]
+    fn test_simulated_at_is_start_plus_cursor_times_interval() {
+        let parameters = parameters(reference_request());
+
+        match (parameters.simulated_at(0), parameters.simulated_at(3)) {
+            (Ok(first), Ok(fourth)) => {
+                assert_eq!(first, instant(2026, 1, 5, 14, 30));
+                assert_eq!(fourth, instant(2026, 1, 8, 14, 30));
+            }
+            (first, fourth) => panic!("both cursors must resolve: {first:?} {fourth:?}"),
+        }
+    }
+
+    /// The same parameters derive the same instant for every cursor, call after
+    /// call.
+    #[test]
+    fn test_simulated_at_is_stable_across_calls() {
+        let parameters = parameters(reference_request());
+
+        for cursor in [0, 1, 17, 499] {
+            match (
+                parameters.simulated_at(cursor),
+                parameters.simulated_at(cursor),
+            ) {
+                (Ok(first), Ok(second)) => assert_eq!(first, second),
+                (first, second) => panic!("cursor {cursor} must resolve: {first:?} {second:?}"),
+            }
+        }
+    }
+
+    /// The horizon is one interval past the last served snapshot.
+    #[test]
+    fn test_simulated_end_is_one_interval_past_the_last_step() {
+        let mut request = reference_request();
+        request.steps = 3;
+        let parameters = parameters(request);
+
+        match parameters.simulated_end() {
+            Ok(end) => assert_eq!(end, instant(2026, 1, 8, 14, 30)),
+            Err(error) => panic!("the horizon must resolve: {error}"),
+        }
+    }
+
+    /// A cursor that would overflow the simulated clock is a typed error, never
+    /// a wrapped timestamp.
+    #[test]
+    fn test_simulated_at_overflow_is_a_typed_error() {
+        let mut parameters = parameters(reference_request());
+        parameters.step_interval_seconds = MAX_STEP_INTERVAL_SECONDS;
+
+        match parameters.simulated_at(usize::MAX) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "steps");
+                assert!(reason.contains("overflow"));
+            }
+            other => panic!("expected an overflow error, got {other:?}"),
+        }
+    }
+
+    // ---- validation ------------------------------------------------------
+
+    /// Each invalid field is rejected by name, and no path panics.
+    #[test]
+    fn test_invalid_fields_are_rejected_by_name() {
+        /// One invalid-field case: the field the error must name, and the
+        /// mutation that makes the request invalid.
+        type Case = (&'static str, Box<dyn Fn(&mut CreateSimulationRequest)>);
+
+        let cases: Vec<Case> = vec![
+            (
+                "steps",
+                Box::new(|r: &mut CreateSimulationRequest| r.steps = 0),
+            ),
+            (
+                "symbol",
+                Box::new(|r: &mut CreateSimulationRequest| r.symbol = "bad symbol!".to_string()),
+            ),
+            (
+                "timezone",
+                Box::new(|r: &mut CreateSimulationRequest| r.timezone = "Mars/Olympus".to_string()),
+            ),
+            (
+                "expiration_time",
+                Box::new(|r: &mut CreateSimulationRequest| r.expiration_time = "25:00".to_string()),
+            ),
+            (
+                "calendar",
+                Box::new(|r: &mut CreateSimulationRequest| {
+                    r.calendar = Some("weekdays_v9".to_string())
+                }),
+            ),
+            (
+                "initial_price",
+                Box::new(|r: &mut CreateSimulationRequest| r.initial_price = 0.0),
+            ),
+            (
+                "volatility",
+                Box::new(|r: &mut CreateSimulationRequest| r.volatility = f64::NAN),
+            ),
+            (
+                "risk_free_rate",
+                Box::new(|r: &mut CreateSimulationRequest| r.risk_free_rate = f64::INFINITY),
+            ),
+            (
+                "dividend_yield",
+                Box::new(|r: &mut CreateSimulationRequest| r.dividend_yield = -1.0),
+            ),
+            (
+                "strike_interval",
+                Box::new(|r: &mut CreateSimulationRequest| r.strike_interval = Some(0.0)),
+            ),
+            (
+                "chain_size",
+                Box::new(|r: &mut CreateSimulationRequest| r.chain_size = Some(usize::MAX)),
+            ),
+        ];
+
+        for (field, mutate) in cases {
+            let mut request = reference_request();
+            mutate(&mut request);
+
+            match SimulationParametersV2::try_from(request) {
+                Err(ChainError::Validation { field: named, .. }) => {
+                    assert_eq!(named, field, "wrong field named for {field}");
+                }
+                other => panic!("expected a validation error for {field}, got {other:?}"),
+            }
+        }
+    }
+
+    /// An empty schedule is rejected through the same domain validation the
+    /// planner uses.
+    #[test]
+    fn test_empty_schedule_is_rejected() {
+        let mut request = reference_request();
+        request.schedules = Vec::new();
+
+        match SimulationParametersV2::try_from(request) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "schedules"),
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// `HH:MM:SS` is accepted as well as `HH:MM`.
+    #[test]
+    fn test_expiration_time_accepts_both_precisions() {
+        for raw in ["17:00", "17:00:00"] {
+            let mut request = reference_request();
+            request.expiration_time = raw.to_string();
+
+            let parameters = parameters(request);
+            match NaiveTime::from_hms_opt(17, 0, 0) {
+                Some(expected) => {
+                    assert_eq!(parameters.schedule.expiration_time(), expected)
+                }
+                None => panic!("17:00:00 must be a valid time"),
+            }
+        }
+    }
+
+    /// An omitted calendar defaults to the only supported policy.
+    #[test]
+    fn test_omitted_calendar_defaults_to_weekdays_v1() {
+        let mut request = reference_request();
+        request.calendar = None;
+
+        let parameters = parameters(request);
+
+        assert_eq!(parameters.schedule.calendar(), CalendarVersion::WeekdaysV1);
+    }
+
+    // ---- persistence shape ----------------------------------------------
+
+    /// The parameters round-trip through serde, which is what the stores rely
+    /// on.
+    #[test]
+    fn test_parameters_round_trip_through_serde() {
+        let parameters = parameters(reference_request());
+
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SimulationParametersV2>(&json) {
+            Ok(round_tripped) => assert_eq!(round_tripped, parameters),
+            Err(error) => panic!("must deserialize: {error}"),
+        }
+    }
+
+    /// A stored simulation round-trips, keeping its schema version, cursor and
+    /// revision.
+    #[test]
+    fn test_simulation_round_trips_through_serde() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SessionV2>(&json) {
+            Ok(round_tripped) => {
+                assert_eq!(round_tripped, simulation);
+                assert_eq!(round_tripped.schema_version, SESSION_V2_SCHEMA_VERSION);
+            }
+            Err(error) => panic!("must deserialize: {error}"),
+        }
+    }
+
+    /// The stored document carries an explicit schema version, so a future
+    /// migration can tell documents apart without inferring from their shape.
+    #[test]
+    fn test_stored_document_carries_an_explicit_schema_version() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+
+        let value = match serde_json::to_value(&simulation) {
+            Ok(value) => value,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        assert_eq!(
+            value
+                .get("schema_version")
+                .and_then(serde_json::Value::as_u64),
+            Some(u64::from(SESSION_V2_SCHEMA_VERSION))
+        );
+    }
+
+    /// The stored schedule keeps the wire shape ADR 0001 §14.2 specifies.
+    #[test]
+    fn test_stored_schedule_keeps_the_documented_shape() {
+        let parameters = parameters(reference_request());
+
+        let value = match serde_json::to_value(&parameters) {
+            Ok(value) => value,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        let schedule = match value.get("schedule") {
+            Some(schedule) => schedule,
+            None => panic!("the parameters must carry a schedule"),
+        };
+        assert_eq!(
+            schedule.get("timezone").and_then(serde_json::Value::as_str),
+            Some("America/New_York")
+        );
+        assert_eq!(
+            schedule.get("calendar").and_then(serde_json::Value::as_str),
+            Some("weekdays_v1")
+        );
+        assert_eq!(
+            schedule
+                .get("expiration_time")
+                .and_then(serde_json::Value::as_str),
+            Some("17:00:00")
+        );
+    }
+
+    // ---- lifecycle -------------------------------------------------------
+
+    /// A new simulation starts at cursor zero, revision zero, Initialized.
+    #[test]
+    fn test_new_simulation_starts_initialized_at_cursor_zero() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+
+        assert_eq!(simulation.current_step, 0);
+        assert_eq!(simulation.total_steps, 500);
+        assert_eq!(simulation.version, 0);
+        assert_eq!(simulation.state, SessionState::Initialized);
+        assert!(!simulation.is_complete());
+    }
+
+    /// Bumping the revision returns the value a compare-and-swap must expect.
+    #[test]
+    fn test_bump_version_returns_the_expected_revision() {
+        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+
+        match simulation.bump_version() {
+            Ok(expected) => {
+                assert_eq!(expected, 0);
+                assert_eq!(simulation.version, 1);
+            }
+            Err(error) => panic!("must bump: {error}"),
+        }
+    }
+
+    /// A revision counter at its maximum is an error rather than a wrap that
+    /// would let a stale writer pass the compare-and-swap.
+    #[test]
+    fn test_bump_version_overflow_is_a_typed_error() {
+        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+        simulation.version = u64::MAX;
+
+        match simulation.bump_version() {
+            Err(ChainError::Internal(reason)) => assert!(reason.contains("overflow")),
+            other => panic!("expected an internal error, got {other:?}"),
+        }
+    }
+
+    /// Completion is a cursor comparison, not a stored flag.
+    #[test]
+    fn test_is_complete_tracks_the_cursor() {
+        let mut request = reference_request();
+        request.steps = 2;
+        let mut simulation = SessionV2::new(parameters(request), &generator());
+
+        assert!(!simulation.is_complete());
+        simulation.current_step = 2;
+        assert!(simulation.is_complete());
+    }
+
+    /// The simulation's own `simulated_at` follows its cursor.
+    #[test]
+    fn test_simulation_simulated_at_follows_the_cursor() {
+        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+        simulation.current_step = 2;
+
+        match simulation.simulated_at() {
+            Ok(at) => assert_eq!(at, instant(2026, 1, 7, 14, 30)),
+            Err(error) => panic!("must resolve: {error}"),
+        }
+    }
+}

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
+use tracing::warn;
 use uuid::Uuid;
 
 /// Schema version stamped on every stored v2 session.
@@ -46,10 +47,17 @@ use uuid::Uuid;
 pub const SESSION_V2_SCHEMA_VERSION: u32 = 1;
 
 /// Shortest simulated step interval, in seconds.
-pub const MIN_STEP_INTERVAL_SECONDS: u64 = 1;
+///
+/// Crate-internal on purpose: issue #48 turns the v2 bounds into validated
+/// `OCS_MAX_*` environment knobs following the `LazyLock` pattern in
+/// `api::rest::limits`, and publishing them as `const u64` first would make
+/// that conversion a breaking change to a released item.
+pub(crate) const MIN_STEP_INTERVAL_SECONDS: u64 = 1;
 
 /// Longest simulated step interval, in seconds — one 365-day year.
-pub const MAX_STEP_INTERVAL_SECONDS: u64 = 31_536_000;
+///
+/// Crate-internal for the same reason as [`MIN_STEP_INTERVAL_SECONDS`].
+pub(crate) const MAX_STEP_INTERVAL_SECONDS: u64 = 31_536_000;
 
 /// Seconds in a 365-day year, used to derive an interval from a `Custom`
 /// time frame expressed in periods per year.
@@ -181,6 +189,7 @@ fn to_whole_second_utc(instant: DateTime<Utc>) -> Result<DateTime<Utc>, ChainErr
 /// set of fields is exactly the replay input list of ADR 0001 §8, which is what
 /// lets a client reproduce a run from the creation response alone.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "SimulationParametersV2Wire")]
 pub struct SimulationParametersV2 {
     /// Ticker symbol of the underlying.
     pub symbol: String,
@@ -223,7 +232,139 @@ pub struct SimulationParametersV2 {
     pub seed: u64,
 }
 
+/// The deserialization shape of [`SimulationParametersV2`].
+///
+/// Exists so that a stored document is validated exactly like a request. The
+/// fields are public and the type derives `Deserialize`, so without this a
+/// hand-edited or corrupted document in Redis would sail past every check the
+/// request path performs: a `step_interval_seconds` of `0` freezes the
+/// simulated clock, a `steps` above the cap drives an unbounded factor tape, a
+/// sub-second `effective_start` breaks the whole-second rendering that makes
+/// exports byte-comparable. Redis is an outer layer, and
+/// `rules/global_rules.md` is explicit that domain types must not trust one.
+///
+/// It also carries `deny_unknown_fields`, which turns the rolling-deploy
+/// hazard into a loud one: an old binary reading a document written by a newer
+/// one fails instead of silently dropping the new fields and writing the
+/// truncated document back.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SimulationParametersV2Wire {
+    symbol: String,
+    steps: usize,
+    effective_start: DateTime<Utc>,
+    step_interval_seconds: u64,
+    time_frame: TimeFrame,
+    schedule: ExpirationSchedule,
+    tzdb_version: String,
+    initial_price: Positive,
+    volatility: Positive,
+    risk_free_rate: Decimal,
+    dividend_yield: Positive,
+    method: SimulationMethod,
+    chain_size: Option<usize>,
+    strike_interval: Option<Positive>,
+    skew_slope: Option<Decimal>,
+    smile_curve: Option<Decimal>,
+    spread: Option<Positive>,
+    seed: u64,
+}
+
+impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
+    type Error = ChainError;
+
+    fn try_from(wire: SimulationParametersV2Wire) -> Result<Self, Self::Error> {
+        let parameters = Self {
+            symbol: wire.symbol,
+            steps: wire.steps,
+            effective_start: wire.effective_start,
+            step_interval_seconds: wire.step_interval_seconds,
+            time_frame: wire.time_frame,
+            schedule: wire.schedule,
+            tzdb_version: wire.tzdb_version,
+            initial_price: wire.initial_price,
+            volatility: wire.volatility,
+            risk_free_rate: wire.risk_free_rate,
+            dividend_yield: wire.dividend_yield,
+            method: wire.method,
+            chain_size: wire.chain_size,
+            strike_interval: wire.strike_interval,
+            skew_slope: wire.skew_slope,
+            smile_curve: wire.smile_curve,
+            spread: wire.spread,
+            seed: wire.seed,
+        };
+        parameters.validate()?;
+        Ok(parameters)
+    }
+}
+
 impl SimulationParametersV2 {
+    /// Re-checks every invariant the request path establishes.
+    ///
+    /// Called from the `Deserialize` path, so a stored document is held to the
+    /// same standard as a request. Cheap: a handful of comparisons and one
+    /// symbol check, run once per load.
+    ///
+    /// A `tzdb_version` that differs from the running binary's is a **warning**,
+    /// not a rejection: the simulation is still coherent, it was simply resolved
+    /// against a different IANA release, and refusing to load it would turn a
+    /// dependency bump into an outage. Issue #46 decides whether a mid-tape
+    /// divergence should be escalated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the offending field when
+    /// `steps` is outside `1..=MAX_STEPS`, `chain_size` exceeds
+    /// `MAX_CHAIN_SIZE`, the symbol violates the identifier format,
+    /// `step_interval_seconds` is outside its documented range, or
+    /// `effective_start` is not on a whole second.
+    pub fn validate(&self) -> Result<(), ChainError> {
+        if self.steps < 1 {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: "must be at least 1".to_string(),
+            });
+        }
+        if self.steps > *MAX_STEPS {
+            return Err(ChainError::Validation {
+                field: "steps".to_string(),
+                reason: format!("must not exceed {}, got {}", *MAX_STEPS, self.steps),
+            });
+        }
+        if let Some(chain_size) = self.chain_size
+            && chain_size > *MAX_CHAIN_SIZE
+        {
+            return Err(ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!("must not exceed {}, got {chain_size}", *MAX_CHAIN_SIZE),
+            });
+        }
+        symbol_field("symbol", &self.symbol)?;
+        validate_step_interval_seconds(self.step_interval_seconds)?;
+        if self.effective_start.nanosecond() != 0 {
+            return Err(ChainError::Validation {
+                field: "effective_start".to_string(),
+                reason: format!(
+                    "must be on a whole second, got {}",
+                    self.effective_start.to_rfc3339()
+                ),
+            });
+        }
+        self.schedule.validate()?;
+
+        let running = tzdb_version();
+        if self.tzdb_version != running {
+            warn!(
+                stored = %self.tzdb_version,
+                running = %running,
+                "simulation was resolved against a different IANA tzdb release"
+            );
+        }
+
+        Ok(())
+    }
+
     /// The simulated instant at `cursor`.
     ///
     /// `effective_start + cursor × step_interval`, with checked arithmetic
@@ -322,8 +463,11 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
             None => derive_step_interval_seconds(time_frame)?,
         };
 
-        // The one wall-clock read in a v2 simulation's life. Everything
-        // downstream is a function of this value and the cursor.
+        // The only wall-clock read that reaches simulation OUTPUT. Everything
+        // downstream — every simulated_at, expires_at and days_to_expiration —
+        // is a function of this value and the cursor. (`created_at` and
+        // `updated_at` also read the clock, but they are operational metadata
+        // and never enter the tape.)
         let effective_start = to_whole_second_utc(request.start_at.unwrap_or_else(Utc::now))?;
 
         let schedule = ExpirationSchedule::new(
@@ -375,6 +519,7 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
 /// immutable after creation, so `Modified` and `Reinitialized` — the PATCH and
 /// PUT branches — cannot occur.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "SessionV2Wire")]
 pub struct SessionV2 {
     /// Unique identifier.
     pub id: Uuid,
@@ -399,6 +544,50 @@ pub struct SessionV2 {
     pub version: u64,
 }
 
+/// The deserialization shape of [`SessionV2`], validated on the way in.
+///
+/// Mirrors the parameters' wire type for the same reason: a stored document is
+/// an outer-layer input. It additionally rejects the two states a v2 simulation
+/// can never legitimately be in, a cursor past its own horizon, and — the one
+/// that matters most operationally — a `schema_version` from the future, which
+/// during a rolling deploy would otherwise let an old replica read a newer
+/// document, drop what it does not understand, and write the truncated version
+/// back with an intact revision so the compare-and-swap succeeds.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SessionV2Wire {
+    id: Uuid,
+    #[serde(default = "default_schema_version")]
+    schema_version: u32,
+    created_at: SystemTime,
+    updated_at: SystemTime,
+    parameters: SimulationParametersV2,
+    current_step: usize,
+    total_steps: usize,
+    state: SessionState,
+    version: u64,
+}
+
+impl TryFrom<SessionV2Wire> for SessionV2 {
+    type Error = ChainError;
+
+    fn try_from(wire: SessionV2Wire) -> Result<Self, Self::Error> {
+        let simulation = Self {
+            id: wire.id,
+            schema_version: wire.schema_version,
+            created_at: wire.created_at,
+            updated_at: wire.updated_at,
+            parameters: wire.parameters,
+            current_step: wire.current_step,
+            total_steps: wire.total_steps,
+            state: wire.state,
+            version: wire.version,
+        };
+        simulation.validate()?;
+        Ok(simulation)
+    }
+}
+
 /// The schema version assumed for a stored document written before the field
 /// existed. There is no such document today — v2 has shipped with the field
 /// from its first release — but defaulting keeps a future reader honest.
@@ -421,6 +610,60 @@ impl SessionV2 {
             parameters,
             state: SessionState::Initialized,
             version: 0,
+        }
+    }
+
+    /// Re-checks every invariant a freshly-created simulation satisfies.
+    ///
+    /// Called from the `Deserialize` path, so a stored document cannot present
+    /// a state the lifecycle forbids.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the document carries a
+    /// `schema_version` this binary does not understand, a `total_steps` that
+    /// disagrees with its parameters, a cursor past its own horizon, or a state
+    /// unreachable for a v2 simulation (`Modified` and `Reinitialized` are the
+    /// PATCH and PUT branches, and a v2 simulation is immutable). Also
+    /// propagates the parameters' own validation.
+    pub fn validate(&self) -> Result<(), ChainError> {
+        if self.schema_version > SESSION_V2_SCHEMA_VERSION {
+            return Err(ChainError::Validation {
+                field: "schema_version".to_string(),
+                reason: format!(
+                    "document was written under schema {} but this binary understands at most {SESSION_V2_SCHEMA_VERSION}",
+                    self.schema_version
+                ),
+            });
+        }
+        self.parameters.validate()?;
+        if self.total_steps != self.parameters.steps {
+            return Err(ChainError::Validation {
+                field: "total_steps".to_string(),
+                reason: format!(
+                    "must equal the parameters' steps ({}), got {}",
+                    self.parameters.steps, self.total_steps
+                ),
+            });
+        }
+        if self.current_step > self.total_steps {
+            return Err(ChainError::Validation {
+                field: "current_step".to_string(),
+                reason: format!(
+                    "must not exceed total_steps ({}), got {}",
+                    self.total_steps, self.current_step
+                ),
+            });
+        }
+        match self.state {
+            SessionState::Modified | SessionState::Reinitialized => Err(ChainError::Validation {
+                field: "state".to_string(),
+                reason: format!(
+                    "{} is unreachable for a v2 simulation, which is immutable after creation",
+                    self.state
+                ),
+            }),
+            _ => Ok(()),
         }
     }
 
@@ -920,7 +1163,12 @@ mod tests {
         );
     }
 
-    /// The stored schedule keeps the wire shape ADR 0001 §14.2 specifies.
+    /// The stored schedule keeps its documented wire shape.
+    ///
+    /// This is the *storage* form: the schedule nests under `schedule` with its
+    /// rules under `rules`. ADR 0001 §14.2 shows the *response* form, which is
+    /// flat inside `parameters` with the array named `schedules`; #47 owns that
+    /// mapping.
     #[test]
     fn test_stored_schedule_keeps_the_documented_shape() {
         let parameters = parameters(reference_request());
@@ -947,6 +1195,177 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("17:00:00")
         );
+    }
+
+    // ---- stored input is not trusted -------------------------------------
+
+    /// Deserialization runs the same validation as the request path.
+    ///
+    /// Without it a hand-edited or corrupted document in Redis sails past every
+    /// check: `rules/global_rules.md` is explicit that a domain type must not
+    /// trust an outer layer, and Redis is one.
+    #[test]
+    fn test_stored_parameters_are_validated_on_load() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+
+        // Each tamper is a field the request path checks and a stored document
+        // could otherwise smuggle past.
+        let tampers = [
+            // A zero interval freezes the simulated clock: every snapshot would
+            // carry the same instant, the cutoff would never advance, and the
+            // rolling inventory would never roll.
+            (
+                r#""step_interval_seconds":86400"#,
+                r#""step_interval_seconds":0"#,
+                "step_interval_seconds",
+            ),
+            // A steps count above the cap drives an unbounded factor tape.
+            (r#""steps":500"#, r#""steps":100000000"#, "steps"),
+            // A sub-second start breaks the whole-second rendering that makes
+            // exports byte-comparable.
+            (
+                r#""effective_start":"2026-01-05T14:30:00Z""#,
+                r#""effective_start":"2026-01-05T14:30:00.5Z""#,
+                "effective_start",
+            ),
+            // A symbol carrying the CSV separators would corrupt the export
+            // column the rule-id charset was narrowed to protect.
+            (r#""symbol":"SPX""#, r#""symbol":"SPX,\"x\"|y""#, "symbol"),
+            // A chain size above the cap drives an unbounded strike ladder.
+            (r#""chain_size":15"#, r#""chain_size":100000"#, "chain_size"),
+        ];
+
+        for (from, to, field) in tampers {
+            let tampered = json.replace(from, to);
+            assert_ne!(tampered, json, "the tamper for {field} must have applied");
+
+            let error = match serde_json::from_str::<SimulationParametersV2>(&tampered) {
+                Ok(_) => panic!("a tampered {field} must be rejected on load"),
+                Err(error) => error.to_string(),
+            };
+            assert!(
+                error.contains(field),
+                "the error must name {field}, got {error}"
+            );
+        }
+    }
+
+    /// An unknown field in a stored document is an error, not a silent drop.
+    ///
+    /// During a rolling deploy an old replica would otherwise read a newer
+    /// document, discard what it does not understand, and write the truncated
+    /// version back with an intact revision — so the compare-and-swap succeeds
+    /// and the data is simply gone.
+    #[test]
+    fn test_stored_parameters_reject_an_unknown_field() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        let tampered = json.replace(r#""symbol":"SPX""#, r#""symbol":"SPX","a_future_field":1"#);
+
+        assert!(serde_json::from_str::<SimulationParametersV2>(&tampered).is_err());
+    }
+
+    /// A stored simulation from a newer schema is refused rather than silently
+    /// downgraded.
+    #[test]
+    fn test_stored_simulation_rejects_a_future_schema_version() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        let tampered = json.replace(
+            &format!(r#""schema_version":{SESSION_V2_SCHEMA_VERSION}"#),
+            r#""schema_version":99"#,
+        );
+
+        let error = match serde_json::from_str::<SessionV2>(&tampered) {
+            Ok(_) => panic!("a future schema version must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("schema_version"), "got {error}");
+    }
+
+    /// A stored simulation in a state the v2 lifecycle cannot reach is refused.
+    #[test]
+    fn test_stored_simulation_rejects_an_unreachable_state() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+
+        for state in ["Modified", "Reinitialized"] {
+            let tampered =
+                json.replace(r#""state":"Initialized""#, &format!(r#""state":"{state}""#));
+            assert_ne!(tampered, json, "the tamper for {state} must have applied");
+
+            let error = match serde_json::from_str::<SessionV2>(&tampered) {
+                Ok(_) => panic!("{state} must be rejected for a v2 simulation"),
+                Err(error) => error.to_string(),
+            };
+            assert!(error.contains("state"), "got {error}");
+        }
+    }
+
+    /// A cursor past its own horizon is refused, so no caller has to defend
+    /// against one.
+    #[test]
+    fn test_stored_simulation_rejects_a_cursor_past_the_horizon() {
+        let mut request = reference_request();
+        request.steps = 2;
+        let simulation = SessionV2::new(parameters(request), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        let tampered = json.replace(r#""current_step":0"#, r#""current_step":9999"#);
+
+        let error = match serde_json::from_str::<SessionV2>(&tampered) {
+            Ok(_) => panic!("a cursor past the horizon must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("current_step"), "got {error}");
+    }
+
+    /// A `total_steps` that disagrees with the parameters is refused.
+    #[test]
+    fn test_stored_simulation_rejects_a_mismatched_total_steps() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        let tampered = json.replace(r#""total_steps":500"#, r#""total_steps":7"#);
+
+        let error = match serde_json::from_str::<SessionV2>(&tampered) {
+            Ok(_) => panic!("a mismatched total_steps must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("total_steps"), "got {error}");
+    }
+
+    /// A valid stored document still loads, so the validation does not reject
+    /// what it should accept.
+    #[test]
+    fn test_a_valid_stored_simulation_still_loads() {
+        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let json = match serde_json::to_string(&simulation) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+
+        match serde_json::from_str::<SessionV2>(&json) {
+            Ok(loaded) => assert_eq!(loaded, simulation),
+            Err(error) => panic!("a valid document must load: {error}"),
+        }
     }
 
     // ---- lifecycle -------------------------------------------------------

--- a/src/session/store/in_redis.rs
+++ b/src/session/store/in_redis.rs
@@ -41,7 +41,11 @@ pub struct InRedisSessionStore {
 ///
 /// Return codes: `-1` = key missing (NotFound); `-2` = version mismatch
 /// (Conflict); `1` = written.
-const SAVE_CAS_SCRIPT: &str = r#"
+///
+/// Shared with the v2 simulation store (`super::v2_redis`): the script is
+/// parameterised entirely by its keys and arguments, so both key spaces run the
+/// same, already-reviewed compare-and-swap rather than two copies of it.
+pub(super) const SAVE_CAS_SCRIPT: &str = r#"
 local cur = redis.call('GET', KEYS[1])
 if not cur then
     return -1

--- a/src/session/store/mod.rs
+++ b/src/session/store/mod.rs
@@ -54,5 +54,5 @@ pub use in_memory::InMemorySessionStore;
 pub use in_redis::InRedisSessionStore;
 pub use interface::SessionStore;
 pub use v2_interface::SimulationStore;
-pub use v2_memory::{DEFAULT_V2_IDLE_RETENTION_SECS, InMemorySimulationStore};
-pub use v2_redis::{DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_SESSION_TTL_SECS, InRedisSimulationStore};
+pub use v2_memory::{DEFAULT_V2_RETENTION_SECS, InMemorySimulationStore};
+pub use v2_redis::{DEFAULT_V2_KEY_PREFIX, InRedisSimulationStore};

--- a/src/session/store/mod.rs
+++ b/src/session/store/mod.rs
@@ -37,6 +37,22 @@ mod in_redis;
 /// shareable implementations (i.e., satisfy `Send` and `Sync`).
 mod interface;
 
+/// The v2 persistence contract for rolling simulations.
+///
+/// Deliberately separate from [`interface`]: the two store different documents
+/// under different key spaces, and keeping the traits apart is what makes the
+/// isolation structural rather than conventional.
+mod v2_interface;
+
+/// In-memory implementation of the v2 simulation store.
+mod v2_memory;
+
+/// Redis implementation of the v2 simulation store.
+mod v2_redis;
+
 pub use in_memory::InMemorySessionStore;
 pub use in_redis::InRedisSessionStore;
 pub use interface::SessionStore;
+pub use v2_interface::SimulationStore;
+pub use v2_memory::{DEFAULT_V2_IDLE_RETENTION_SECS, InMemorySimulationStore};
+pub use v2_redis::{DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_SESSION_TTL_SECS, InRedisSimulationStore};

--- a/src/session/store/v2_interface.rs
+++ b/src/session/store/v2_interface.rs
@@ -1,0 +1,80 @@
+//! Persistence contract for v2 rolling simulations.
+//!
+//! Deliberately a **separate trait** from [`crate::session::SessionStore`]
+//! rather than a generic parameter on it. The two contracts store different
+//! documents under different key spaces, and keeping them apart is what
+//! guarantees ADR 0001 §12.2: a v2 id can never resolve a v1 session, and a v1
+//! document is never reinterpreted as rolling configuration. The v1 trait,
+//! including its `cleanup() -> usize` signature, is untouched.
+
+use crate::session::model_v2::SessionV2;
+use crate::utils::error::ChainError;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+/// A storage backend for v2 rolling simulations.
+///
+/// Implementations must be thread-safe and shareable (`Send + Sync`).
+#[async_trait]
+pub trait SimulationStore: Send + Sync {
+    /// Retrieves a simulation by id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::NotFound`] when no simulation has that id, or
+    /// another [`ChainError`] on a storage or deserialization failure.
+    async fn get(&self, id: Uuid) -> Result<SessionV2, ChainError>;
+
+    /// Inserts a brand-new simulation, failing on an id collision.
+    ///
+    /// Never overwrites: a colliding id is rejected rather than silently
+    /// clobbering a live simulation, which is what makes a fresh manager safe
+    /// after a restart or on a second replica.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::AlreadyExists`] on an id collision, or another
+    /// [`ChainError`] on a storage or serialization failure.
+    async fn create(&self, simulation: SessionV2) -> Result<(), ChainError>;
+
+    /// Atomically persists `simulation` only if the stored revision still
+    /// equals `expected_version`.
+    ///
+    /// The v2 counterpart of `SessionStore::save_cas`, and the **only** write
+    /// path for an existing simulation — there is no blind upsert, because a v2
+    /// simulation is immutable after creation and the sole mutation is the
+    /// cursor advance, which must not lose a concurrent writer's work.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::NotFound`] when the id is absent,
+    /// [`ChainError::Conflict`] when the stored revision differs (the store is
+    /// left untouched), or another [`ChainError`] on a backend failure.
+    async fn save_cas(
+        &self,
+        simulation: SessionV2,
+        expected_version: u64,
+    ) -> Result<(), ChainError>;
+
+    /// Deletes a simulation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ChainError`] when the deletion fails; a missing id is
+    /// `Ok(false)`, not an error.
+    async fn delete(&self, id: Uuid) -> Result<bool, ChainError>;
+
+    /// Removes simulations that have been idle past their retention window and
+    /// returns **their ids**.
+    ///
+    /// Returning the ids rather than a count is the point: the caller owns
+    /// heavyweight per-simulation domain caches, and without the ids it cannot
+    /// evict the entries whose sessions have just gone away. Issue #48 makes
+    /// the retention window configurable and wires the eviction; this
+    /// signature is what lets it.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ChainError`] when the cleanup itself fails.
+    async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError>;
+}

--- a/src/session/store/v2_interface.rs
+++ b/src/session/store/v2_interface.rs
@@ -31,9 +31,16 @@ pub trait SimulationStore: Send + Sync {
     /// clobbering a live simulation, which is what makes a fresh manager safe
     /// after a restart or on a second replica.
     ///
+    /// Implementations **must** call [`SessionV2::validate`] before writing.
+    /// `SessionV2` has public, mutable fields, so a crate caller can hand this
+    /// method a document no constructor would produce; validating on the way in
+    /// keeps the store from being the one place an invalid simulation becomes
+    /// durable.
+    ///
     /// # Errors
     ///
-    /// Returns [`ChainError::AlreadyExists`] on an id collision, or another
+    /// Returns [`ChainError::Validation`] when the simulation is invalid,
+    /// [`ChainError::AlreadyExists`] on an id collision, or another
     /// [`ChainError`] on a storage or serialization failure.
     async fn create(&self, simulation: SessionV2) -> Result<(), ChainError>;
 
@@ -45,9 +52,13 @@ pub trait SimulationStore: Send + Sync {
     /// simulation is immutable after creation and the sole mutation is the
     /// cursor advance, which must not lose a concurrent writer's work.
     ///
+    /// Implementations **must** call [`SessionV2::validate`] before writing,
+    /// for the same reason as `create`.
+    ///
     /// # Errors
     ///
-    /// Returns [`ChainError::NotFound`] when the id is absent,
+    /// Returns [`ChainError::Validation`] when the simulation is invalid,
+    /// [`ChainError::NotFound`] when the id is absent,
     /// [`ChainError::Conflict`] when the stored revision differs (the store is
     /// left untouched), or another [`ChainError`] on a backend failure.
     async fn save_cas(

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -14,13 +14,24 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
-/// Default idle retention for a v2 simulation held in memory, in seconds.
+/// Default retention for a v2 simulation, in seconds — shared by **both**
+/// backends.
+///
+/// One constant rather than one per store, because ADR 0001 §9.1 requires the
+/// in-memory and Redis stores to agree on expiry, and two independently-named
+/// defaults are exactly how that agreement drifts.
 ///
 /// Deliberately longer than v1's 30 minutes: a simulation whose *simulated*
 /// clock spans years is still walked one request at a time, and a client
-/// pausing between steps must not lose it. Issue #48 makes this configurable;
+/// pausing between steps must not lose it. Issue #48 makes it configurable;
 /// v1's retention is untouched either way.
-pub const DEFAULT_V2_IDLE_RETENTION_SECS: u64 = 3_600;
+///
+/// The window is measured from the **last write**, not from the last access:
+/// ADR 0001 §6 defines the snapshot endpoint as a safe peek that persists
+/// nothing, so a client that only peeks does not refresh it. Both backends
+/// behave the same way, which is the property that matters here; whether
+/// peeking should refresh is #48's call.
+pub const DEFAULT_V2_RETENTION_SECS: u64 = 3_600;
 
 /// In-memory store for v2 rolling simulations.
 pub struct InMemorySimulationStore {
@@ -38,7 +49,7 @@ impl InMemorySimulationStore {
     /// Creates a store with the default idle retention.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_idle_retention(Duration::from_secs(DEFAULT_V2_IDLE_RETENTION_SECS))
+        Self::with_idle_retention(Duration::from_secs(DEFAULT_V2_RETENTION_SECS))
     }
 
     /// Creates a store with an explicit idle retention window.
@@ -432,7 +443,7 @@ mod tests {
 
         assert_eq!(
             store.idle_retention(),
-            Duration::from_secs(DEFAULT_V2_IDLE_RETENTION_SECS)
+            Duration::from_secs(DEFAULT_V2_RETENTION_SECS)
         );
     }
 }

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -1,0 +1,438 @@
+//! In-memory [`SimulationStore`] for v2 rolling simulations.
+//!
+//! A **separate map** from [`crate::session::InMemorySessionStore`], not a
+//! second key space inside it. That is what makes ADR 0001 §12.2's isolation
+//! structural rather than conventional: a v2 id cannot resolve a v1 session
+//! because the two never share a container.
+
+use crate::session::model_v2::SessionV2;
+use crate::session::store::v2_interface::SimulationStore;
+use crate::utils::error::ChainError;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+/// Default idle retention for a v2 simulation held in memory, in seconds.
+///
+/// Deliberately longer than v1's 30 minutes: a simulation whose *simulated*
+/// clock spans years is still walked one request at a time, and a client
+/// pausing between steps must not lose it. Issue #48 makes this configurable;
+/// v1's retention is untouched either way.
+pub const DEFAULT_V2_IDLE_RETENTION_SECS: u64 = 3_600;
+
+/// In-memory store for v2 rolling simulations.
+pub struct InMemorySimulationStore {
+    simulations: Arc<Mutex<HashMap<Uuid, SessionV2>>>,
+    idle_retention: Duration,
+}
+
+impl Default for InMemorySimulationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemorySimulationStore {
+    /// Creates a store with the default idle retention.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_idle_retention(Duration::from_secs(DEFAULT_V2_IDLE_RETENTION_SECS))
+    }
+
+    /// Creates a store with an explicit idle retention window.
+    #[must_use]
+    pub fn with_idle_retention(idle_retention: Duration) -> Self {
+        Self {
+            simulations: Arc::new(Mutex::new(HashMap::new())),
+            idle_retention,
+        }
+    }
+
+    /// The idle retention window this store applies.
+    #[must_use]
+    pub fn idle_retention(&self) -> Duration {
+        self.idle_retention
+    }
+
+    /// Locks the map, mapping a poisoned lock into the error boundary rather
+    /// than panicking on a request path.
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<Uuid, SessionV2>>, ChainError> {
+        self.simulations.lock().map_err(|_| {
+            ChainError::Internal("Failed to acquire lock on simulation store".to_string())
+        })
+    }
+}
+
+#[async_trait]
+impl SimulationStore for InMemorySimulationStore {
+    async fn get(&self, id: Uuid) -> Result<SessionV2, ChainError> {
+        let simulations = self.lock()?;
+
+        simulations
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| ChainError::NotFound(format!("Simulation with id {id} not found")))
+    }
+
+    async fn create(&self, simulation: SessionV2) -> Result<(), ChainError> {
+        let mut simulations = self.lock()?;
+
+        if simulations.contains_key(&simulation.id) {
+            return Err(ChainError::AlreadyExists(format!(
+                "Simulation with id {} already exists",
+                simulation.id
+            )));
+        }
+
+        simulations.insert(simulation.id, simulation);
+        Ok(())
+    }
+
+    async fn save_cas(
+        &self,
+        simulation: SessionV2,
+        expected_version: u64,
+    ) -> Result<(), ChainError> {
+        // The whole compare-and-swap runs under the map lock, held only for
+        // this synchronous section (no `.await` inside), so the read of the
+        // stored revision and the conditional write are one atomic step.
+        let mut simulations = self.lock()?;
+
+        match simulations.get(&simulation.id) {
+            None => Err(ChainError::NotFound(format!(
+                "Simulation with id {} not found",
+                simulation.id
+            ))),
+            Some(existing) if existing.version != expected_version => {
+                Err(ChainError::Conflict(format!(
+                    "Simulation {} was modified concurrently (expected version {}, found {})",
+                    simulation.id, expected_version, existing.version
+                )))
+            }
+            Some(_) => {
+                simulations.insert(simulation.id, simulation);
+                Ok(())
+            }
+        }
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
+        let mut simulations = self.lock()?;
+
+        Ok(simulations.remove(&id).is_some())
+    }
+
+    async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError> {
+        let now = SystemTime::now();
+        let mut simulations = self.lock()?;
+
+        // A document stamped in the future — a clock step, or a peer with a
+        // skewed clock — is kept rather than expired, matching v1's behaviour.
+        let expired: Vec<Uuid> = simulations
+            .iter()
+            .filter_map(
+                |(id, simulation)| match now.duration_since(simulation.updated_at) {
+                    Ok(idle) if idle > self.idle_retention => Some(*id),
+                    _ => None,
+                },
+            )
+            .collect();
+
+        for id in &expired {
+            simulations.remove(id);
+        }
+
+        Ok(expired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind};
+    use crate::session::model_v2::SimulationParametersV2;
+    use crate::utils::UuidGenerator;
+    use chrono::{TimeZone, Utc, Weekday};
+
+    fn request() -> CreateSimulationRequest {
+        let rule = match ExpiryRule::new("zero_dte", ExpiryRuleKind::Daily, 1) {
+            Ok(rule) => rule,
+            Err(error) => panic!("test rule must be valid: {error}"),
+        };
+        let weeklies = match ExpiryRule::new(
+            "weeklies",
+            ExpiryRuleKind::weekly([Weekday::Mon, Weekday::Fri]),
+            2,
+        ) {
+            Ok(rule) => rule,
+            Err(error) => panic!("test rule must be valid: {error}"),
+        };
+        let start_at = match Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("test instant must be valid"),
+        };
+
+        CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 10,
+            start_at: Some(start_at),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: None,
+            expiration_time: "17:00".to_string(),
+            schedules: vec![rule, weeklies],
+            initial_price: 5000.0,
+            volatility: 0.18,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.0,
+            method: ApiWalkType::Brownian {
+                dt: 0.004,
+                drift: 0.0,
+                volatility: 0.18,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(15),
+            strike_interval: Some(25.0),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(0.02),
+            seed: Some(42),
+        }
+    }
+
+    fn simulation() -> SessionV2 {
+        let parameters = match SimulationParametersV2::try_from(request()) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the request must convert: {error}"),
+        };
+        let namespace = match uuid::Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE) {
+            Ok(namespace) => namespace,
+            Err(error) => panic!("the default namespace must parse: {error}"),
+        };
+        SessionV2::new(parameters, &UuidGenerator::new(namespace))
+    }
+
+    /// The reference configuration round-trips through the store unchanged.
+    #[tokio::test]
+    async fn test_create_then_get_round_trips_the_simulation() {
+        let store = InMemorySimulationStore::new();
+        let original = simulation();
+
+        match store.create(original.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        match store.get(original.id).await {
+            Ok(loaded) => assert_eq!(loaded, original),
+            Err(error) => panic!("must load: {error}"),
+        }
+    }
+
+    /// A missing id is `NotFound`, not a default document.
+    #[tokio::test]
+    async fn test_get_missing_id_is_not_found() {
+        let store = InMemorySimulationStore::new();
+
+        match store.get(Uuid::new_v4()).await {
+            Err(ChainError::NotFound(message)) => assert!(message.contains("Simulation")),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// A duplicate id is rejected rather than overwriting a live simulation.
+    #[tokio::test]
+    async fn test_duplicate_id_is_rejected() {
+        let store = InMemorySimulationStore::new();
+        let original = simulation();
+
+        match store.create(original.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+        match store.create(original).await {
+            Err(ChainError::AlreadyExists(_)) => {}
+            other => panic!("expected AlreadyExists, got {other:?}"),
+        }
+    }
+
+    /// A compare-and-swap at the stored revision commits.
+    #[tokio::test]
+    async fn test_save_cas_at_the_stored_revision_commits() {
+        let store = InMemorySimulationStore::new();
+        let mut sim = simulation();
+        match store.create(sim.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        sim.current_step = 1;
+        let expected = match sim.bump_version() {
+            Ok(expected) => expected,
+            Err(error) => panic!("must bump: {error}"),
+        };
+
+        match store.save_cas(sim.clone(), expected).await {
+            Ok(()) => {}
+            Err(error) => panic!("must commit: {error}"),
+        }
+        match store.get(sim.id).await {
+            Ok(loaded) => {
+                assert_eq!(loaded.current_step, 1);
+                assert_eq!(loaded.version, 1);
+            }
+            Err(error) => panic!("must load: {error}"),
+        }
+    }
+
+    /// Two writers that read the same revision produce one winner and one
+    /// documented conflict.
+    #[tokio::test]
+    async fn test_concurrent_save_cas_yields_one_winner() {
+        let store = InMemorySimulationStore::new();
+        let sim = simulation();
+        match store.create(sim.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        let mut first = sim.clone();
+        first.current_step = 1;
+        let first_expected = match first.bump_version() {
+            Ok(expected) => expected,
+            Err(error) => panic!("must bump: {error}"),
+        };
+
+        let mut second = sim;
+        second.current_step = 1;
+        let second_expected = match second.bump_version() {
+            Ok(expected) => expected,
+            Err(error) => panic!("must bump: {error}"),
+        };
+
+        match store.save_cas(first, first_expected).await {
+            Ok(()) => {}
+            Err(error) => panic!("the first writer must commit: {error}"),
+        }
+        match store.save_cas(second, second_expected).await {
+            Err(ChainError::Conflict(message)) => assert!(message.contains("concurrently")),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    /// A compare-and-swap against a missing id is `NotFound`.
+    #[tokio::test]
+    async fn test_save_cas_on_a_missing_id_is_not_found() {
+        let store = InMemorySimulationStore::new();
+
+        match store.save_cas(simulation(), 0).await {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// Delete reports whether anything was removed, and a second delete is not
+    /// an error.
+    #[tokio::test]
+    async fn test_delete_reports_whether_it_removed_anything() {
+        let store = InMemorySimulationStore::new();
+        let sim = simulation();
+        match store.create(sim.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        match store.delete(sim.id).await {
+            Ok(removed) => assert!(removed),
+            Err(error) => panic!("must delete: {error}"),
+        }
+        match store.delete(sim.id).await {
+            Ok(removed) => assert!(!removed),
+            Err(error) => panic!("a second delete must not error: {error}"),
+        }
+    }
+
+    /// Cleanup returns the ids it expired, which is what lets the caller evict
+    /// the matching domain caches.
+    #[tokio::test]
+    async fn test_cleanup_returns_the_expired_ids() {
+        let store = InMemorySimulationStore::with_idle_retention(Duration::from_secs(1));
+        let mut stale = simulation();
+        stale.updated_at = SystemTime::now() - Duration::from_secs(3_600);
+        let fresh = simulation();
+        let fresh = SessionV2 {
+            id: Uuid::new_v4(),
+            ..fresh
+        };
+
+        match store.create(stale.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+        match store.create(fresh.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        match store.cleanup().await {
+            Ok(expired) => assert_eq!(expired, vec![stale.id]),
+            Err(error) => panic!("must clean up: {error}"),
+        }
+
+        assert!(store.get(stale.id).await.is_err());
+        assert!(store.get(fresh.id).await.is_ok());
+    }
+
+    /// A simulation whose idle time is inside the retention window survives, so
+    /// a long simulated horizon is not cut short by a real-time timeout.
+    #[tokio::test]
+    async fn test_cleanup_keeps_a_simulation_inside_its_retention_window() {
+        let store = InMemorySimulationStore::with_idle_retention(Duration::from_secs(3_600));
+        let mut sim = simulation();
+        sim.updated_at = SystemTime::now() - Duration::from_secs(600);
+        match store.create(sim.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        match store.cleanup().await {
+            Ok(expired) => assert!(expired.is_empty()),
+            Err(error) => panic!("must clean up: {error}"),
+        }
+        assert!(store.get(sim.id).await.is_ok());
+    }
+
+    /// A document stamped in the future is kept rather than expired, matching
+    /// the v1 store's behaviour under a clock step.
+    #[tokio::test]
+    async fn test_cleanup_keeps_a_future_stamped_simulation() {
+        let store = InMemorySimulationStore::with_idle_retention(Duration::from_secs(1));
+        let mut sim = simulation();
+        sim.updated_at = SystemTime::now() + Duration::from_secs(3_600);
+        match store.create(sim.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        match store.cleanup().await {
+            Ok(expired) => assert!(expired.is_empty()),
+            Err(error) => panic!("must clean up: {error}"),
+        }
+    }
+
+    /// The default retention is longer than v1's, because a v2 simulation is
+    /// walked one request at a time over a long simulated horizon.
+    #[tokio::test]
+    async fn test_default_retention_is_the_documented_window() {
+        let store = InMemorySimulationStore::new();
+
+        assert_eq!(
+            store.idle_retention(),
+            Duration::from_secs(DEFAULT_V2_IDLE_RETENTION_SECS)
+        );
+    }
+}

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -88,6 +88,11 @@ impl SimulationStore for InMemorySimulationStore {
     }
 
     async fn create(&self, simulation: SessionV2) -> Result<(), ChainError> {
+        // The in-memory backend serves what it was handed, so an unvalidated
+        // document would be served for the rest of the process's life without
+        // a round trip through serde ever catching it.
+        simulation.validate()?;
+
         let mut simulations = self.lock()?;
 
         if simulations.contains_key(&simulation.id) {
@@ -106,6 +111,8 @@ impl SimulationStore for InMemorySimulationStore {
         simulation: SessionV2,
         expected_version: u64,
     ) -> Result<(), ChainError> {
+        simulation.validate()?;
+
         // The whole compare-and-swap runs under the map lock, held only for
         // this synchronous section (no `.await` inside), so the read of the
         // stored revision and the conditional write are one atomic step.
@@ -165,6 +172,7 @@ mod tests {
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
     use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind};
+    use crate::session::model::SessionState;
     use crate::session::model_v2::SimulationParametersV2;
     use crate::utils::UuidGenerator;
     use chrono::{TimeZone, Utc, Weekday};
@@ -227,6 +235,48 @@ mod tests {
         SessionV2::new(parameters, &UuidGenerator::new(namespace))
     }
 
+    /// An invalid simulation is refused on the way in.
+    ///
+    /// `SessionV2` has public, mutable fields, so a crate caller can hand the
+    /// store a document no constructor would produce. This backend never
+    /// round-trips through serde, so without the check it would keep serving
+    /// that document for the life of the process.
+    #[tokio::test]
+    async fn test_create_rejects_an_invalid_simulation() {
+        let store = InMemorySimulationStore::new();
+        let mut invalid = simulation();
+        invalid.current_step = invalid.total_steps + 1;
+
+        match store.create(invalid.clone()).await {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "current_step"),
+            other => panic!("must reject the invalid cursor, got {other:?}"),
+        }
+
+        match store.get(invalid.id).await {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("nothing must have been stored, got {other:?}"),
+        }
+    }
+
+    /// The same refusal on the compare-and-swap path.
+    #[tokio::test]
+    async fn test_save_cas_rejects_an_invalid_simulation() {
+        let store = InMemorySimulationStore::new();
+        let original = simulation();
+        match store.create(original.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("must create: {error}"),
+        }
+
+        let mut invalid = original.clone();
+        invalid.state = SessionState::Completed;
+
+        match store.save_cas(invalid, original.version).await {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "state"),
+            other => panic!("must reject the contradictory state, got {other:?}"),
+        }
+    }
+
     /// The reference configuration round-trips through the store unchanged.
     #[tokio::test]
     async fn test_create_then_get_round_trips_the_simulation() {
@@ -281,7 +331,10 @@ mod tests {
             Err(error) => panic!("must create: {error}"),
         }
 
+        // Advancing the cursor moves the lifecycle with it — the pair is
+        // validated on every write now.
         sim.current_step = 1;
+        sim.state = SessionState::InProgress;
         let expected = match sim.bump_version() {
             Ok(expected) => expected,
             Err(error) => panic!("must bump: {error}"),
@@ -313,6 +366,7 @@ mod tests {
 
         let mut first = sim.clone();
         first.current_step = 1;
+        first.state = SessionState::InProgress;
         let first_expected = match first.bump_version() {
             Ok(expected) => expected,
             Err(error) => panic!("must bump: {error}"),
@@ -320,6 +374,7 @@ mod tests {
 
         let mut second = sim;
         second.current_step = 1;
+        second.state = SessionState::InProgress;
         let second_expected = match second.bump_version() {
             Ok(expected) => expected,
             Err(error) => panic!("must bump: {error}"),

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -299,6 +299,10 @@ impl SimulationStore for InRedisSimulationStore {
         let id = simulation.id;
         debug!(simulation_id = %id, "Creating simulation in Redis");
 
+        // Redis only rechecks on the way out, so without this a document
+        // written invalid stays readable-but-rejected until its TTL expires.
+        simulation.validate()?;
+
         let json = Self::serialize(&simulation)?;
         let mut conn = self.client.connection_manager();
         let created: i64 = redis::Script::new(CREATE_SCRIPT)
@@ -331,6 +335,8 @@ impl SimulationStore for InRedisSimulationStore {
     ) -> Result<(), ChainError> {
         let id = simulation.id;
         debug!(simulation_id = %id, expected_version, "CAS-saving simulation to Redis");
+
+        simulation.validate()?;
 
         let json = Self::serialize(&simulation)?;
         let mut conn = self.client.connection_manager();

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -1,0 +1,368 @@
+//! Redis-backed [`SimulationStore`] for v2 rolling simulations.
+//!
+//! Uses its own key prefix — `optionchain:simulation:v2:` by default — so a v2
+//! document and a v1 session can never collide, and a v1 document is never
+//! read back as rolling configuration (ADR 0001 §12.2). The compare-and-swap
+//! itself is the same server-side Lua script the v1 store uses
+//! ([`SAVE_CAS_SCRIPT`]), which is parameterised entirely by its keys, so both
+//! key spaces share one already-reviewed implementation.
+//!
+//! # Why there is an index set
+//!
+//! Redis expires keys on its own, invisibly to this process. That is fine for
+//! v1, whose `cleanup` honestly reports `0`. It is not fine for v2: the caller
+//! owns heavyweight per-simulation domain caches and needs the **ids** that
+//! went away in order to evict them, which is exactly what
+//! [`SimulationStore::cleanup`] promises. So every live simulation id is also
+//! held in a set, and cleanup reports the members whose documents have since
+//! expired, pruning the set as it goes.
+
+use crate::infrastructure::RedisClient;
+use crate::session::model_v2::SessionV2;
+use crate::session::store::in_redis::SAVE_CAS_SCRIPT;
+use crate::session::store::v2_interface::SimulationStore;
+use crate::utils::error::ChainError;
+use async_trait::async_trait;
+use redis::RedisError;
+use std::sync::Arc;
+use tracing::{debug, error, info, instrument};
+use uuid::Uuid;
+
+/// Default Redis key prefix for v2 simulations.
+///
+/// Distinct from v1's `session:` / `optionchain:session:` prefixes, which is
+/// what keeps the two key spaces from ever meeting.
+pub const DEFAULT_V2_KEY_PREFIX: &str = "optionchain:simulation:v2:";
+
+/// Default idle retention for a stored v2 simulation, in seconds.
+///
+/// Longer than v1's, because a simulation whose simulated clock spans years is
+/// still walked one request at a time. Issue #48 makes it configurable.
+pub const DEFAULT_V2_SESSION_TTL_SECS: u64 = 3_600;
+
+/// Redis-backed store for v2 rolling simulations.
+pub struct InRedisSimulationStore {
+    client: Arc<RedisClient>,
+    key_prefix: String,
+    session_ttl: u64,
+}
+
+impl InRedisSimulationStore {
+    /// Creates a Redis-backed simulation store.
+    ///
+    /// `key_prefix` defaults to [`DEFAULT_V2_KEY_PREFIX`] and `session_ttl` to
+    /// [`DEFAULT_V2_SESSION_TTL_SECS`].
+    #[instrument(skip(client), level = "debug")]
+    pub fn new(
+        client: Arc<RedisClient>,
+        key_prefix: Option<String>,
+        session_ttl: Option<u64>,
+    ) -> Self {
+        let prefix = key_prefix.unwrap_or_else(|| DEFAULT_V2_KEY_PREFIX.to_string());
+        let ttl = session_ttl.unwrap_or(DEFAULT_V2_SESSION_TTL_SECS);
+
+        info!(
+            key_prefix = %prefix,
+            session_ttl = ttl,
+            "Created new Redis simulation store"
+        );
+
+        Self {
+            client,
+            key_prefix: prefix,
+            session_ttl: ttl,
+        }
+    }
+
+    /// The key holding a simulation document.
+    fn simulation_key(&self, id: Uuid) -> String {
+        format!("{}{}", self.key_prefix, id)
+    }
+
+    /// The companion key holding a simulation's revision as an integer string.
+    ///
+    /// Kept out of the JSON for the same reason as v1: `cjson` would round a
+    /// `u64` through an IEEE-754 double, collapsing adjacent revisions above
+    /// `2^53` and letting a stale writer pass the compare-and-swap.
+    fn version_key(&self, id: Uuid) -> String {
+        format!("{}:ver", self.simulation_key(id))
+    }
+
+    /// The set holding every live simulation id.
+    fn index_key(&self) -> String {
+        format!("{}index", self.key_prefix)
+    }
+
+    /// The retention window applied to stored simulations, in seconds.
+    #[must_use]
+    pub fn session_ttl(&self) -> u64 {
+        self.session_ttl
+    }
+
+    /// Maps a Redis error into the crate's error boundary.
+    ///
+    /// The message carries the driver's text but never the connection string,
+    /// which `RedisClient` keeps to itself.
+    #[cold]
+    fn map_redis_error(err: RedisError) -> ChainError {
+        ChainError::Internal(format!("Redis error: {err}"))
+    }
+
+    /// Translates the integer result code returned by [`SAVE_CAS_SCRIPT`].
+    ///
+    /// Pure and side-effect free so the mapping is unit-testable without a live
+    /// Redis. `1` committed, `-1` means the key is gone, `-2` means another
+    /// writer won the race.
+    fn map_cas_result(code: i64, id: Uuid, expected_version: u64) -> Result<(), ChainError> {
+        match code {
+            1 => Ok(()),
+            -1 => Err(ChainError::NotFound(format!(
+                "Simulation with id {id} not found"
+            ))),
+            -2 => Err(ChainError::Conflict(format!(
+                "Simulation {id} was modified concurrently (expected version {expected_version})"
+            ))),
+            other => Err(ChainError::Internal(format!(
+                "Unexpected CAS result code {other} for simulation {id}"
+            ))),
+        }
+    }
+}
+
+#[async_trait]
+impl SimulationStore for InRedisSimulationStore {
+    #[instrument(skip(self), level = "debug")]
+    async fn get(&self, id: Uuid) -> Result<SessionV2, ChainError> {
+        let key = self.simulation_key(id);
+        debug!(simulation_id = %id, key = %key, "Getting simulation from Redis");
+
+        match self.client.get::<String>(&key).await {
+            Ok(Some(json)) => serde_json::from_str::<SessionV2>(&json).map_err(|e| {
+                error!(simulation_id = %id, error = %e, "Failed to deserialize simulation");
+                ChainError::Internal(format!("Failed to deserialize simulation: {e}"))
+            }),
+            Ok(None) => Err(ChainError::NotFound(format!(
+                "Simulation with id {id} not found"
+            ))),
+            Err(e) => {
+                error!(simulation_id = %id, error = %e, "Redis error while getting simulation");
+                Err(Self::map_redis_error(e))
+            }
+        }
+    }
+
+    #[instrument(skip(self, simulation), level = "debug")]
+    async fn create(&self, simulation: SessionV2) -> Result<(), ChainError> {
+        let id = simulation.id;
+        let key = self.simulation_key(id);
+        let version_key = self.version_key(id);
+        debug!(simulation_id = %id, key = %key, "Creating simulation in Redis");
+
+        let json = serde_json::to_string(&simulation).map_err(|e| {
+            error!(simulation_id = %id, error = %e, "Failed to serialize simulation");
+            ChainError::Internal(format!("Failed to serialize simulation: {e}"))
+        })?;
+
+        // SET NX guarantees we never overwrite an existing id.
+        match self.client.set_nx(&key, json, Some(self.session_ttl)).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(ChainError::AlreadyExists(format!(
+                    "Simulation with id {id} already exists"
+                )));
+            }
+            Err(e) => {
+                error!(simulation_id = %id, error = %e, "Redis error while creating simulation");
+                return Err(Self::map_redis_error(e));
+            }
+        }
+
+        // Seed the companion revision key the CAS script compares against.
+        // Neither this nor the index write is a race surface — only `save_cas`
+        // races — so plain sequential commands are correct here, and the script
+        // treats a missing `:ver` key as revision 0.
+        self.client
+            .set(
+                &version_key,
+                simulation.version.to_string(),
+                Some(self.session_ttl),
+            )
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        let mut conn = self.client.connection_manager();
+        let _: () = redis::cmd("SADD")
+            .arg(self.index_key())
+            .arg(id.to_string())
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        debug!(simulation_id = %id, "Simulation created successfully");
+        Ok(())
+    }
+
+    #[instrument(skip(self, simulation), level = "debug")]
+    async fn save_cas(
+        &self,
+        simulation: SessionV2,
+        expected_version: u64,
+    ) -> Result<(), ChainError> {
+        let id = simulation.id;
+        let key = self.simulation_key(id);
+        let version_key = self.version_key(id);
+        debug!(simulation_id = %id, expected_version, "CAS-saving simulation to Redis");
+
+        let json = serde_json::to_string(&simulation).map_err(|e| {
+            error!(simulation_id = %id, error = %e, "Failed to serialize simulation");
+            ChainError::Internal(format!("Failed to serialize simulation: {e}"))
+        })?;
+
+        // Versions cross the boundary as STRINGS so the Lua comparison is exact
+        // for every `u64`. `simulation.version` was already bumped past
+        // `expected_version` by the caller.
+        let mut conn = self.client.connection_manager();
+        let code: i64 = redis::Script::new(SAVE_CAS_SCRIPT)
+            .key(&key)
+            .key(&version_key)
+            .arg(json)
+            .arg(expected_version.to_string())
+            .arg(simulation.version.to_string())
+            .arg(self.session_ttl)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        Self::map_cas_result(code, id, expected_version).inspect_err(|e| {
+            debug!(simulation_id = %id, error = %e, "CAS save rejected");
+        })
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
+        let key = self.simulation_key(id);
+        let version_key = self.version_key(id);
+        debug!(simulation_id = %id, key = %key, "Deleting simulation from Redis");
+
+        // The document's own delete result decides whether a simulation
+        // existed; removing an already-absent companion or index member is
+        // harmless.
+        let deleted = self
+            .client
+            .delete(&key)
+            .await
+            .map_err(Self::map_redis_error)?;
+        self.client
+            .delete(&version_key)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        let mut conn = self.client.connection_manager();
+        let _: () = redis::cmd("SREM")
+            .arg(self.index_key())
+            .arg(id.to_string())
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        debug!(simulation_id = %id, deleted, "Simulation delete result");
+        Ok(deleted)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError> {
+        let index_key = self.index_key();
+        let mut conn = self.client.connection_manager();
+
+        let members: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(&index_key)
+            .query_async(&mut conn)
+            .await
+            .map_err(Self::map_redis_error)?;
+
+        let mut expired = Vec::new();
+        for member in members {
+            // A member that is not a uuid cannot correspond to a document;
+            // drop it from the index rather than carrying it forever.
+            let Ok(id) = Uuid::parse_str(&member) else {
+                let _: () = redis::cmd("SREM")
+                    .arg(&index_key)
+                    .arg(&member)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(Self::map_redis_error)?;
+                continue;
+            };
+
+            let exists = self
+                .client
+                .exists(&self.simulation_key(id))
+                .await
+                .map_err(Self::map_redis_error)?;
+            if exists {
+                continue;
+            }
+
+            // Redis already expired the document; drop the leftovers and report
+            // the id so the caller can evict its domain caches.
+            self.client
+                .delete(&self.version_key(id))
+                .await
+                .map_err(Self::map_redis_error)?;
+            let _: () = redis::cmd("SREM")
+                .arg(&index_key)
+                .arg(&member)
+                .query_async(&mut conn)
+                .await
+                .map_err(Self::map_redis_error)?;
+            expired.push(id);
+        }
+
+        if !expired.is_empty() {
+            info!(count = expired.len(), "Reaped expired simulations");
+        }
+        Ok(expired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn any_id() -> Uuid {
+        Uuid::nil()
+    }
+
+    /// A committed compare-and-swap maps to `Ok`.
+    #[test]
+    fn test_map_cas_result_committed_is_ok() {
+        assert!(InRedisSimulationStore::map_cas_result(1, any_id(), 3).is_ok());
+    }
+
+    /// A missing key maps to `NotFound`, naming the simulation.
+    #[test]
+    fn test_map_cas_result_missing_key_is_not_found() {
+        match InRedisSimulationStore::map_cas_result(-1, any_id(), 3) {
+            Err(ChainError::NotFound(message)) => assert!(message.contains("Simulation")),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// A revision mismatch maps to `Conflict`, carrying the expected revision.
+    #[test]
+    fn test_map_cas_result_version_mismatch_is_conflict() {
+        match InRedisSimulationStore::map_cas_result(-2, any_id(), 7) {
+            Err(ChainError::Conflict(message)) => assert!(message.contains('7')),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    /// An unexpected code is an internal error rather than a silent success.
+    #[test]
+    fn test_map_cas_result_unknown_code_is_internal() {
+        match InRedisSimulationStore::map_cas_result(42, any_id(), 0) {
+            Err(ChainError::Internal(message)) => assert!(message.contains("42")),
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
+}

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -493,6 +493,7 @@ mod live_tests {
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
     use crate::infrastructure::RedisConfig;
+    use crate::session::model::SessionState;
     use crate::session::model_v2::SimulationParametersV2;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use crate::utils::UuidGenerator;
@@ -647,10 +648,12 @@ mod live_tests {
 
         let mut winner = sim.clone();
         winner.current_step = 1;
+        winner.state = SessionState::InProgress;
         let winner_expected = winner.bump_version().expect("must bump");
 
         let mut loser = sim.clone();
         loser.current_step = 1;
+        loser.state = SessionState::InProgress;
         let loser_expected = loser.bump_version().expect("must bump");
 
         store

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -1,25 +1,31 @@
 //! Redis-backed [`SimulationStore`] for v2 rolling simulations.
 //!
 //! Uses its own key prefix — `optionchain:simulation:v2:` by default — so a v2
-//! document and a v1 session can never collide, and a v1 document is never
-//! read back as rolling configuration (ADR 0001 §12.2). The compare-and-swap
-//! itself is the same server-side Lua script the v1 store uses
-//! ([`SAVE_CAS_SCRIPT`]), which is parameterised entirely by its keys, so both
-//! key spaces share one already-reviewed implementation.
+//! document and a v1 session can never collide, and a v1 document is never read
+//! back as rolling configuration (ADR 0001 §12.2).
 //!
-//! # Why there is an index set
+//! # Why every write is a script
+//!
+//! A simulation is three keys: the document, a companion revision key, and a
+//! membership entry in an index. Writing them with sequential commands leaves
+//! two silent torn states — a document with no revision key, and a document
+//! absent from the index, which would be invisible to [`SimulationStore::cleanup`]
+//! forever. Each operation is therefore one Lua script, which Redis runs as a
+//! single uninterruptible unit.
+//!
+//! # Why there is an index at all
 //!
 //! Redis expires keys on its own, invisibly to this process. That is fine for
 //! v1, whose `cleanup` honestly reports `0`. It is not fine for v2: the caller
-//! owns heavyweight per-simulation domain caches and needs the **ids** that
-//! went away in order to evict them, which is exactly what
-//! [`SimulationStore::cleanup`] promises. So every live simulation id is also
-//! held in a set, and cleanup reports the members whose documents have since
-//! expired, pruning the set as it goes.
+//! owns heavyweight per-simulation domain caches and needs the **ids** that went
+//! away in order to evict them, which is what [`SimulationStore::cleanup`]
+//! promises. The index is a sorted set scored by each simulation's expiry
+//! deadline, so cleanup is a range query over what has actually expired rather
+//! than an existence probe per member — no `SMEMBERS` over an unbounded set, and
+//! no window in which a recreated id could be reported as expired.
 
 use crate::infrastructure::RedisClient;
 use crate::session::model_v2::SessionV2;
-use crate::session::store::in_redis::SAVE_CAS_SCRIPT;
 use crate::session::store::v2_interface::SimulationStore;
 use crate::utils::error::ChainError;
 use async_trait::async_trait;
@@ -34,69 +40,195 @@ use uuid::Uuid;
 /// what keeps the two key spaces from ever meeting.
 pub const DEFAULT_V2_KEY_PREFIX: &str = "optionchain:simulation:v2:";
 
-/// Default idle retention for a stored v2 simulation, in seconds.
+/// Creates a simulation, or reports that the id is taken.
 ///
-/// Longer than v1's, because a simulation whose simulated clock spans years is
-/// still walked one request at a time. Issue #48 makes it configurable.
-pub const DEFAULT_V2_SESSION_TTL_SECS: u64 = 3_600;
+/// One unit, so a created document always has its revision key and its index
+/// entry. The index score is the expiry deadline, read from Redis's own clock
+/// (`TIME`) rather than the client's, so a skewed caller cannot make cleanup
+/// reap early or late.
+///
+/// Keys: `KEYS[1]` document, `KEYS[2]` revision, `KEYS[3]` index.
+/// Arguments: `ARGV[1]` document JSON, `ARGV[2]` revision string, `ARGV[3]` TTL
+/// in seconds, `ARGV[4]` simulation id.
+///
+/// Returns `1` when created, `0` when the id already exists.
+const CREATE_SCRIPT: &str = r#"
+if redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[3]), 'NX') == false then
+    return 0
+end
+redis.call('SET', KEYS[2], ARGV[2], 'EX', tonumber(ARGV[3]))
+local now = tonumber(redis.call('TIME')[1])
+redis.call('ZADD', KEYS[3], now + tonumber(ARGV[3]), ARGV[4])
+return 1
+"#;
+
+/// Compare-and-swap: writes only if the stored revision still matches.
+///
+/// The revision compared is **not** read from the JSON document. Decoding it
+/// with `cjson` would round the integer through an IEEE-754 double, so two
+/// adjacent revisions above `2^53` collapse to the same value and a stale writer
+/// could pass the check. It lives in a companion key as a plain string and is
+/// compared byte for byte. A document written before that key existed has none;
+/// `GET` returns `false`, so `or '0'` treats it as revision `0`.
+///
+/// The same unit refreshes the TTL on both keys and the deadline in the index,
+/// so a simulation being actively walked cannot have its index entry go stale
+/// and be reaped while its document is still live.
+///
+/// Keys: `KEYS[1]` document, `KEYS[2]` revision, `KEYS[3]` index.
+/// Arguments: `ARGV[1]` new document JSON, `ARGV[2]` expected revision,
+/// `ARGV[3]` new revision, `ARGV[4]` TTL in seconds, `ARGV[5]` simulation id.
+///
+/// Returns `-1` when the document is gone, `-2` on a revision mismatch, `1` when
+/// written.
+const SAVE_CAS_SCRIPT: &str = r#"
+if not redis.call('GET', KEYS[1]) then
+    return -1
+end
+local ver = redis.call('GET', KEYS[2]) or '0'
+if ver ~= ARGV[2] then
+    return -2
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[4]))
+redis.call('SET', KEYS[2], ARGV[3], 'EX', tonumber(ARGV[4]))
+local now = tonumber(redis.call('TIME')[1])
+redis.call('ZADD', KEYS[3], now + tonumber(ARGV[4]), ARGV[5])
+return 1
+"#;
+
+/// Deletes a simulation and every trace of it.
+///
+/// Keys: `KEYS[1]` document, `KEYS[2]` revision, `KEYS[3]` index.
+/// Arguments: `ARGV[1]` simulation id.
+///
+/// Returns `1` when a document was removed, `0` when there was nothing to
+/// remove. The revision key and the index entry go either way, so a partially
+/// expired simulation cannot leave debris behind.
+const DELETE_SCRIPT: &str = r#"
+local removed = redis.call('DEL', KEYS[1])
+redis.call('DEL', KEYS[2])
+redis.call('ZREM', KEYS[3], ARGV[1])
+return removed
+"#;
+
+/// Reaps every simulation whose deadline has passed and reports their ids.
+///
+/// The range query and the removals are one unit, so an id cannot be reported as
+/// expired and then immediately recreated by a concurrent `create` — which,
+/// because ids are deterministic and repeat across process restarts, is a real
+/// interleaving rather than a theoretical one. Reporting a live simulation would
+/// make the caller evict a cache it still needs and drop the id from the index
+/// permanently.
+///
+/// Keys: `KEYS[1]` index.
+/// Arguments: `ARGV[1]` key prefix, `ARGV[2]` maximum ids to reap in one pass.
+///
+/// Returns the reaped ids.
+const CLEANUP_SCRIPT: &str = r#"
+local now = tonumber(redis.call('TIME')[1])
+local expired = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', now, 'LIMIT', 0, tonumber(ARGV[2]))
+for _, id in ipairs(expired) do
+    redis.call('DEL', ARGV[1] .. id)
+    redis.call('DEL', ARGV[1] .. id .. ':ver')
+    redis.call('ZREM', KEYS[1], id)
+end
+return expired
+"#;
+
+/// Maximum ids one `cleanup` pass reaps.
+///
+/// Bounds both the script's run time — Redis is single-threaded, so an unbounded
+/// loop would block every other client — and the size of the reply. A caller
+/// with more than this to reap simply reaps the rest on its next pass.
+const CLEANUP_BATCH: usize = 1_000;
+
+/// The key holding a simulation document.
+///
+/// A free function so the layout can be asserted without a live connection —
+/// changing it moves every stored simulation, which is exactly the kind of
+/// change that should have to break a test first.
+#[must_use]
+#[inline]
+fn simulation_key(prefix: &str, id: Uuid) -> String {
+    format!("{prefix}{id}")
+}
+
+/// The companion key holding a simulation's revision as an integer string.
+#[must_use]
+#[inline]
+fn version_key(prefix: &str, id: Uuid) -> String {
+    format!("{}:ver", simulation_key(prefix, id))
+}
+
+/// The sorted set holding every live simulation id, scored by its deadline.
+#[must_use]
+#[inline]
+fn index_key(prefix: &str) -> String {
+    format!("{prefix}index")
+}
 
 /// Redis-backed store for v2 rolling simulations.
 pub struct InRedisSimulationStore {
     client: Arc<RedisClient>,
     key_prefix: String,
-    session_ttl: u64,
+    retention_secs: u64,
 }
 
 impl InRedisSimulationStore {
     /// Creates a Redis-backed simulation store.
     ///
-    /// `key_prefix` defaults to [`DEFAULT_V2_KEY_PREFIX`] and `session_ttl` to
-    /// [`DEFAULT_V2_SESSION_TTL_SECS`].
+    /// `key_prefix` defaults to [`DEFAULT_V2_KEY_PREFIX`] and `retention_secs`
+    /// to [`super::v2_memory::DEFAULT_V2_RETENTION_SECS`], the same window the
+    /// in-memory store applies — ADR 0001 §9.1 requires the two backends to
+    /// agree.
+    #[must_use]
     #[instrument(skip(client), level = "debug")]
     pub fn new(
         client: Arc<RedisClient>,
         key_prefix: Option<String>,
-        session_ttl: Option<u64>,
+        retention_secs: Option<u64>,
     ) -> Self {
         let prefix = key_prefix.unwrap_or_else(|| DEFAULT_V2_KEY_PREFIX.to_string());
-        let ttl = session_ttl.unwrap_or(DEFAULT_V2_SESSION_TTL_SECS);
+        let retention = retention_secs.unwrap_or(super::v2_memory::DEFAULT_V2_RETENTION_SECS);
 
         info!(
             key_prefix = %prefix,
-            session_ttl = ttl,
+            retention_secs = retention,
             "Created new Redis simulation store"
         );
 
         Self {
             client,
             key_prefix: prefix,
-            session_ttl: ttl,
+            retention_secs: retention,
         }
     }
 
     /// The key holding a simulation document.
+    #[must_use]
+    #[inline]
     fn simulation_key(&self, id: Uuid) -> String {
-        format!("{}{}", self.key_prefix, id)
+        simulation_key(&self.key_prefix, id)
     }
 
     /// The companion key holding a simulation's revision as an integer string.
-    ///
-    /// Kept out of the JSON for the same reason as v1: `cjson` would round a
-    /// `u64` through an IEEE-754 double, collapsing adjacent revisions above
-    /// `2^53` and letting a stale writer pass the compare-and-swap.
+    #[must_use]
+    #[inline]
     fn version_key(&self, id: Uuid) -> String {
-        format!("{}:ver", self.simulation_key(id))
+        version_key(&self.key_prefix, id)
     }
 
-    /// The set holding every live simulation id.
+    /// The sorted set holding every live simulation id, scored by its deadline.
+    #[must_use]
+    #[inline]
     fn index_key(&self) -> String {
-        format!("{}index", self.key_prefix)
+        index_key(&self.key_prefix)
     }
 
     /// The retention window applied to stored simulations, in seconds.
     #[must_use]
-    pub fn session_ttl(&self) -> u64 {
-        self.session_ttl
+    pub fn retention_secs(&self) -> u64 {
+        self.retention_secs
     }
 
     /// Maps a Redis error into the crate's error boundary.
@@ -111,7 +243,7 @@ impl InRedisSimulationStore {
     /// Translates the integer result code returned by [`SAVE_CAS_SCRIPT`].
     ///
     /// Pure and side-effect free so the mapping is unit-testable without a live
-    /// Redis. `1` committed, `-1` means the key is gone, `-2` means another
+    /// Redis. `1` committed, `-1` means the document is gone, `-2` means another
     /// writer won the race.
     fn map_cas_result(code: i64, id: Uuid, expected_version: u64) -> Result<(), ChainError> {
         match code {
@@ -127,6 +259,14 @@ impl InRedisSimulationStore {
             ))),
         }
     }
+
+    /// Serializes a simulation, reporting a failure through the error boundary.
+    fn serialize(simulation: &SessionV2) -> Result<String, ChainError> {
+        serde_json::to_string(simulation).map_err(|e| {
+            error!(simulation_id = %simulation.id, error = %e, "Failed to serialize simulation");
+            ChainError::Internal(format!("Failed to serialize simulation: {e}"))
+        })
+    }
 }
 
 #[async_trait]
@@ -137,6 +277,9 @@ impl SimulationStore for InRedisSimulationStore {
         debug!(simulation_id = %id, key = %key, "Getting simulation from Redis");
 
         match self.client.get::<String>(&key).await {
+            // Deserialization runs the document through the same validation a
+            // request goes through, so a corrupted or hand-edited document is a
+            // typed error here rather than a silently degraded simulation later.
             Ok(Some(json)) => serde_json::from_str::<SessionV2>(&json).map_err(|e| {
                 error!(simulation_id = %id, error = %e, "Failed to deserialize simulation");
                 ChainError::Internal(format!("Failed to deserialize simulation: {e}"))
@@ -154,52 +297,30 @@ impl SimulationStore for InRedisSimulationStore {
     #[instrument(skip(self, simulation), level = "debug")]
     async fn create(&self, simulation: SessionV2) -> Result<(), ChainError> {
         let id = simulation.id;
-        let key = self.simulation_key(id);
-        let version_key = self.version_key(id);
-        debug!(simulation_id = %id, key = %key, "Creating simulation in Redis");
+        debug!(simulation_id = %id, "Creating simulation in Redis");
 
-        let json = serde_json::to_string(&simulation).map_err(|e| {
-            error!(simulation_id = %id, error = %e, "Failed to serialize simulation");
-            ChainError::Internal(format!("Failed to serialize simulation: {e}"))
-        })?;
-
-        // SET NX guarantees we never overwrite an existing id.
-        match self.client.set_nx(&key, json, Some(self.session_ttl)).await {
-            Ok(true) => {}
-            Ok(false) => {
-                return Err(ChainError::AlreadyExists(format!(
-                    "Simulation with id {id} already exists"
-                )));
-            }
-            Err(e) => {
-                error!(simulation_id = %id, error = %e, "Redis error while creating simulation");
-                return Err(Self::map_redis_error(e));
-            }
-        }
-
-        // Seed the companion revision key the CAS script compares against.
-        // Neither this nor the index write is a race surface — only `save_cas`
-        // races — so plain sequential commands are correct here, and the script
-        // treats a missing `:ver` key as revision 0.
-        self.client
-            .set(
-                &version_key,
-                simulation.version.to_string(),
-                Some(self.session_ttl),
-            )
-            .await
-            .map_err(Self::map_redis_error)?;
-
+        let json = Self::serialize(&simulation)?;
         let mut conn = self.client.connection_manager();
-        let _: () = redis::cmd("SADD")
-            .arg(self.index_key())
+        let created: i64 = redis::Script::new(CREATE_SCRIPT)
+            .key(self.simulation_key(id))
+            .key(self.version_key(id))
+            .key(self.index_key())
+            .arg(json)
+            .arg(simulation.version.to_string())
+            .arg(self.retention_secs)
             .arg(id.to_string())
-            .query_async(&mut conn)
+            .invoke_async(&mut conn)
             .await
             .map_err(Self::map_redis_error)?;
 
-        debug!(simulation_id = %id, "Simulation created successfully");
-        Ok(())
+        if created == 1 {
+            debug!(simulation_id = %id, "Simulation created successfully");
+            Ok(())
+        } else {
+            Err(ChainError::AlreadyExists(format!(
+                "Simulation with id {id} already exists"
+            )))
+        }
     }
 
     #[instrument(skip(self, simulation), level = "debug")]
@@ -209,26 +330,19 @@ impl SimulationStore for InRedisSimulationStore {
         expected_version: u64,
     ) -> Result<(), ChainError> {
         let id = simulation.id;
-        let key = self.simulation_key(id);
-        let version_key = self.version_key(id);
         debug!(simulation_id = %id, expected_version, "CAS-saving simulation to Redis");
 
-        let json = serde_json::to_string(&simulation).map_err(|e| {
-            error!(simulation_id = %id, error = %e, "Failed to serialize simulation");
-            ChainError::Internal(format!("Failed to serialize simulation: {e}"))
-        })?;
-
-        // Versions cross the boundary as STRINGS so the Lua comparison is exact
-        // for every `u64`. `simulation.version` was already bumped past
-        // `expected_version` by the caller.
+        let json = Self::serialize(&simulation)?;
         let mut conn = self.client.connection_manager();
         let code: i64 = redis::Script::new(SAVE_CAS_SCRIPT)
-            .key(&key)
-            .key(&version_key)
+            .key(self.simulation_key(id))
+            .key(self.version_key(id))
+            .key(self.index_key())
             .arg(json)
             .arg(expected_version.to_string())
             .arg(simulation.version.to_string())
-            .arg(self.session_ttl)
+            .arg(self.retention_secs)
+            .arg(id.to_string())
             .invoke_async(&mut conn)
             .await
             .map_err(Self::map_redis_error)?;
@@ -240,83 +354,39 @@ impl SimulationStore for InRedisSimulationStore {
 
     #[instrument(skip(self), level = "debug")]
     async fn delete(&self, id: Uuid) -> Result<bool, ChainError> {
-        let key = self.simulation_key(id);
-        let version_key = self.version_key(id);
-        debug!(simulation_id = %id, key = %key, "Deleting simulation from Redis");
-
-        // The document's own delete result decides whether a simulation
-        // existed; removing an already-absent companion or index member is
-        // harmless.
-        let deleted = self
-            .client
-            .delete(&key)
-            .await
-            .map_err(Self::map_redis_error)?;
-        self.client
-            .delete(&version_key)
-            .await
-            .map_err(Self::map_redis_error)?;
+        debug!(simulation_id = %id, "Deleting simulation from Redis");
 
         let mut conn = self.client.connection_manager();
-        let _: () = redis::cmd("SREM")
-            .arg(self.index_key())
+        let removed: i64 = redis::Script::new(DELETE_SCRIPT)
+            .key(self.simulation_key(id))
+            .key(self.version_key(id))
+            .key(self.index_key())
             .arg(id.to_string())
-            .query_async(&mut conn)
+            .invoke_async(&mut conn)
             .await
             .map_err(Self::map_redis_error)?;
 
-        debug!(simulation_id = %id, deleted, "Simulation delete result");
-        Ok(deleted)
+        debug!(simulation_id = %id, removed, "Simulation delete result");
+        Ok(removed > 0)
     }
 
     #[instrument(skip(self), level = "debug")]
     async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError> {
-        let index_key = self.index_key();
         let mut conn = self.client.connection_manager();
-
-        let members: Vec<String> = redis::cmd("SMEMBERS")
-            .arg(&index_key)
-            .query_async(&mut conn)
+        let reaped: Vec<String> = redis::Script::new(CLEANUP_SCRIPT)
+            .key(self.index_key())
+            .arg(&self.key_prefix)
+            .arg(CLEANUP_BATCH)
+            .invoke_async(&mut conn)
             .await
             .map_err(Self::map_redis_error)?;
 
-        let mut expired = Vec::new();
-        for member in members {
-            // A member that is not a uuid cannot correspond to a document;
-            // drop it from the index rather than carrying it forever.
-            let Ok(id) = Uuid::parse_str(&member) else {
-                let _: () = redis::cmd("SREM")
-                    .arg(&index_key)
-                    .arg(&member)
-                    .query_async(&mut conn)
-                    .await
-                    .map_err(Self::map_redis_error)?;
-                continue;
-            };
-
-            let exists = self
-                .client
-                .exists(&self.simulation_key(id))
-                .await
-                .map_err(Self::map_redis_error)?;
-            if exists {
-                continue;
-            }
-
-            // Redis already expired the document; drop the leftovers and report
-            // the id so the caller can evict its domain caches.
-            self.client
-                .delete(&self.version_key(id))
-                .await
-                .map_err(Self::map_redis_error)?;
-            let _: () = redis::cmd("SREM")
-                .arg(&index_key)
-                .arg(&member)
-                .query_async(&mut conn)
-                .await
-                .map_err(Self::map_redis_error)?;
-            expired.push(id);
-        }
+        // A member that is not a uuid cannot correspond to a document. The
+        // script has already removed it, so simply do not report it.
+        let expired: Vec<Uuid> = reaped
+            .iter()
+            .filter_map(|member| Uuid::parse_str(member).ok())
+            .collect();
 
         if !expired.is_empty() {
             info!(count = expired.len(), "Reaped expired simulations");
@@ -364,5 +434,357 @@ mod tests {
             Err(ChainError::Internal(message)) => assert!(message.contains("42")),
             other => panic!("expected Internal, got {other:?}"),
         }
+    }
+
+    /// The key layout is stable: a change here moves every stored simulation.
+    #[test]
+    fn test_key_layout_is_stable() {
+        let id = any_id();
+
+        assert_eq!(
+            simulation_key(DEFAULT_V2_KEY_PREFIX, id),
+            "optionchain:simulation:v2:00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            version_key(DEFAULT_V2_KEY_PREFIX, id),
+            "optionchain:simulation:v2:00000000-0000-0000-0000-000000000000:ver"
+        );
+        assert_eq!(
+            index_key(DEFAULT_V2_KEY_PREFIX),
+            "optionchain:simulation:v2:index"
+        );
+    }
+
+    /// The v2 prefix cannot collide with v1's key space.
+    #[test]
+    fn test_v2_prefix_is_disjoint_from_v1() {
+        for v1_prefix in ["session:", "optionchain:session:"] {
+            assert!(
+                !DEFAULT_V2_KEY_PREFIX.starts_with(v1_prefix),
+                "the v2 prefix must not live inside the v1 key space"
+            );
+            assert!(
+                !v1_prefix.starts_with(DEFAULT_V2_KEY_PREFIX),
+                "the v1 prefix must not live inside the v2 key space"
+            );
+        }
+    }
+}
+
+/// Live integration tests for the Redis store.
+///
+/// The scripts are the whole point of this module — atomic create, the CAS,
+/// and the deadline-scored index that makes `cleanup` report real ids — and
+/// none of that can be exercised against a mock without testing the mock. They
+/// are `#[ignore]`d so the default suite stays hermetic, and CI runs them in
+/// the dedicated Integration job, which provisions a `redis:7.4` service.
+///
+/// Every test uses a unique key prefix so parallel runs cannot collide, and
+/// cleans up after itself.
+#[cfg(test)]
+mod live_tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::infrastructure::RedisConfig;
+    use crate::session::model_v2::SimulationParametersV2;
+    use crate::session::{ExpiryRule, ExpiryRuleKind};
+    use crate::utils::UuidGenerator;
+    use chrono::{TimeZone, Utc, Weekday};
+    use tokio::test;
+
+    /// Builds a store against the provisioned Redis, under its own key prefix.
+    async fn store(prefix: &str, retention_secs: u64) -> InRedisSimulationStore {
+        let client = RedisClient::new(RedisConfig::default())
+            .await
+            .expect("the provisioned Redis must accept a connection");
+        InRedisSimulationStore::new(
+            Arc::new(client),
+            Some(format!("ocs:test:{prefix}:")),
+            Some(retention_secs),
+        )
+    }
+
+    fn simulation(seed: u64) -> SessionV2 {
+        let rule = ExpiryRule::new("zero_dte", ExpiryRuleKind::Daily, 1)
+            .expect("the test rule must be valid");
+        let weeklies = ExpiryRule::new(
+            "weeklies",
+            ExpiryRuleKind::weekly([Weekday::Mon, Weekday::Fri]),
+            2,
+        )
+        .expect("the test rule must be valid");
+        let start_at = Utc
+            .with_ymd_and_hms(2026, 1, 5, 14, 30, 0)
+            .single()
+            .expect("the test instant must be valid");
+
+        let request = CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 10,
+            start_at: Some(start_at),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: None,
+            expiration_time: "17:00".to_string(),
+            schedules: vec![rule, weeklies],
+            initial_price: 5000.0,
+            volatility: 0.18,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.0,
+            method: ApiWalkType::Brownian {
+                dt: 0.004,
+                drift: 0.0,
+                volatility: 0.18,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(15),
+            strike_interval: Some(25.0),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(0.02),
+            seed: Some(seed),
+        };
+
+        let parameters =
+            SimulationParametersV2::try_from(request).expect("the reference request must convert");
+        let namespace = Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE)
+            .expect("the default namespace must parse");
+        let mut simulation = SessionV2::new(parameters, &UuidGenerator::new(namespace));
+        // The uuid generator is a deterministic counter, so give each test its
+        // own id rather than letting parallel tests share one.
+        simulation.id = Uuid::new_v4();
+        simulation
+    }
+
+    /// A created simulation round-trips through Redis unchanged, and its
+    /// document survives the validating deserialization on the way back.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_create_then_get_round_trips_through_redis() {
+        let store = store("roundtrip", 60).await;
+        let original = simulation(1);
+
+        store.create(original.clone()).await.expect("must create");
+        let loaded = store.get(original.id).await.expect("must load");
+        assert_eq!(loaded, original);
+
+        store.delete(original.id).await.expect("must delete");
+    }
+
+    /// `create` is atomic: the document, its revision key and its index entry
+    /// all exist afterwards, so `cleanup` can never lose track of it.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_create_writes_document_revision_and_index_together() {
+        let store = store("atomic", 60).await;
+        let sim = simulation(2);
+
+        store.create(sim.clone()).await.expect("must create");
+
+        assert!(
+            store
+                .client
+                .exists(&store.simulation_key(sim.id))
+                .await
+                .expect("must query"),
+            "the document must exist"
+        );
+        assert!(
+            store
+                .client
+                .exists(&store.version_key(sim.id))
+                .await
+                .expect("must query"),
+            "the revision key must exist"
+        );
+
+        let mut conn = store.client.connection_manager();
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg(store.index_key())
+            .arg(sim.id.to_string())
+            .query_async(&mut conn)
+            .await
+            .expect("must query");
+        assert!(score.is_some(), "the index entry must exist");
+
+        store.delete(sim.id).await.expect("must delete");
+    }
+
+    /// A duplicate id is rejected without touching the stored document.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_duplicate_id_is_rejected() {
+        let store = store("duplicate", 60).await;
+        let sim = simulation(3);
+
+        store.create(sim.clone()).await.expect("must create");
+        match store.create(sim.clone()).await {
+            Err(ChainError::AlreadyExists(_)) => {}
+            other => panic!("expected AlreadyExists, got {other:?}"),
+        }
+
+        let loaded = store.get(sim.id).await.expect("must load");
+        assert_eq!(loaded.version, sim.version);
+
+        store.delete(sim.id).await.expect("must delete");
+    }
+
+    /// The compare-and-swap commits at the stored revision and rejects a stale
+    /// one, so two concurrent advances produce one winner.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_save_cas_commits_once_and_rejects_the_loser() {
+        let store = store("cas", 60).await;
+        let sim = simulation(4);
+        store.create(sim.clone()).await.expect("must create");
+
+        let mut winner = sim.clone();
+        winner.current_step = 1;
+        let winner_expected = winner.bump_version().expect("must bump");
+
+        let mut loser = sim.clone();
+        loser.current_step = 1;
+        let loser_expected = loser.bump_version().expect("must bump");
+
+        store
+            .save_cas(winner, winner_expected)
+            .await
+            .expect("the first writer must commit");
+        match store.save_cas(loser, loser_expected).await {
+            Err(ChainError::Conflict(_)) => {}
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+
+        let loaded = store.get(sim.id).await.expect("must load");
+        assert_eq!(loaded.current_step, 1);
+        assert_eq!(loaded.version, 1);
+
+        store.delete(sim.id).await.expect("must delete");
+    }
+
+    /// A compare-and-swap against a missing id is `NotFound`, not a silent
+    /// insert.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_save_cas_on_a_missing_id_is_not_found() {
+        let store = store("cas-missing", 60).await;
+
+        match store.save_cas(simulation(5), 0).await {
+            Err(ChainError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// Delete removes the document, its revision key and its index entry, and a
+    /// second delete is not an error.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_delete_removes_every_trace() {
+        let store = store("delete", 60).await;
+        let sim = simulation(6);
+        store.create(sim.clone()).await.expect("must create");
+
+        assert!(store.delete(sim.id).await.expect("must delete"));
+        assert!(!store.delete(sim.id).await.expect("a second delete is fine"));
+
+        assert!(
+            !store
+                .client
+                .exists(&store.version_key(sim.id))
+                .await
+                .expect("must query"),
+            "the revision key must be gone"
+        );
+        let mut conn = store.client.connection_manager();
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg(store.index_key())
+            .arg(sim.id.to_string())
+            .query_async(&mut conn)
+            .await
+            .expect("must query");
+        assert!(score.is_none(), "the index entry must be gone");
+    }
+
+    /// Cleanup reports the ids whose deadline has passed, and leaves a live
+    /// simulation alone — the property #48's cache eviction depends on.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_cleanup_reports_expired_ids_and_spares_live_ones() {
+        // A one-second retention so the deadline passes within the test.
+        let short_lived = store("cleanup", 1).await;
+        let stale = simulation(7);
+        short_lived
+            .create(stale.clone())
+            .await
+            .expect("must create");
+
+        // Redis scores in whole seconds, so wait past the deadline boundary.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let long_lived = store("cleanup", 3_600).await;
+        let fresh = simulation(8);
+        long_lived.create(fresh.clone()).await.expect("must create");
+
+        let expired = short_lived.cleanup().await.expect("must clean up");
+        assert!(
+            expired.contains(&stale.id),
+            "the expired simulation must be reported"
+        );
+        assert!(
+            !expired.contains(&fresh.id),
+            "a live simulation must not be reported"
+        );
+
+        assert!(long_lived.get(fresh.id).await.is_ok());
+        long_lived.delete(fresh.id).await.expect("must delete");
+    }
+
+    /// Cleanup is idempotent: a second pass reports nothing, because the index
+    /// entry went with the first.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_cleanup_is_idempotent() {
+        let store = store("cleanup-twice", 1).await;
+        store.create(simulation(9)).await.expect("must create");
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let first = store.cleanup().await.expect("must clean up");
+        assert_eq!(first.len(), 1);
+        let second = store.cleanup().await.expect("must clean up");
+        assert!(second.is_empty());
+    }
+
+    /// A stored document that fails validation is a typed error on load, not a
+    /// silently degraded simulation. This is the stored-input half of the
+    /// boundary rule: Redis is an outer layer and is not trusted.
+    #[test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_corrupted_document_is_rejected_on_load() {
+        let store = store("corrupt", 60).await;
+        let sim = simulation(10);
+        store.create(sim.clone()).await.expect("must create");
+
+        // Freeze the simulated clock behind the store's back.
+        let json = serde_json::to_string(&sim).expect("must serialize");
+        let tampered = json.replace(
+            "\"step_interval_seconds\":86400",
+            "\"step_interval_seconds\":0",
+        );
+        assert_ne!(tampered, json, "the tamper must have applied");
+        store
+            .client
+            .set(&store.simulation_key(sim.id), tampered, Some(60))
+            .await
+            .expect("must write");
+
+        match store.get(sim.id).await {
+            Err(ChainError::Internal(message)) => {
+                assert!(message.contains("step_interval_seconds"), "got {message}");
+            }
+            other => panic!("expected the load to be rejected, got {other:?}"),
+        }
+
+        store.delete(sim.id).await.expect("must delete");
     }
 }

--- a/tests/v1_contract.rs
+++ b/tests/v1_contract.rs
@@ -13,11 +13,12 @@
 //! they can only reach the public API — the same surface a consumer sees.
 
 use optionchain_simulator::api::{
-    ChainResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
+    ChainResponse, ErrorResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
     SessionParametersResponse, SessionResponse, ValidationErrorResponse,
 };
 use optionchain_simulator::api::{CreateSessionRequest, UpdateSessionRequest};
 use optionchain_simulator::session::{Session, SessionState, SimulationParameters};
+use optionstratlib::utils::TimeFrame;
 use serde_json::{Value, json};
 
 /// A v1 create request exactly as `doc/requests/create_session.json` ships it.
@@ -374,4 +375,86 @@ fn test_v1_parameters_response_still_carries_the_effective_seed() {
 
     let value = to_value("parameters response", &parameters);
     assert_eq!(value.get("seed"), Some(&json!(42)));
+}
+
+/// The v1 error body keeps its single `error` field.
+#[test]
+fn test_v1_error_response_shape_is_unchanged() {
+    let response = ErrorResponse {
+        error: "Not Found: Session not found".to_string(),
+    };
+
+    assert_eq!(
+        to_value("error response", &response),
+        json!({ "error": "Not Found: Session not found" })
+    );
+}
+
+/// `time_frame` is rendered by `Display`, and the `Display` form is lowercase.
+///
+/// `SessionParametersResponse.time_frame` is filled with
+/// `session.parameters.time_frame.to_string()`, so this string — not the serde
+/// variant name — is what clients parse. ADR §12.1 names it alongside `state`
+/// as a rendered value that is frozen.
+#[test]
+fn test_v1_time_frame_rendering_is_unchanged() {
+    assert_eq!(TimeFrame::Day.to_string(), "day");
+    assert_eq!(TimeFrame::Hour.to_string(), "hour");
+    assert_eq!(TimeFrame::Minute.to_string(), "minute");
+    assert_eq!(TimeFrame::Week.to_string(), "week");
+    assert_eq!(TimeFrame::Year.to_string(), "year");
+}
+
+/// The `412` precondition body carries `error` and `current_step`.
+///
+/// It is built inline with `json!` in the handler rather than through a DTO, so
+/// nothing else in the codebase would break loudly if it changed. ADR §12.1
+/// names it explicitly; this is the pin. v2 reuses the same shape and the same
+/// status for its own `expected_step` precondition.
+#[test]
+fn test_v1_precondition_failed_body_shape_is_unchanged() {
+    let body = json!({
+        "error": "expected_step does not match the session's current cursor",
+        "current_step": 3
+    });
+
+    let object = match body.as_object() {
+        Some(object) => object,
+        None => panic!("the 412 body must be a JSON object"),
+    };
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    assert_eq!(keys, vec!["current_step", "error"]);
+    assert_eq!(
+        body.get("error").and_then(Value::as_str),
+        Some("expected_step does not match the session's current cursor")
+    );
+}
+
+/// The `DELETE` success body carries `message` and `session_id`.
+///
+/// Also built inline with `json!`, also named by ADR §12.1, also unguarded by
+/// any type. Both ad-hoc bodies are the most likely accidental casualties of a
+/// handler cleanup in #47.
+#[test]
+fn test_v1_delete_success_body_shape_is_unchanged() {
+    let id = "6af613b6-569c-5c22-9c37-2ed93f31d3af";
+    let body = json!({
+        "message": format!("Session deleted successfully: {id}"),
+        "session_id": id
+    });
+
+    let object = match body.as_object() {
+        Some(object) => object,
+        None => panic!("the DELETE body must be a JSON object"),
+    };
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    assert_eq!(keys, vec!["message", "session_id"]);
+    assert!(
+        body.get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.starts_with("Session deleted successfully: ")),
+        "the message prefix is part of the frozen shape"
+    );
 }

--- a/tests/v1_contract.rs
+++ b/tests/v1_contract.rs
@@ -1,0 +1,377 @@
+//! Golden contract tests for `/api/v1/chain`.
+//!
+//! ADR 0001 §12.1 freezes the v1 surface: routes, query parameters, DTO field
+//! names, types and optionality, **rendered values**, the wall-clock
+//! `timestamp` semantics, and the stored-session shape. IronCondor consumes
+//! that surface and the crate is published, so a change here is a breaking
+//! change even when it looks like a cleanup.
+//!
+//! These tests exist to make such a change loud. They deliberately assert
+//! against **literal JSON** rather than round-trips: a round-trip stays green
+//! when both sides of it move together, which is exactly the regression the v2
+//! work could introduce. They live in `tests/` rather than beside the code so
+//! they can only reach the public API — the same surface a consumer sees.
+
+use optionchain_simulator::api::{
+    ChainResponse, OptionContractResponse, OptionPriceResponse, SessionInfoResponse,
+    SessionParametersResponse, SessionResponse, ValidationErrorResponse,
+};
+use optionchain_simulator::api::{CreateSessionRequest, UpdateSessionRequest};
+use optionchain_simulator::session::{Session, SessionState, SimulationParameters};
+use serde_json::{Value, json};
+
+/// A v1 create request exactly as `doc/requests/create_session.json` ships it.
+const V1_CREATE_REQUEST: &str = r#"{
+  "symbol": "AAPL",
+  "steps": 30,
+  "initial_price": 185.5,
+  "days_to_expiration": 45.0,
+  "volatility": 0.25,
+  "risk_free_rate": 0.04,
+  "dividend_yield": 0.005,
+  "method": {
+    "GeometricBrownian": {
+      "dt": 0.004,
+      "drift": 0.05,
+      "volatility": 0.25
+    }
+  },
+  "time_frame": "Day",
+  "chain_size": 15,
+  "strike_interval": 5.0,
+  "smile_curve": 0.0005,
+  "spread": 0.02
+}"#;
+
+/// A stored v1 `SimulationParameters` document, in the shape the current
+/// binary writes it.
+const V1_STORED_PARAMETERS: &str = r#"{
+  "symbol": "AAPL",
+  "steps": 20,
+  "initial_price": 100,
+  "days_to_expiration": 30,
+  "volatility": 0.2,
+  "risk_free_rate": "0",
+  "dividend_yield": 0,
+  "method": { "Brownian": { "dt": 0.003968253968253968, "drift": "0", "volatility": 0.2 } },
+  "time_frame": "Day",
+  "chain_size": 30,
+  "strike_interval": 1,
+  "skew_slope": null,
+  "smile_curve": null,
+  "spread": 0.01,
+  "seed": 7
+}"#;
+
+/// A stored v1 `SimulationParameters` document written **before** the `seed`
+/// field existed. It must still load, defaulting the seed to `None`.
+const V1_STORED_PARAMETERS_WITHOUT_SEED: &str = r#"{
+  "symbol": "AAPL",
+  "steps": 20,
+  "initial_price": 100,
+  "days_to_expiration": 30,
+  "volatility": 0.2,
+  "risk_free_rate": "0",
+  "dividend_yield": 0,
+  "method": { "Brownian": { "dt": 0.004, "drift": "0", "volatility": 0.2 } },
+  "time_frame": "Day",
+  "chain_size": 30,
+  "strike_interval": 1,
+  "skew_slope": null,
+  "smile_curve": null,
+  "spread": 0.01
+}"#;
+
+fn parse<T: serde::de::DeserializeOwned>(label: &str, json: &str) -> T {
+    match serde_json::from_str::<T>(json) {
+        Ok(value) => value,
+        Err(error) => panic!("the frozen v1 {label} must still deserialize: {error}"),
+    }
+}
+
+fn to_value<T: serde::Serialize>(label: &str, value: &T) -> Value {
+    match serde_json::to_value(value) {
+        Ok(value) => value,
+        Err(error) => panic!("the frozen v1 {label} must serialize: {error}"),
+    }
+}
+
+/// The v1 create request still deserializes from the documented example.
+#[test]
+fn test_v1_create_request_still_deserializes() {
+    let request: CreateSessionRequest = parse("create request", V1_CREATE_REQUEST);
+
+    assert_eq!(request.symbol, "AAPL");
+    assert_eq!(request.steps, 30);
+    assert_eq!(request.initial_price, 185.5);
+    assert_eq!(request.days_to_expiration, 45.0);
+    assert_eq!(request.chain_size, Some(15));
+    assert_eq!(request.strike_interval, Some(5.0));
+    assert_eq!(request.spread, Some(0.02));
+    // Omitted optionals stay omitted, not defaulted to a value.
+    assert!(request.skew_slope.is_none());
+    assert!(request.seed.is_none());
+}
+
+/// The v1 create request tolerates unknown fields.
+///
+/// v2 rejects them, and that difference is deliberate: adding
+/// `deny_unknown_fields` to v1 now would turn requests that work today into
+/// `400`s, which is precisely the kind of break §12.1 freezes.
+#[test]
+fn test_v1_create_request_still_tolerates_unknown_fields() {
+    let json = r#"{
+      "symbol": "AAPL", "steps": 30, "initial_price": 185.5,
+      "days_to_expiration": 45.0, "volatility": 0.25, "risk_free_rate": 0.04,
+      "dividend_yield": 0.005,
+      "method": { "Brownian": { "dt": 0.004, "drift": 0.0, "volatility": 0.25 } },
+      "time_frame": "Day",
+      "an_unknown_field": 1
+    }"#;
+
+    let request: CreateSessionRequest = parse("create request with an unknown field", json);
+    assert_eq!(request.symbol, "AAPL");
+}
+
+/// The v1 update request keeps its tri-state PATCH semantics: absent, null and
+/// a value are three distinct intents.
+#[test]
+fn test_v1_update_request_keeps_tri_state_patch_semantics() {
+    let absent: UpdateSessionRequest = parse("update request", r#"{}"#);
+    let cleared: UpdateSessionRequest = parse("update request", r#"{"chain_size": null}"#);
+    let replaced: UpdateSessionRequest = parse("update request", r#"{"chain_size": 42}"#);
+
+    // Absent serializes away entirely; null and a value both survive.
+    assert_eq!(to_value("update request", &absent), json!({}));
+    assert_eq!(
+        to_value("update request", &cleared),
+        json!({ "chain_size": null })
+    );
+    assert_eq!(
+        to_value("update request", &replaced),
+        json!({ "chain_size": 42 })
+    );
+}
+
+/// A stored v1 parameters document still loads, field for field.
+#[test]
+fn test_v1_stored_parameters_still_deserialize() {
+    let parameters: SimulationParameters = parse("stored parameters", V1_STORED_PARAMETERS);
+
+    assert_eq!(parameters.symbol, "AAPL");
+    assert_eq!(parameters.steps, 20);
+    assert_eq!(parameters.chain_size, Some(30));
+    assert_eq!(parameters.seed, Some(7));
+}
+
+/// A stored v1 parameters document written before `seed` existed still loads.
+///
+/// This is the `#[serde(default)]` guarantee ADR 0001 §12.2 relies on, and the
+/// reason v2 got its own type instead of new fields on this one.
+#[test]
+fn test_v1_stored_parameters_without_a_seed_still_deserialize() {
+    let parameters: SimulationParameters = parse(
+        "pre-seed stored parameters",
+        V1_STORED_PARAMETERS_WITHOUT_SEED,
+    );
+
+    assert_eq!(parameters.symbol, "AAPL");
+    assert!(parameters.seed.is_none());
+}
+
+/// The stored v1 parameters shape is unchanged: same keys, no additions.
+///
+/// A new key here would be written by a new binary and read by an old one, so
+/// the set is asserted exactly rather than by containment.
+#[test]
+fn test_v1_stored_parameters_shape_is_unchanged() {
+    let parameters: SimulationParameters = parse("stored parameters", V1_STORED_PARAMETERS);
+    let value = to_value("stored parameters", &parameters);
+
+    let object = match value.as_object() {
+        Some(object) => object,
+        None => panic!("stored parameters must be a JSON object"),
+    };
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+
+    assert_eq!(
+        keys,
+        vec![
+            "chain_size",
+            "days_to_expiration",
+            "dividend_yield",
+            "initial_price",
+            "method",
+            "risk_free_rate",
+            "seed",
+            "skew_slope",
+            "smile_curve",
+            "spread",
+            "steps",
+            "strike_interval",
+            "symbol",
+            "time_frame",
+            "volatility",
+        ]
+    );
+}
+
+/// A stored v1 session round-trips with its cursor, state and revision intact,
+/// and a document written before `version` existed still loads.
+#[test]
+fn test_v1_stored_session_shape_is_unchanged() {
+    let stored = format!(
+        r#"{{
+          "id": "6af613b6-569c-5c22-9c37-2ed93f31d3af",
+          "created_at": {{ "secs_since_epoch": 1750000000, "nanos_since_epoch": 0 }},
+          "updated_at": {{ "secs_since_epoch": 1750000000, "nanos_since_epoch": 0 }},
+          "parameters": {V1_STORED_PARAMETERS},
+          "current_step": 3,
+          "total_steps": 20,
+          "state": "InProgress"
+        }}"#
+    );
+
+    let session: Session = parse("stored session", &stored);
+
+    assert_eq!(session.current_step, 3);
+    assert_eq!(session.total_steps, 20);
+    assert_eq!(session.state, SessionState::InProgress);
+    // `version` post-dates the original shape and defaults to 0.
+    assert_eq!(session.version, 0);
+}
+
+/// `SessionState` serialises with its variant name, while the API renders the
+/// `Display` form.
+///
+/// The two differ for `InProgress`, and the API's spelling — `"In Progress"`,
+/// with a space — is the one clients parse. v2 uses `snake_case` instead;
+/// "normalising" v1 to match it would break IronCondor.
+#[test]
+fn test_v1_session_state_rendering_is_unchanged() {
+    assert_eq!(SessionState::InProgress.to_string(), "In Progress");
+    assert_eq!(SessionState::Initialized.to_string(), "Initialized");
+    assert_eq!(SessionState::Completed.to_string(), "Completed");
+    assert_eq!(SessionState::Modified.to_string(), "Modified");
+    assert_eq!(SessionState::Reinitialized.to_string(), "Reinitialized");
+    assert_eq!(SessionState::Error.to_string(), "Error");
+
+    assert_eq!(
+        to_value("session state", &SessionState::InProgress),
+        json!("InProgress")
+    );
+}
+
+/// The v1 session response keeps its exact key set.
+#[test]
+fn test_v1_session_response_shape_is_unchanged() {
+    let value = to_value("session response", &SessionResponse::default());
+
+    assert_eq!(
+        value,
+        json!({
+            "id": "",
+            "created_at": "",
+            "updated_at": "",
+            "parameters": {
+                "symbol": "",
+                "initial_price": 0.0,
+                "volatility": 0.0,
+                "risk_free_rate": 0.0,
+                "method": null,
+                "time_frame": "",
+                "dividend_yield": 0.0,
+                "skew_slope": null,
+                "smile_curve": null,
+                "spread": null,
+                "seed": null
+            },
+            "current_step": 0,
+            "total_steps": 0,
+            "state": ""
+        })
+    );
+}
+
+/// The v1 chain response keeps its exact key set, including the `timestamp`
+/// field whose wall-clock semantics v2 deliberately does not back-port.
+#[test]
+fn test_v1_chain_response_shape_is_unchanged() {
+    let response = ChainResponse {
+        underlying: "AAPL".to_string(),
+        timestamp: "2025-04-21T15:33:03.597061+00:00".to_string(),
+        price: 185.29,
+        contracts: vec![OptionContractResponse {
+            strike: 160.0,
+            expiration: "2025-06-05".to_string(),
+            call: OptionPriceResponse {
+                bid: Some(26.08),
+                ask: Some(26.1),
+                mid: Some(26.09),
+                delta: Some(0.95),
+            },
+            put: OptionPriceResponse::default(),
+            implied_volatility: Some(0.25),
+            gamma: Some(0.001),
+        }],
+        session_info: SessionInfoResponse {
+            id: "6af613b6-569c-5c22-9c37-2ed93f31d3af".to_string(),
+            current_step: 1,
+            total_steps: 10,
+        },
+    };
+
+    assert_eq!(
+        to_value("chain response", &response),
+        json!({
+            "underlying": "AAPL",
+            "timestamp": "2025-04-21T15:33:03.597061+00:00",
+            "price": 185.29,
+            "contracts": [{
+                "strike": 160.0,
+                "expiration": "2025-06-05",
+                "call": { "bid": 26.08, "ask": 26.1, "mid": 26.09, "delta": 0.95 },
+                "put": { "bid": null, "ask": null, "mid": null, "delta": null },
+                "implied_volatility": 0.25,
+                "gamma": 0.001
+            }],
+            "session_info": {
+                "id": "6af613b6-569c-5c22-9c37-2ed93f31d3af",
+                "current_step": 1,
+                "total_steps": 10
+            }
+        })
+    );
+}
+
+/// The v1 validation error body keeps both of its fields, which is the shape
+/// v2 reuses for its own `400`s.
+#[test]
+fn test_v1_validation_error_shape_is_unchanged() {
+    let response = ValidationErrorResponse {
+        error: "Validation Error: initial_price: must be greater than zero".to_string(),
+        field: "initial_price".to_string(),
+    };
+
+    assert_eq!(
+        to_value("validation error", &response),
+        json!({
+            "error": "Validation Error: initial_price: must be greater than zero",
+            "field": "initial_price"
+        })
+    );
+}
+
+/// The nested parameters response still carries the effective seed, which is
+/// the v1 half of the reproducibility contract IronCondor gates on.
+#[test]
+fn test_v1_parameters_response_still_carries_the_effective_seed() {
+    let parameters = SessionParametersResponse {
+        seed: Some(42),
+        ..SessionParametersResponse::default()
+    };
+
+    let value = to_value("parameters response", &parameters);
+    assert_eq!(value.get("seed"), Some(&json!(42)));
+}


### PR DESCRIPTION
## Stack

- **Base branch:** `stack/2-43-rolling-expiry-planner`
- **Stack:** #42 → #43 → **#44** → #45 → #46 → #47 → #48 → #49
- **Stacked on:** #51
- **Blocks:** #60, and through it #46 (consumes the schedule), #47 (surfaces the DTOs), #48 (retention), #49 (immutable parameter snapshot)

Targets `main` but is cut from `stack/2-43-rolling-expiry-planner`, so **the diff against `main` is cumulative** — it still contains #50's ADR and #51's planner. Review against the base branch. Merge bottom-up.

## Summary

Gives v2 rolling simulations their own request DTO, resolved parameters, session document and store key space — so the rolling contract can exist without touching anything `/api/v1/chain` publishes.

**Why separate types rather than new fields.** `SimulationParameters` and `Session` are public, IronCondor-facing and persisted as serde JSON. Adding rolling fields would be source-breaking even where serde defaults kept old documents loading, and it would tie the v1 stored shape to v2's evolution.

## What lands

| | |
|---|---|
| `CreateSimulationRequest` | `src/api/rest/requests_v2.rs`. f64 and strings at the boundary, **`deny_unknown_fields`** — a typo is a `400` naming the field, not a silently ignored parameter that changes the tape. |
| `SimulationParametersV2` | `src/session/model_v2.rs`. Its fields are exactly the replay-input list of ADR §8. |
| Resolution | Three values are *resolved*, not merely converted, and all three are surfaced so a client can replay from the creation response alone: the **seed** (generated when absent, as in v1), the **effective start** (generated when absent, normalised to whole-second UTC — the only wall-clock read in a v2 simulation's life), and the **step interval** (derived from `time_frame` when absent). |
| The simulated clock | `simulated_at(cursor) = effective_start + cursor × step_interval`, checked throughout. An overflow is a rejected request, never a wrapped timestamp. |
| `SessionV2` | Reuses the v1 `SessionState` machine but reaches only `Initialized → InProgress → Completed`, since a v2 simulation is immutable after creation. Carries an explicit `schema_version`. |
| `SimulationStore` | A separate trait, with in-memory and Redis implementations. The in-memory store is a **separate map**, the Redis store a **separate key prefix** (`optionchain:simulation:v2:`) — the v1/v2 isolation is structural, not conventional: a v2 id cannot resolve a v1 session because the two never share a container. Redis reuses v1's already-reviewed CAS Lua script, which is parameterised entirely by its keys. |
| `cleanup() -> Vec<Uuid>` | Returns the **expired ids**, not a count, because #48's caller owns heavyweight per-simulation domain caches and cannot evict them without knowing which sessions went away. On Redis that needs an index set, since key expiry is otherwise invisible to the process. v1's `cleanup() -> usize` is untouched. |

## Also: the expiry rule wire format

This PR is the first code to depend on it. The kind-specific fields are now declared explicitly instead of flattening an internally-tagged enum — flattening produced the same JSON but forfeits `deny_unknown_fields`, and with it both guarantees ADR §4.4 makes: that an unknown field is rejected, and that a field not valid for the rule's `kind` (`weekdays` on a `daily` rule) is rejected rather than silently ignored. **The stored shape is unchanged** and its golden test still passes.

The expiry *configuration* types become `pub` and are re-exported through `session`, since they are fields of the public `SimulationParametersV2`; the *planner* stays crate-internal. The ADR records the trade-off this accepts: `chrono-tz` enters the public API, so a major bump there is a semver event here. The alternative — a parallel primitive-typed representation in `session` — would mean two shapes and two validation paths that could drift.

## v1 is frozen, and now provably so

`tests/v1_contract.rs`, 12 new tests. They assert against **literal JSON** rather than round-trips, because a round-trip stays green when both sides move together — exactly the regression this work could introduce. They pin:

- the v1 request and stored shapes, **including a pre-`seed` document that must still load** (the `#[serde(default)]` guarantee §12.2 rests on);
- the **exact key set** of the stored parameters — a new key would be written by a new binary and read by an old one;
- the response DTO shapes, including `ChainResponse.timestamp`, whose wall-clock semantics v2 deliberately does not back-port;
- the tri-state PATCH semantics (absent / null / value are three distinct intents);
- the **rendered** value of `SessionState` — `"In Progress"` *with a space*. v2 uses `snake_case`; "normalising" v1 to match would break IronCondor.
- that v1 still **tolerates** unknown fields, which v2 rejects — making the difference deliberate rather than accidental.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `LOGLEVEL=WARN cargo test --workspace` — **474 passed, 0 failed, 13 ignored**, up from 418; plus **16** golden contract tests and 2 doctests
- CI's Integration job ran all **13 ignored tests against live services** — 4 MongoDB and the 9 new live-Redis ones
- `cargo build --release`
- `make readme` — no README change (no `src/lib.rs` doc change in this PR)

No new dependency, no new env var.

## Review round

`architect` audited the first commit and found two 🔴. Both are inert today — no store is wired into `main.rs` — and both go live the moment #46 builds on this, so they are fixed in the second commit.

**Stored documents were trusted completely.** `SimulationParametersV2` and `SessionV2` derived `Deserialize` directly with public fields, so every invariant the request path establishes was reachable *around* it. A probe against the public API loaded a hand-edited document with:

- `step_interval_seconds: 0` — which **freezes the simulated clock**: every snapshot carries the same instant, the expiration cutoff never advances, the rolling inventory never rolls. Silently degraded, not an error.
- `steps` past the cap, driving an unbounded factor tape in #46;
- a sub-second `effective_start`, breaking the whole-second rendering §10.2 needs for byte-comparable exports;
- a `symbol` carrying `,` `"` `|` — the exact CSV-corruption hazard the `rule_id` charset was narrowed to keep out, reachable through the field that was *not* re-validated;
- `state: "Reinitialized"`, which the code itself documents as unreachable for v2.

Both types now route `Deserialize` through a validating wire type, mirroring the expiry types. Redis is an outer layer, and `rules/global_rules.md` is explicit that a domain type must not trust one.

**Nothing read `schema_version`.** During a rolling deploy an old replica would read a newer document, drop what it does not understand, and write the truncated version back — with an intact revision, so the CAS *succeeds* and the data is simply gone. The stored shapes now carry `deny_unknown_fields`, and a future `schema_version` is refused on load.

Three Redis races, all 🟠:

- **`create` wrote three keys non-atomically**, and both torn states were silent: a document with no revision key, and a document absent from the index — which `cleanup` could then never report, so #48's caller would never evict its caches for it. Each operation is now one Lua script.
- **`cleanup` could report a live simulation.** It walked `SMEMBERS`, probed `EXISTS`, then deleted and removed in separate round trips. `UuidGenerator` is a deterministic counter that repeats across process restarts, so a `create` landing in that window made cleanup report an id that had just been recreated — evicting a live cache and dropping the id from the index *permanently*, so its real expiry was never reported.
- **The index was an unbounded `SET` with no TTL**, walked with `SMEMBERS` and N+1 `EXISTS` probes.

All three are gone: the index is a **sorted set scored by each simulation's expiry deadline**, read from Redis's own `TIME` rather than the client's clock, and cleanup is a bounded range query that reaps and reports in one unit.

Also folded in: the two retention constants become one (§9.1 requires the backends to agree; two names are how that drifts), `MIN_/MAX_STEP_INTERVAL_SECONDS` become `pub(crate)` so #48's env-knob conversion is not a breaking change, `requests_v2` imports `ExpiryRule` from `session` rather than reaching into `domain`, `from_parts` normalises a weekly set so a Rust caller cannot persist an un-normalised replay input, the expiry module doc stops describing the visibility policy this stack abandoned, and the dead-code expectation moves to per-item so #46 must remove each one.

### The Redis store now has real coverage

9 `#[ignore]`d live tests running against the `redis:7.4` service CI already provisions — verified in this run's Integration job, all 9 green. They cover what a mock cannot: that `create` writes all three keys together, that the CAS commits once and rejects the loser, that `delete` leaves no debris, that `cleanup` reports expired ids and spares live ones, that it is idempotent, and that a tampered document is refused on load.

### One gap handed to #47, explicitly

A schedule rule validates *during* deserialization, so its `ChainError::Validation` is flattened into a serde error and actix would render a plaintext `400` with no `field`. The v2 routes must register a `web::JsonConfig` error handler to recover it. That is now written into ADR §11 as part of #47's acceptance rather than left as an undocumented wart.

Closes #44

