### PR TITLE
Bump ClickHouse to the 26.3 LTS line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         ports:
           - 6379:6379
       clickhouse:
-        image: clickhouse/clickhouse-server:24.8
+        image: clickhouse/clickhouse-server:26.3.17.110
         env:
           CLICKHOUSE_USER: admin
           CLICKHOUSE_PASSWORD: password

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -92,7 +92,7 @@ services:
         delay: 5s
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8@sha256:1ffa82edee000a42c09313bd9f1293d94c570aee74babc1b3ca9983a35fa597b
+    image: clickhouse/clickhouse-server:26.3.17.110@sha256:2ef11bbe2e44ab7022f37ff3019b3f2125ed09e919ea6194660be6130b7ca4b7
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}


### PR DESCRIPTION
## Summary

The stack pinned `clickhouse/clickhouse-server:24.8`, two years of releases
behind. It moves to `26.3.17.110`, the current LTS line, in the compose file and
in the CI service container.

## Why 26.3 and not 26.7

ClickHouse cuts an LTS every March and August — 24.8 was the previous LTS this
stack tracked, and 26.3 is the current one. `26.7.3.19` is newer (it is what
`:latest` resolves to) but belongs to the monthly stable line. The LTS keeps
taking security and correctness fixes with far less churn, which is the right
trade for a service that only reads historical prices.

## Changes

- `Docker/docker-compose.yml`: `clickhouse/clickhouse-server:24.8` →
  `26.3.17.110`, pinned by immutable digest
  (`sha256:2ef11bbe2e44ab7022f37ff3019b3f2125ed09e919ea6194660be6130b7ca4b7`)
  per the policy in the file header (#22).
- `.github/workflows/ci.yml`: the `clickhouse` service container in the
  integration job moves to the same version.

## Upgrade note

This jump skips two LTS lines (25.3, 25.8). ClickHouse reads older data
directories, but **downgrading is not supported** — once 26.3 has opened the
`clickhouse_data` volume, going back to 24.8 is not a supported path. A
deployment holding data worth keeping should back it up first, or step through
the intermediate LTS releases. The env-driven config this repo uses
(`CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` / `CLICKHOUSE_DB`) is unchanged
across these versions.

## Testing

- [x] The tag exists and the pinned digest is what Docker Hub resolves
      (`docker buildx imagetools inspect clickhouse/clickhouse-server:26.3.17.110`)
- [x] `docker compose -f Docker/docker-compose.yml config` renders the new image
      with its digest
- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] CI integration job against the new service container — runs on this PR

Note: ClickHouse is the one optional dependency — `src/domain/simulator.rs` logs
the connection failure and continues with `database_repo: None` — so a problem
here degrades the `Historical` source rather than taking the service down.