### PR TITLE
Bump Redis and MongoDB to the latest stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
       # so the ignored live tests authenticate successfully and can ASSERT
       # success instead of tolerating connection failures.
       mongodb:
-        image: mongo:7
+        image: mongo:8.0.29
         env:
           MONGO_INITDB_ROOT_USERNAME: admin
           MONGO_INITDB_ROOT_PASSWORD: password
         ports:
           - 27017:27017
       redis:
-        image: redis:7.4
+        image: redis:8.10.0
         ports:
           - 6379:6379
       clickhouse:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -49,7 +49,7 @@ version: '3.8'
 services:
   # Redis service configuration
   redis:
-    image: redis:7.4@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
+    image: redis:8.10.0@sha256:344e3945a0b431c8ff1eecd58c5573538126bd756f02fc7e218ddf1fc2546366
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-password}
     volumes:
       - redis-data:/data
@@ -70,7 +70,7 @@ services:
 
   # MongoDB service configuration
   mongodb:
-    image: mongo:7.0@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703
+    image: mongo:8.0.29@sha256:de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb


### PR DESCRIPTION
## Summary

The stack pinned `redis:7.4` and `mongo:7.0`. Both move to the newest stable
release, in the compose file and in the CI service containers so the ignored
live-service tests keep running against the versions the stack actually deploys.

## Changes

- `Docker/docker-compose.yml`:
  - `redis:7.4` → `redis:8.10.0` — the newest GA release on the 8.x line.
  - `mongo:7.0` → `mongo:8.0.29`. 8.0 is the current LTS/production line; 8.1,
    8.2 and 8.3 are published on Docker Hub but are **rapid releases**, which
    MongoDB does not support for self-managed deployments, so the latest stable
    for this stack is the newest 8.0 patch.
  - Both pinned by immutable digest per the policy in the file header (#22),
    resolved with `docker buildx imagetools inspect`.
- `.github/workflows/ci.yml`: the `mongodb` and `redis` service containers in
  the integration job move to the same versions.

## Upgrade note

Deploying this over an **existing** `mongodb-data` volume is a 7.0 → 8.0 major
upgrade: the data dir must already be on `featureCompatibilityVersion: 7.0`
before mongod 8.0 starts against it. A fresh deploy, or one where the volume is
wiped, is unaffected. Redis loads its existing RDB/AOF across this bump without
a migration step.

## Testing

- [x] Both tags exist and the pinned digests are the ones Docker Hub resolves
      (`docker buildx imagetools inspect mongo:8.0.29` / `redis:8.10.0`)
- [x] `docker compose -f Docker/docker-compose.yml config` renders both images
      with their digests
- [ ] CI integration job against the new service containers — runs on this PR