### PR TITLE
Make the stack network external and shareable

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -7,7 +7,9 @@ version: '3.8'
 # which is what `make deploy` runs. It restores everything the base file leaves
 # out because swarm rejects or ignores it:
 #
-#   - the network driver: `bridge`, since `overlay` needs a swarm manager;
+#   - nothing about the network: it is external in both files, and `make
+#     network` creates it locally with the bridge driver (overlay needs a
+#     swarm manager);
 #   - `container_name`, `restart` and `depends_on`, which `docker stack deploy`
 #     drops with an "Ignoring unsupported options" warning;
 #   - the ClickHouse `ulimits` (a swarm sets nofile through the daemon's
@@ -90,5 +92,7 @@ services:
 
 networks:
   optionchain-network:
-    # Overrides the base file's overlay: a local engine is not a swarm manager.
-    driver: bridge
+    # Same external network as the base file - a local engine just creates it
+    # with the bridge driver instead of overlay (`make network`).
+    external: true
+    name: ${OPTIONCHAIN_NETWORK:-optionchain-network}

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -29,8 +29,11 @@ version: '3.8'
 #     `make deploy` / `make deploy-swarm` pass OPTIONCHAIN_VERSION so the
 #     deployed tag always matches the manifest. `docker stack deploy` does NOT
 #     read .env, so export the overrides in the shell.
-#   - The network is `overlay`, the only scope swarm accepts for services. The
-#     dev override swaps it for `bridge` on a non-swarm engine.
+#   - The network is EXTERNAL and shared: create it once per environment
+#     (`make network` locally, `make network-swarm` on a manager) so other
+#     stacks can attach to it and resolve these services by name. Swarm needs
+#     it to be an attachable overlay - a bridge network is node-scoped and
+#     rejected for services.
 #   - Nothing swarm ignores is declared here: `container_name`, `restart`,
 #     `depends_on` and `ulimits` live in the dev override, and the `deploy`
 #     blocks carry the equivalent restart policy. Keeping them out is what
@@ -145,14 +148,13 @@ services:
 
 networks:
   optionchain-network:
-    # overlay is MANDATORY under swarm: a bridge network is node-scoped and
-    # `docker stack deploy` refuses it with "cannot be used with services. Only
-    # networks scoped to the swarm can be used". The default therefore targets
-    # swarm - including deploys driven by Portainer, which passes no
-    # environment - and docker-compose.dev.yml overrides it back to bridge for
-    # a local, non-swarm engine.
-    driver: overlay
-    attachable: true
+    # EXTERNAL so other stacks can join the same network and reach this service
+    # by name. It is NOT created by this file and NOT stack-prefixed: create it
+    # once per environment before the first deploy (make network), as an
+    # attachable overlay on a swarm - the only scope swarm accepts for services
+    # - or as a bridge on a local engine.
+    external: true
+    name: ${OPTIONCHAIN_NETWORK:-optionchain-network}
 
 volumes:
   redis-data:

--- a/Makefile
+++ b/Makefile
@@ -25,19 +25,36 @@ docker-push: docker-build
 	docker push $(IMAGE_NAME):latest
 	@echo "pushed $(IMAGE_NAME):$(VERSION) and :latest"
 
+# The stack network is external and shared with other stacks, so it is created
+# once per environment instead of by the compose file: bridge on a local
+# engine, attachable overlay on a swarm (the only scope swarm accepts for
+# services). Both targets are idempotent.
+OPTIONCHAIN_NETWORK ?= optionchain-network
+
+.PHONY: network
+network:
+	@docker network inspect $(OPTIONCHAIN_NETWORK) >/dev/null 2>&1 \
+		|| docker network create --driver bridge $(OPTIONCHAIN_NETWORK)
+
+.PHONY: network-swarm
+network-swarm:
+	@docker network inspect $(OPTIONCHAIN_NETWORK) >/dev/null 2>&1 \
+		|| docker network create --driver overlay --attachable $(OPTIONCHAIN_NETWORK)
+
 # Local stack: the deployable services plus the dev override (admin UIs and
 # host-published infrastructure ports).
 .PHONY: deploy
-deploy:
-	OPTIONCHAIN_VERSION=$(VERSION) docker compose -p $(PROJECT_NAME) \
+deploy: network
+	OPTIONCHAIN_VERSION=$(VERSION) OPTIONCHAIN_NETWORK=$(OPTIONCHAIN_NETWORK) \
+		docker compose -p $(PROJECT_NAME) \
 		-f Docker/docker-compose.yml -f Docker/docker-compose.dev.yml \
 		up --pull always --force-recreate -d
 
 # Same stack on a swarm manager: overlay network, no build context, and never
 # the dev override (admin UIs with default credentials, published infra ports).
 .PHONY: deploy-swarm
-deploy-swarm:
-	OPTIONCHAIN_VERSION=$(VERSION) \
+deploy-swarm: network-swarm
+	OPTIONCHAIN_VERSION=$(VERSION) OPTIONCHAIN_NETWORK=$(OPTIONCHAIN_NETWORK) \
 		docker stack deploy --with-registry-auth -c Docker/docker-compose.yml $(PROJECT_NAME)
 
 # Default target


### PR DESCRIPTION
## Summary

The compose file created its own network, so the engine prefixed it with the
stack name (`simulator_optionchain-network`) and it belonged to this deployment
alone: another stack could not attach to it and resolve `backend`, `redis`,
`mongodb` or `clickhouse` by name.

The network is now **external** in both compose files, under the unprefixed name
`${OPTIONCHAIN_NETWORK:-optionchain-network}`, so any other stack can join it by
declaring the same external network.

## Changes

- `Docker/docker-compose.yml` and `Docker/docker-compose.dev.yml`:

  ```yaml
  networks:
    optionchain-network:
      external: true
      name: ${OPTIONCHAIN_NETWORK:-optionchain-network}
  ```

  The dev override no longer sets `driver: bridge` — an external network takes
  its driver from whoever created it, and declaring both would be a conflict.
- `Makefile`: external means the engine will not create it, so creation moves to
  two idempotent targets (inspect first, create only on a miss) —
  `make network` for a local bridge, `make network-swarm` for the attachable
  overlay a swarm requires, since a bridge network is node-scoped and rejected
  for services. `deploy` and `deploy-swarm` depend on them, so a fresh
  environment still deploys in one command, and both export
  `OPTIONCHAIN_NETWORK` so a renamed network stays consistent between creation
  and deploy.

## Deploying this over an existing stack

The running stack owns the old prefixed network, and Docker will not repoint
services at a different network in place:

```
docker stack rm simulator
docker network create --driver overlay --attachable optionchain-network
# redeploy from Portainer once `docker network ls` no longer shows
# simulator_optionchain-network
```

Volumes are untouched by `docker stack rm`, so the Redis/MongoDB/ClickHouse data
survives; it is a service interruption, not a data loss. For another stack to
join, it declares the same block and its services list `optionchain-network`.

## Testing

- [x] `docker compose config` (base, and base + dev override) renders
      `name: optionchain-network, external: true` — the two files merge without
      a driver conflict
- [x] `OPTIONCHAIN_NETWORK=otra-red docker compose config` renders
      `name: otra-red`
- [x] `docker stack config -c Docker/docker-compose.yml` renders the external
      network and still reports **zero** ignored-option warnings
- [x] `make network` creates `optionchain-network` (`bridge local`) and is a
      no-op on a second run; `make -n network-swarm` expands to
      `docker network create --driver overlay --attachable`
- [ ] A real swarm deploy against the external overlay — needs the published
      image, which does not exist until a version bump lands on `main`