### PR TITLE
feat(session): make v2 retention and cache cleanup configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,153 @@
+# OptionChain-Simulator — environment variables
+#
+# Every variable the service reads is listed here with its default and its
+# accepted range. Copy this file to `.env` and change what you need; anything
+# left unset takes the default shown.
+#
+# Two behaviours to know before editing:
+#
+#   * The v2 knobs (OCS_V2_*, OCS_MAX_CACHED_*) are VALIDATED AT STARTUP. An
+#     invalid value fails the process with a message naming the variable,
+#     because silently reverting to a default would change how long simulations
+#     live or how much memory the service holds without anyone noticing.
+#
+#   * The v1 request caps (OCS_MAX_STEPS, OCS_MAX_CHAIN_SIZE,
+#     OCS_MAX_HISTORICAL_PRICES) and OCS_MAX_CACHED_WALKS warn and fall back to
+#     their defaults instead, because a bad value there degrades one request
+#     rather than the service.
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+# Verbosity of the tracing subscriber.
+# Values: TRACE | DEBUG | INFO | WARN | ERROR.  Default: DEBUG
+LOGLEVEL=INFO
+
+
+# ---------------------------------------------------------------------------
+# Request caps (v1 and v2)
+# ---------------------------------------------------------------------------
+# These bound what a single request may ask for, so a pathological one cannot
+# exhaust memory or CPU. Unset or invalid values fall back to the default and
+# emit a warning.
+
+# Maximum simulation steps per session or simulation.
+# Range: >= 1.  Default: 10000
+OCS_MAX_STEPS=10000
+
+# Maximum option-chain size (strikes) per request.
+# Range: >= 1.  Default: 500
+OCS_MAX_CHAIN_SIZE=500
+
+# Maximum number of embedded prices a Historical walk request may carry.
+# Range: >= 1.  Default: 100000
+OCS_MAX_HISTORICAL_PRICES=100000
+
+
+# ---------------------------------------------------------------------------
+# v1 domain cache
+# ---------------------------------------------------------------------------
+
+# Maximum random walks held in the v1 simulation cache, evicted
+# least-recently-used. Eviction never changes what a client sees: a rebuilt
+# walk reproduces the identical tape from the same seed.
+# Range: >= 1.  Default: 1000
+OCS_MAX_CACHED_WALKS=1000
+
+
+# ---------------------------------------------------------------------------
+# v2 rolling simulations
+# ---------------------------------------------------------------------------
+# These are about REAL time and REAL memory. None of them touch the simulated
+# clock, which may span years regardless of how long a simulation is kept.
+
+# How long an idle v2 simulation is kept before the retention sweep reaps it,
+# in seconds. Measured from the last WRITE, not the last read: peeking a
+# snapshot persists nothing, so a client that only peeks does not refresh the
+# window.
+#
+# Deliberately longer than v1's 1800 s: a v2 simulation is walked one request
+# at a time over a long simulated horizon, and losing it to a short idle
+# timeout would make that horizon unusable.
+#
+# Range: 1 .. 2592000 (30 days).  Default: 3600
+OCS_V2_RETENTION_SECS=3600
+
+# How often the retention sweep runs, in seconds. Each pass reaps expired
+# simulations and evicts the factor tapes and snapshots they left behind.
+# Range: 1 .. 3600.  Default: 60
+OCS_V2_CLEANUP_INTERVAL_SECS=60
+
+# Maximum v2 factor tapes held resident, evicted least-recently-used. A tape is
+# one small row per step, so this bound is generous relative to the snapshot
+# one.
+# Range: 1 .. 1000000.  Default: 64
+OCS_MAX_CACHED_TAPES=64
+
+# Maximum v2 snapshots held resident, evicted least-recently-used. A snapshot
+# holds every strike of every live expiration, so this bound is deliberately
+# small. Eviction is never observable in what is served — a rebuilt snapshot
+# prices identically, because it is a pure function of the factor row and the
+# planner.
+# Range: 1 .. 1000000.  Default: 256
+OCS_MAX_CACHED_SNAPSHOTS=256
+
+
+# ---------------------------------------------------------------------------
+# Redis — session and simulation storage
+# ---------------------------------------------------------------------------
+# Never commit a real password. This file documents the shape; `.env` holds the
+# values and is gitignored.
+
+# Host and port of the Redis server.  Defaults: 127.0.0.1 / 6379
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+
+# Logical database index.  Default: 0
+REDIS_DB=0
+
+# Credentials. Both optional; leave unset for an unauthenticated server.
+REDIS_USER=
+REDIS_PASSWORD=
+
+# Connection timeout, in seconds.  Default: 30
+REDIS_TIMEOUT=30
+
+# Timeout for establishing the connection, in seconds.  Default: 5
+REDIS_CONNECT_TIMEOUT=5
+
+
+# ---------------------------------------------------------------------------
+# MongoDB — event and step logging
+# ---------------------------------------------------------------------------
+# Logging is best-effort: a MongoDB failure never fails a request.
+
+# Connection URI.  Default: mongodb://admin:password@localhost:27017
+MONGODB_URI=mongodb://admin:password@localhost:27017
+
+# Database and collections.
+# Defaults: optionchain_simulator / steps / events
+MONGODB_DATABASE=optionchain_simulator
+MONGODB_STEPS_COLLECTION=steps
+MONGODB_EVENTS_COLLECTION=events
+
+# Server-selection timeout, in seconds. Bounded so a missing MongoDB cannot
+# stall startup indefinitely.
+# Default: 30
+MONGODB_TIMEOUT=30
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse — historical price data
+# ---------------------------------------------------------------------------
+
+# Host and port.  Defaults: localhost / 8123
+CLICKHOUSE_HOST=localhost
+CLICKHOUSE_PORT=8123
+
+# Database and credentials.  Defaults: default / admin / password
+CLICKHOUSE_DB=default
+CLICKHOUSE_USER=admin
+CLICKHOUSE_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -150,6 +150,39 @@ are byte- and behaviour-compatible; v2 ships as a separate surface with its
 own session type and its own stored-session schema, so existing clients
 need no changes.
 
+### Configuration
+
+Every environment variable the service reads is documented in
+`.env.example` with its default and accepted range. Two families, with
+deliberately different failure behaviour:
+
+- **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
+  `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CACHED_WALKS` — warn and fall back
+  to their defaults when set to something invalid. A bad value there
+  degrades one request.
+- **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
+  `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
+  `OCS_MAX_CACHED_SNAPSHOTS` — are **validated at startup** and fail the
+  process with a message naming the variable. Silently reverting a
+  retention window would expire simulations a client is still walking, and
+  silently reverting a cache bound would change the service's memory
+  profile with nothing to show for it.
+
+**v2 retention is real time, not simulated time.** A simulation whose
+simulated clock spans three years is still walked one request at a time, so
+its idle window is an operational choice independent of the horizon. It
+defaults to an hour — longer than v1's thirty minutes — and is measured from
+the last **write**: peeking a snapshot persists nothing, so a client that
+only peeks does not refresh it. The in-memory and Redis backends apply the
+same window from the same constant.
+
+A retention sweep runs every `OCS_V2_CLEANUP_INTERVAL_SECS`, reaping expired
+simulations and evicting the factor tapes and snapshots they left behind.
+Eviction is never observable in what is served: both rebuild identically
+from the effective parameters, so it costs latency and nothing else. The
+sweep publishes `v2_simulations_expired_total`, and the caches publish
+`v2_tape_cache_size` and `v2_snapshot_cache_size`.
+
 ### Request/Response Models
 
 #### 1. Create Session (POST /api/v1/chain)

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -344,9 +344,10 @@ mod tests {
     /// Mounts the real v2 routes over an in-memory store.
     macro_rules! v2_service {
         () => {{
-            let manager = Arc::new(crate::session::SimulationManager::new(Arc::new(
-                InMemorySimulationStore::new(),
-            )));
+            let manager = Arc::new(crate::session::SimulationManager::new(
+                Arc::new(InMemorySimulationStore::new()),
+                crate::infrastructure::SimulationV2Config::default(),
+            ));
             actix_test::init_service(
                 App::new().configure(|cfg| configure_v2_routes(cfg, manager.clone())),
             )

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -51,6 +51,7 @@
 
 use crate::domain::expiry::{ActiveExpiry, RollingPlanner};
 use crate::domain::factors::{FactorRow, FactorTape, build_chain};
+use crate::infrastructure::DEFAULT_MAX_CACHED_SNAPSHOTS;
 use crate::session::SimulationParametersV2;
 use crate::utils::ChainError;
 use chrono::{DateTime, Utc};
@@ -58,48 +59,9 @@ use optionstratlib::ExpirationDate;
 use optionstratlib::chains::chain::OptionChain;
 use positive::Positive;
 use std::collections::HashMap;
-use std::sync::LazyLock;
 use std::time::Instant;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument};
 use uuid::Uuid;
-
-/// Default number of snapshots held in the per-process cache.
-///
-/// A snapshot is heavy — every strike of every live expiration — so the bound
-/// is deliberately small compared with the walk cache's. Eviction is not
-/// observable in anything served: a rebuilt snapshot prices identically,
-/// because it is a pure function of the factor row and the planner. The one
-/// value that can differ is upstream's host-clock expiration stamp (see the
-/// module docs), which no response carries.
-///
-/// The bound counts entries, not contracts, so the worst case scales with
-/// `chain_size` and the number of live expirations. Issue #62 tracks bounding
-/// it by weight, together with the per-snapshot work cap, before #47 serves
-/// any of this.
-const DEFAULT_MAX_CACHED_SNAPSHOTS: usize = 256;
-
-/// Hard bound on the number of snapshots the cache may hold
-/// (`OCS_MAX_CACHED_SNAPSHOTS`).
-///
-/// Read once via [`LazyLock`], mirroring `OCS_MAX_CACHED_WALKS` in
-/// [`crate::domain::simulator`]; an unset or invalid value falls back to the
-/// default and emits a `tracing::warn!`, so a misconfiguration never aborts
-/// startup. Issue #48 folds this into the typed v2 configuration.
-static MAX_CACHED_SNAPSHOTS: LazyLock<usize> =
-    LazyLock::new(|| match std::env::var("OCS_MAX_CACHED_SNAPSHOTS").ok() {
-        None => DEFAULT_MAX_CACHED_SNAPSHOTS,
-        Some(value) => match value.trim().parse::<usize>() {
-            Ok(parsed) if parsed >= 1 => parsed,
-            _ => {
-                warn!(
-                    raw = %value,
-                    default = DEFAULT_MAX_CACHED_SNAPSHOTS,
-                    "invalid OCS_MAX_CACHED_SNAPSHOTS; falling back to default"
-                );
-                DEFAULT_MAX_CACHED_SNAPSHOTS
-            }
-        },
-    });
 
 /// One live expiration at one step: when it expires, how far away that is,
 /// which rules asked for it, and its priced chain.
@@ -335,10 +297,15 @@ impl Default for SnapshotCache {
 }
 
 impl SnapshotCache {
-    /// Creates a cache bounded by `OCS_MAX_CACHED_SNAPSHOTS`.
+    /// Creates a cache bounded by the documented default.
+    ///
+    /// The bound is configuration, not a constant of the domain: the service
+    /// passes the operator's value through [`SnapshotCache::with_capacity`].
+    /// This constructor exists for tests and for a caller with nothing to say
+    /// about it.
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self::with_capacity(*MAX_CACHED_SNAPSHOTS)
+        Self::with_capacity(DEFAULT_MAX_CACHED_SNAPSHOTS)
     }
 
     /// Creates a cache with an explicit bound.
@@ -356,13 +323,6 @@ impl SnapshotCache {
 
     /// The number of snapshots currently held.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the export in #49 and the cache metrics in #48"
-        )
-    )]
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -1,6 +1,9 @@
 pub mod clickhouse;
 pub mod mongo;
 pub mod redis;
+/// Operational configuration for v2 rolling simulations: retention, the
+/// cleanup cadence, and the domain-cache capacities.
+pub mod simulation_v2;
 
 /// Redacts URL userinfo (credentials) from every URL-like substring inside a
 /// larger text (log lines, driver error messages).

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -1,0 +1,398 @@
+//! Operational configuration for v2 rolling simulations.
+//!
+//! Everything here is about **real** time and **real** memory: how long an idle
+//! simulation is kept, how often expired ones are reaped, and how much of the
+//! expensive derived state stays resident. None of it touches the *simulated*
+//! clock, which may span years regardless.
+//!
+//! That separation is the point of the module. A simulation whose simulated
+//! horizon is three years is still walked one request at a time, and losing it
+//! to a thirty-minute idle timeout would make the horizon unusable — so v2 gets
+//! its own retention window rather than inheriting v1's.
+//!
+//! # Why this validates instead of falling back
+//!
+//! `api::rest::limits` reads its caps with a warn-and-default, because a bad
+//! `OCS_MAX_STEPS` degrades one request. These knobs are different: a retention
+//! window silently reset to a default would expire simulations a client is
+//! still walking, and a cache capacity silently reset would change the
+//! service's memory profile without anyone noticing. So an invalid value fails
+//! startup with a message naming the variable, which is what
+//! `rules/global_rules.md` asks of a configuration knob.
+
+use crate::utils::ChainError;
+use std::env;
+use std::time::Duration;
+use tracing::info;
+
+/// Default idle retention for a v2 simulation, in seconds.
+///
+/// An hour rather than v1's thirty minutes: a v2 simulation is walked one
+/// request at a time over a long simulated horizon, and a client pausing
+/// between steps must not lose it.
+pub const DEFAULT_RETENTION_SECS: u64 = 3_600;
+
+/// Default interval between cleanup passes, in seconds.
+///
+/// Frequent enough that an expired simulation's caches are reclaimed promptly,
+/// rare enough that the pass itself is not a load.
+pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 60;
+
+/// Default number of factor tapes held resident.
+///
+/// A tape is `O(steps)` four-field rows, so this is generous relative to the
+/// snapshot bound.
+pub const DEFAULT_MAX_CACHED_TAPES: usize = 64;
+
+/// Default number of snapshots held resident.
+///
+/// A snapshot holds every strike of every live expiration, so the bound is
+/// deliberately small. Issue #62 tracks bounding it by weight rather than by
+/// entry count.
+pub const DEFAULT_MAX_CACHED_SNAPSHOTS: usize = 256;
+
+/// The longest retention window that can be configured, in seconds — thirty
+/// days.
+///
+/// Not a technical limit but an operational one: a window longer than this is
+/// almost certainly a typo (seconds entered as milliseconds, say), and the
+/// consequence would be simulations pinning memory for weeks.
+const MAX_RETENTION_SECS: u64 = 30 * 24 * 3_600;
+
+/// The longest cleanup interval that can be configured, in seconds — one hour.
+const MAX_CLEANUP_INTERVAL_SECS: u64 = 3_600;
+
+/// The largest cache bound that can be configured.
+const MAX_CACHE_CAPACITY: usize = 1_000_000;
+
+/// Operational limits for the v2 rolling-simulation surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimulationV2Config {
+    /// How long an idle simulation is kept before it is reaped.
+    ///
+    /// Measured from the last **write**, not the last read: a peek persists
+    /// nothing (ADR 0001 §6), so a client that only peeks does not refresh the
+    /// window. Both stores behave the same way.
+    pub retention: Duration,
+    /// How often the cleanup pass runs.
+    pub cleanup_interval: Duration,
+    /// How many factor tapes stay resident.
+    pub max_cached_tapes: usize,
+    /// How many snapshots stay resident.
+    pub max_cached_snapshots: usize,
+}
+
+impl Default for SimulationV2Config {
+    fn default() -> Self {
+        Self {
+            retention: Duration::from_secs(DEFAULT_RETENTION_SECS),
+            cleanup_interval: Duration::from_secs(DEFAULT_CLEANUP_INTERVAL_SECS),
+            max_cached_tapes: DEFAULT_MAX_CACHED_TAPES,
+            max_cached_snapshots: DEFAULT_MAX_CACHED_SNAPSHOTS,
+        }
+    }
+}
+
+impl SimulationV2Config {
+    /// Reads the configuration from the environment.
+    ///
+    /// An unset variable takes its documented default. A set-but-invalid one
+    /// fails, rather than falling back — see the module docs for why.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the environment variable when
+    /// its value does not parse, is zero, or exceeds its documented bound.
+    pub fn from_env() -> Result<Self, ChainError> {
+        let config = Self {
+            retention: Duration::from_secs(parse_secs(
+                "OCS_V2_RETENTION_SECS",
+                read("OCS_V2_RETENTION_SECS").as_deref(),
+                DEFAULT_RETENTION_SECS,
+                MAX_RETENTION_SECS,
+            )?),
+            cleanup_interval: Duration::from_secs(parse_secs(
+                "OCS_V2_CLEANUP_INTERVAL_SECS",
+                read("OCS_V2_CLEANUP_INTERVAL_SECS").as_deref(),
+                DEFAULT_CLEANUP_INTERVAL_SECS,
+                MAX_CLEANUP_INTERVAL_SECS,
+            )?),
+            max_cached_tapes: parse_capacity(
+                "OCS_MAX_CACHED_TAPES",
+                read("OCS_MAX_CACHED_TAPES").as_deref(),
+                DEFAULT_MAX_CACHED_TAPES,
+            )?,
+            max_cached_snapshots: parse_capacity(
+                "OCS_MAX_CACHED_SNAPSHOTS",
+                read("OCS_MAX_CACHED_SNAPSHOTS").as_deref(),
+                DEFAULT_MAX_CACHED_SNAPSHOTS,
+            )?,
+        };
+
+        info!(
+            retention_secs = config.retention.as_secs(),
+            cleanup_interval_secs = config.cleanup_interval.as_secs(),
+            max_cached_tapes = config.max_cached_tapes,
+            max_cached_snapshots = config.max_cached_snapshots,
+            "Loaded the v2 simulation configuration"
+        );
+        Ok(config)
+    }
+
+    /// The retention window in seconds, for the stores that take one.
+    #[must_use]
+    pub fn retention_secs(&self) -> u64 {
+        self.retention.as_secs()
+    }
+}
+
+/// Parses a duration knob, in seconds.
+///
+/// Takes the raw value rather than reading it, so the parsing and the bounds
+/// can be tested without mutating the process environment — which would need
+/// `unsafe` in this edition and would race every other test in the binary.
+fn parse_secs(
+    variable: &str,
+    raw: Option<&str>,
+    default: u64,
+    max: u64,
+) -> Result<u64, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    let seconds = raw.parse::<u64>().map_err(|_| invalid(variable, raw))?;
+    if seconds == 0 {
+        return Err(ChainError::Validation {
+            field: variable.to_string(),
+            reason: "must be at least 1 second".to_string(),
+        });
+    }
+    if seconds > max {
+        return Err(ChainError::Validation {
+            field: variable.to_string(),
+            reason: format!("must not exceed {max} seconds, got {seconds}"),
+        });
+    }
+    Ok(seconds)
+}
+
+/// Parses a cache-capacity knob.
+///
+/// Takes the raw value for the same reason as [`parse_secs`].
+fn parse_capacity(variable: &str, raw: Option<&str>, default: usize) -> Result<usize, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    let capacity = raw.parse::<usize>().map_err(|_| invalid(variable, raw))?;
+    if capacity == 0 {
+        return Err(ChainError::Validation {
+            field: variable.to_string(),
+            reason: "must be at least 1".to_string(),
+        });
+    }
+    if capacity > MAX_CACHE_CAPACITY {
+        return Err(ChainError::Validation {
+            field: variable.to_string(),
+            reason: format!("must not exceed {MAX_CACHE_CAPACITY}, got {capacity}"),
+        });
+    }
+    Ok(capacity)
+}
+
+/// Reads a variable, treating an empty or whitespace-only value as unset.
+///
+/// A blank value in a `.env` file is how a knob gets "commented out" in
+/// practice; treating it as unset is friendlier than failing startup over it,
+/// and unambiguous either way.
+fn read(variable: &str) -> Option<String> {
+    let raw = env::var(variable).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// The error for a value that does not parse.
+#[cold]
+fn invalid(variable: &str, raw: &str) -> ChainError {
+    ChainError::Validation {
+        field: variable.to_string(),
+        reason: format!("must be a whole number, got {raw:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The defaults are the documented ones.
+    #[test]
+    fn test_the_defaults_are_the_documented_values() {
+        let config = SimulationV2Config::default();
+
+        assert_eq!(config.retention.as_secs(), DEFAULT_RETENTION_SECS);
+        assert_eq!(
+            config.cleanup_interval.as_secs(),
+            DEFAULT_CLEANUP_INTERVAL_SECS
+        );
+        assert_eq!(config.max_cached_tapes, DEFAULT_MAX_CACHED_TAPES);
+        assert_eq!(config.max_cached_snapshots, DEFAULT_MAX_CACHED_SNAPSHOTS);
+        assert_eq!(config.retention_secs(), DEFAULT_RETENTION_SECS);
+    }
+
+    /// The v2 retention outlasts v1's thirty minutes, which is the whole reason
+    /// it is a separate knob.
+    ///
+    /// v1's window is not a constant this crate can reference — it is the
+    /// literal `1800` default inside `InRedisSessionStore::new` — so the
+    /// comparison is written against that number directly.
+    #[test]
+    fn test_the_v2_retention_outlasts_the_v1_default() {
+        let v1_default_secs: u64 = 1_800;
+
+        assert!(
+            SimulationV2Config::default().retention_secs() > v1_default_secs,
+            "a v2 simulation is walked one request at a time over a long horizon"
+        );
+    }
+
+    /// An unset knob takes its default.
+    #[test]
+    fn test_an_unset_duration_takes_its_default() {
+        match parse_secs("OCS_V2_RETENTION_SECS", None, 900, 3_600) {
+            Ok(seconds) => assert_eq!(seconds, 900),
+            Err(error) => panic!("an unset knob must take its default: {error}"),
+        }
+    }
+
+    /// A valid duration is accepted verbatim.
+    #[test]
+    fn test_a_valid_duration_is_accepted() {
+        match parse_secs("OCS_V2_RETENTION_SECS", Some("120"), 900, 3_600) {
+            Ok(seconds) => assert_eq!(seconds, 120),
+            Err(error) => panic!("a valid duration must be accepted: {error}"),
+        }
+    }
+
+    /// A duration that does not parse fails, naming the variable — rather than
+    /// falling back and silently changing how long simulations live.
+    #[test]
+    fn test_an_unparseable_duration_fails_by_name() {
+        match parse_secs("OCS_V2_RETENTION_SECS", Some("an hour"), 900, 3_600) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_V2_RETENTION_SECS");
+                assert!(reason.contains("whole number"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A zero retention would expire every simulation instantly.
+    #[test]
+    fn test_a_zero_duration_is_rejected() {
+        match parse_secs("OCS_V2_RETENTION_SECS", Some("0"), 900, 3_600) {
+            Err(ChainError::Validation { reason, .. }) => {
+                assert!(reason.contains("at least 1 second"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A retention beyond the operational ceiling is almost certainly a typo,
+    /// and would pin memory for weeks.
+    #[test]
+    fn test_a_duration_beyond_its_ceiling_is_rejected() {
+        match parse_secs("OCS_V2_RETENTION_SECS", Some("999999999"), 900, 3_600) {
+            Err(ChainError::Validation { reason, .. }) => {
+                assert!(reason.contains("must not exceed"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// An unset capacity takes its default; a valid one is accepted.
+    #[test]
+    fn test_capacity_parsing_accepts_valid_values() {
+        match parse_capacity("OCS_MAX_CACHED_TAPES", None, 64) {
+            Ok(capacity) => assert_eq!(capacity, 64),
+            Err(error) => panic!("an unset knob must take its default: {error}"),
+        }
+        match parse_capacity("OCS_MAX_CACHED_TAPES", Some("8"), 64) {
+            Ok(capacity) => assert_eq!(capacity, 8),
+            Err(error) => panic!("a valid capacity must be accepted: {error}"),
+        }
+    }
+
+    /// A zero capacity would make the cache inert, so it fails rather than
+    /// silently reverting to the default.
+    #[test]
+    fn test_a_zero_capacity_is_rejected() {
+        match parse_capacity("OCS_MAX_CACHED_SNAPSHOTS", Some("0"), 256) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_MAX_CACHED_SNAPSHOTS");
+                assert!(reason.contains("at least 1"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A capacity beyond the ceiling is rejected.
+    #[test]
+    fn test_a_capacity_beyond_its_ceiling_is_rejected() {
+        match parse_capacity("OCS_MAX_CACHED_SNAPSHOTS", Some("99999999"), 256) {
+            Err(ChainError::Validation { reason, .. }) => {
+                assert!(reason.contains("must not exceed"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A capacity that does not parse fails by name.
+    #[test]
+    fn test_an_unparseable_capacity_fails_by_name() {
+        match parse_capacity("OCS_MAX_CACHED_TAPES", Some("lots"), 64) {
+            Err(ChainError::Validation { field, .. }) => {
+                assert_eq!(field, "OCS_MAX_CACHED_TAPES");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// Both backends apply the same default retention.
+    ///
+    /// ADR 0001 §9.1 requires the in-memory and Redis stores to agree on
+    /// expiry, and two independently-named defaults are exactly how that
+    /// agreement drifts. There is now one number, and this asserts every path
+    /// still reaches it.
+    #[test]
+    fn test_both_stores_default_to_the_configured_retention() {
+        use crate::session::{DEFAULT_V2_RETENTION_SECS, InMemorySimulationStore};
+
+        assert_eq!(DEFAULT_V2_RETENTION_SECS, DEFAULT_RETENTION_SECS);
+        assert_eq!(
+            InMemorySimulationStore::new().idle_retention(),
+            SimulationV2Config::default().retention,
+            "the in-memory store must apply the configured window"
+        );
+    }
+
+    /// The configuration loads from the ambient environment.
+    ///
+    /// The service is deployed with these unset far more often than not, so the
+    /// path that has to work is the one that takes every default.
+    #[test]
+    fn test_it_loads_from_the_environment() {
+        match SimulationV2Config::from_env() {
+            Ok(config) => {
+                assert!(config.retention.as_secs() >= 1);
+                assert!(config.max_cached_tapes >= 1);
+                assert!(config.max_cached_snapshots >= 1);
+            }
+            Err(error) => panic!("the ambient environment must load: {error}"),
+        }
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -11,6 +11,10 @@ pub use clickhouse::model::{OHLCVData, PriceType};
 pub(crate) use clickhouse::{calculate_required_duration, select_random_date, validate_symbol};
 pub use config::clickhouse::ClickHouseConfig;
 pub use config::redis::RedisConfig;
+pub use config::simulation_v2::{
+    DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOTS, DEFAULT_MAX_CACHED_TAPES,
+    DEFAULT_RETENTION_SECS, SimulationV2Config,
+};
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;
 pub use repositories::mongo_repo::{MongoDBRepository, init_mongodb};

--- a/src/infrastructure/telemetry/collector.rs
+++ b/src/infrastructure/telemetry/collector.rs
@@ -29,6 +29,12 @@ pub struct MetricsCollector {
     cache_hit_counter: IntCounter,
     cache_miss_counter: IntCounter,
     simulation_cache_size: IntGauge,
+    /// Factor tapes currently resident for v2 rolling simulations.
+    v2_tape_cache_size: IntGauge,
+    /// Snapshots currently resident for v2 rolling simulations.
+    v2_snapshot_cache_size: IntGauge,
+    /// v2 simulations reaped by the retention sweep since startup.
+    v2_simulations_expired: IntCounter,
 
     // Resource metrics
     memory_usage: Gauge,
@@ -103,6 +109,21 @@ impl MetricsCollector {
         let simulation_cache_size =
             IntGauge::new("simulation_cache_size", "Number of cached random walks")?;
 
+        // v2 keeps two caches rather than one, and they behave very
+        // differently: a tape is O(steps) small rows, a snapshot holds every
+        // strike of every live expiration. Reporting them separately is what
+        // makes it possible to tell which bound needs moving.
+        let v2_tape_cache_size =
+            IntGauge::new("v2_tape_cache_size", "Number of cached v2 factor tapes")?;
+
+        let v2_snapshot_cache_size =
+            IntGauge::new("v2_snapshot_cache_size", "Number of cached v2 snapshots")?;
+
+        let v2_simulations_expired = IntCounter::new(
+            "v2_simulations_expired_total",
+            "Total number of v2 simulations reaped by the retention sweep",
+        )?;
+
         // Create resource metrics
         let memory_usage = Gauge::new("memory_usage_bytes", "Current memory usage in bytes")?;
 
@@ -136,6 +157,9 @@ impl MetricsCollector {
         registry.register(Box::new(cache_hit_counter.clone()))?;
         registry.register(Box::new(cache_miss_counter.clone()))?;
         registry.register(Box::new(simulation_cache_size.clone()))?;
+        registry.register(Box::new(v2_tape_cache_size.clone()))?;
+        registry.register(Box::new(v2_snapshot_cache_size.clone()))?;
+        registry.register(Box::new(v2_simulations_expired.clone()))?;
         registry.register(Box::new(memory_usage.clone()))?;
 
         // Register MongoDB metrics
@@ -156,6 +180,9 @@ impl MetricsCollector {
             cache_hit_counter,
             cache_miss_counter,
             simulation_cache_size,
+            v2_tape_cache_size,
+            v2_snapshot_cache_size,
+            v2_simulations_expired,
             memory_usage,
             mongodb_insert_counter,
             mongodb_insert_duration,
@@ -255,6 +282,27 @@ impl MetricsCollector {
     }
 
     /// Records the current memory usage
+    /// Publishes how much v2 derived state is resident.
+    ///
+    /// Both caches at once, because they are only meaningful together: a full
+    /// snapshot cache with an empty tape cache means something quite different
+    /// from the reverse.
+    pub fn set_v2_cache_sizes(&self, tapes: i64, snapshots: i64) {
+        self.v2_tape_cache_size.set(tapes);
+        self.v2_snapshot_cache_size.set(snapshots);
+    }
+
+    /// Records simulations reaped by the retention sweep.
+    ///
+    /// Counted rather than gauged: the interesting question is how many are
+    /// being expired over time, not how many were expired in the last pass.
+    pub fn record_v2_simulations_expired(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.v2_simulations_expired.inc_by(count as u64);
+    }
+
     pub fn record_memory_usage(&self, bytes: f64) {
         self.memory_usage.set(bytes);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,39 @@
 //! own session type and its own stored-session schema, so existing clients
 //! need no changes.
 //!
+//! ## Configuration
+//!
+//! Every environment variable the service reads is documented in
+//! `.env.example` with its default and accepted range. Two families, with
+//! deliberately different failure behaviour:
+//!
+//! - **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
+//!   `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CACHED_WALKS` — warn and fall back
+//!   to their defaults when set to something invalid. A bad value there
+//!   degrades one request.
+//! - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
+//!   `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
+//!   `OCS_MAX_CACHED_SNAPSHOTS` — are **validated at startup** and fail the
+//!   process with a message naming the variable. Silently reverting a
+//!   retention window would expire simulations a client is still walking, and
+//!   silently reverting a cache bound would change the service's memory
+//!   profile with nothing to show for it.
+//!
+//! **v2 retention is real time, not simulated time.** A simulation whose
+//! simulated clock spans three years is still walked one request at a time, so
+//! its idle window is an operational choice independent of the horizon. It
+//! defaults to an hour — longer than v1's thirty minutes — and is measured from
+//! the last **write**: peeking a snapshot persists nothing, so a client that
+//! only peeks does not refresh it. The in-memory and Redis backends apply the
+//! same window from the same constant.
+//!
+//! A retention sweep runs every `OCS_V2_CLEANUP_INTERVAL_SECS`, reaping expired
+//! simulations and evicting the factor tapes and snapshots they left behind.
+//! Eviction is never observable in what is served: both rebuild identically
+//! from the effective parameters, so it costs latency and nothing else. The
+//! sweep publishes `v2_simulations_expired_total`, and the caches publish
+//! `v2_tape_cache_size` and `v2_snapshot_cache_size`.
+//!
 //! ## Request/Response Models
 //!
 //! ### 1. Create Session (POST /api/v1/chain)

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,14 +59,14 @@
 
 use optionchain_simulator::api::{ListenOn, start_server};
 use optionchain_simulator::infrastructure::{
-    MetricsCollector, RedisClient, RedisConfig, init_mongodb,
+    MetricsCollector, RedisClient, RedisConfig, SimulationV2Config, init_mongodb,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
 };
 use optionstratlib::utils::setup_logger_with_level;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 
 /// The `main` function is the entry point of the application using the Actix Web server framework.
 /// It initializes the logger, sets up the session management with Redis as the backend, and starts the HTTP server.
@@ -136,12 +136,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The v2 rolling simulations live in their own Redis key space, so a v2 id
     // can never resolve a v1 session and a v1 document is never read back as
     // rolling configuration (ADR 0001 section 12.2).
+    //
+    // Their operational limits are loaded and validated here, before anything
+    // binds: an invalid knob fails startup with a message naming the variable
+    // rather than silently reverting to a default that would change how long
+    // simulations live.
+    let v2_config = SimulationV2Config::from_env()?;
     let simulation_store = Arc::new(InRedisSimulationStore::new(
         redis_client_v2,
         None, // the documented v2 prefix
-        None, // the shared v2 retention window
+        Some(v2_config.retention_secs()),
     ));
-    let simulation_manager = Arc::new(SimulationManager::new(simulation_store));
+    let simulation_manager = Arc::new(SimulationManager::new(simulation_store, v2_config));
+
+    // Reap idle simulations and evict what they left cached. Detached, because
+    // the sweep is independent of any request; it stops when the process does.
+    let sweeper = Arc::clone(&simulation_manager);
+    let sweeper_metrics = Arc::clone(&metrics_collector);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(v2_config.cleanup_interval);
+        loop {
+            ticker.tick().await;
+            match sweeper.cleanup().await {
+                Ok(expired) => {
+                    sweeper_metrics.record_v2_simulations_expired(expired.len());
+                    sweeper_metrics.set_v2_cache_sizes(
+                        sweeper.cached_tapes() as i64,
+                        sweeper.cached_snapshots() as i64,
+                    );
+                }
+                // A failed sweep is worth knowing about but must not stop the
+                // loop: the next tick retries, and Redis expiring keys on its
+                // own means nothing leaks in the meantime except the cache
+                // entries this pass would have dropped.
+                Err(error) => warn!(%error, "the v2 retention sweep failed"),
+            }
+        }
+    });
     let listen_on = ListenOn::All;
     let port = 7070;
     // Start HTTP server

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -24,44 +24,17 @@
 
 use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
+use crate::infrastructure::SimulationV2Config;
 use crate::session::manager::DEFAULT_NAMESPACE;
 use crate::session::model::SessionState;
 use crate::session::store::SimulationStore;
 use crate::session::{SessionV2, SimulationParametersV2};
 use crate::utils::{ChainError, UuidGenerator};
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 use uuid::Uuid;
-
-/// Default number of factor tapes held in memory.
-///
-/// A tape is `O(steps)` four-field rows, so this bound is generous compared
-/// with the snapshot cache's. Issue #48 folds it into the typed v2
-/// configuration.
-const DEFAULT_MAX_CACHED_TAPES: usize = 64;
-
-/// Hard bound on cached factor tapes (`OCS_MAX_CACHED_TAPES`).
-///
-/// Read once via [`LazyLock`], mirroring `OCS_MAX_CACHED_WALKS`; an unset or
-/// invalid value falls back to the default and warns rather than aborting
-/// startup.
-static MAX_CACHED_TAPES: LazyLock<usize> =
-    LazyLock::new(|| match std::env::var("OCS_MAX_CACHED_TAPES").ok() {
-        None => DEFAULT_MAX_CACHED_TAPES,
-        Some(value) => match value.trim().parse::<usize>() {
-            Ok(parsed) if parsed >= 1 => parsed,
-            _ => {
-                warn!(
-                    raw = %value,
-                    default = DEFAULT_MAX_CACHED_TAPES,
-                    "invalid OCS_MAX_CACHED_TAPES; falling back to default"
-                );
-                DEFAULT_MAX_CACHED_TAPES
-            }
-        },
-    });
 
 /// The UUID v5 namespace simulations are generated under.
 ///
@@ -86,6 +59,7 @@ struct TapeEntry {
 pub struct SimulationManager {
     store: Arc<dyn SimulationStore>,
     uuid_generator: UuidGenerator,
+    config: SimulationV2Config,
     tapes: Mutex<HashMap<Uuid, TapeEntry>>,
     snapshots: Mutex<SnapshotCache>,
 }
@@ -97,13 +71,20 @@ impl SimulationManager {
     /// because it deals in `domain` types that are not part of this crate's
     /// public API. The v2 REST surface is the contract, not these signatures.
     #[must_use]
-    pub fn new(store: Arc<dyn SimulationStore>) -> Self {
+    pub fn new(store: Arc<dyn SimulationStore>, config: SimulationV2Config) -> Self {
         Self {
             store,
             uuid_generator: UuidGenerator::new(default_namespace()),
+            config,
             tapes: Mutex::new(HashMap::new()),
-            snapshots: Mutex::new(SnapshotCache::new()),
+            snapshots: Mutex::new(SnapshotCache::with_capacity(config.max_cached_snapshots)),
         }
+    }
+
+    /// The operational configuration this manager applies.
+    #[must_use]
+    pub fn config(&self) -> SimulationV2Config {
+        self.config
     }
 
     /// Creates a simulation from resolved parameters.
@@ -239,11 +220,7 @@ impl SimulationManager {
     ///
     /// Returns any storage failure.
     #[instrument(skip(self), level = "debug")]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the cleanup loop is wired by #48")
-    )]
-    pub(crate) async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError> {
+    pub async fn cleanup(&self) -> Result<Vec<Uuid>, ChainError> {
         let expired = self.store.cleanup().await?;
         for id in &expired {
             self.evict(*id);
@@ -253,11 +230,7 @@ impl SimulationManager {
 
     /// The number of factor tapes currently cached.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "consumed by the v2 cache metrics in #48")
-    )]
-    pub(crate) fn cached_tapes(&self) -> usize {
+    pub fn cached_tapes(&self) -> usize {
         match self.tapes.lock() {
             Ok(tapes) => tapes.len(),
             Err(poisoned) => poisoned.into_inner().len(),
@@ -266,11 +239,7 @@ impl SimulationManager {
 
     /// The number of snapshots currently cached.
     #[must_use]
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "consumed by the v2 cache metrics in #48")
-    )]
-    pub(crate) fn cached_snapshots(&self) -> usize {
+    pub fn cached_snapshots(&self) -> usize {
         match self.snapshots.lock() {
             Ok(snapshots) => snapshots.len(),
             Err(poisoned) => poisoned.into_inner().len(),
@@ -368,11 +337,14 @@ impl SimulationManager {
         };
 
         tapes.remove(&id);
-        // `MAX_CACHED_TAPES` is validated `>= 1` at parse time, so `- 1` cannot
-        // underflow. Evicting before the insert keeps the id being inserted out
-        // of the running for victim.
-        let max = *MAX_CACHED_TAPES;
-        debug_assert!(max >= 1, "MAX_CACHED_TAPES is validated >= 1 at parse time");
+        // The capacity is validated `>= 1` when the configuration loads, so
+        // `- 1` cannot underflow. Evicting before the insert keeps the id being
+        // inserted out of the running for victim.
+        let max = self.config.max_cached_tapes;
+        debug_assert!(
+            max >= 1,
+            "the configured capacity is validated >= 1 at load"
+        );
         while tapes.len() > max - 1 {
             let victim = tapes
                 .iter()
@@ -481,7 +453,10 @@ mod tests {
     }
 
     fn manager() -> SimulationManager {
-        SimulationManager::new(Arc::new(InMemorySimulationStore::new()))
+        SimulationManager::new(
+            Arc::new(InMemorySimulationStore::new()),
+            SimulationV2Config::default(),
+        )
     }
 
     async fn created(manager: &SimulationManager, steps: usize) -> SessionV2 {
@@ -621,7 +596,7 @@ mod tests {
     #[tokio::test]
     async fn test_a_lost_race_is_a_conflict() {
         let store = Arc::new(InMemorySimulationStore::new());
-        let manager = SimulationManager::new(store.clone());
+        let manager = SimulationManager::new(store.clone(), SimulationV2Config::default());
         let created = created(&manager, 5).await;
 
         // Advance once through the manager, then replay an advance built from
@@ -706,7 +681,7 @@ mod tests {
         let store = Arc::new(InMemorySimulationStore::with_idle_retention(
             std::time::Duration::from_secs(1),
         ));
-        let manager = SimulationManager::new(store);
+        let manager = SimulationManager::new(store, SimulationV2Config::default());
         let created = created(&manager, 5).await;
         match manager.peek(created.id).await {
             Ok(_) => {}

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -15,23 +15,19 @@ use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
 /// Default retention for a v2 simulation, in seconds — shared by **both**
-/// backends.
+/// backends and by the configuration.
 ///
-/// One constant rather than one per store, because ADR 0001 §9.1 requires the
-/// in-memory and Redis stores to agree on expiry, and two independently-named
-/// defaults are exactly how that agreement drifts.
+/// Re-exported from [`crate::infrastructure::DEFAULT_RETENTION_SECS`] rather
+/// than restated, because ADR 0001 §9.1 requires the in-memory and Redis stores
+/// to agree on expiry and a second literal is exactly how that agreement
+/// drifts. An operator changes it through `OCS_V2_RETENTION_SECS`; this is only
+/// the value a store built without one applies.
 ///
-/// Deliberately longer than v1's 30 minutes: a simulation whose *simulated*
-/// clock spans years is still walked one request at a time, and a client
-/// pausing between steps must not lose it. Issue #48 makes it configurable;
-/// v1's retention is untouched either way.
-///
-/// The window is measured from the **last write**, not from the last access:
-/// ADR 0001 §6 defines the snapshot endpoint as a safe peek that persists
-/// nothing, so a client that only peeks does not refresh it. Both backends
-/// behave the same way, which is the property that matters here; whether
-/// peeking should refresh is #48's call.
-pub const DEFAULT_V2_RETENTION_SECS: u64 = 3_600;
+/// The window is measured from the **last write**, not the last access: ADR
+/// 0001 §6 defines the snapshot endpoint as a safe peek that persists nothing,
+/// so a client that only peeks does not refresh it. Both backends behave the
+/// same way.
+pub use crate::infrastructure::DEFAULT_RETENTION_SECS as DEFAULT_V2_RETENTION_SECS;
 
 /// In-memory store for v2 rolling simulations.
 pub struct InMemorySimulationStore {


### PR DESCRIPTION
## Stack

- **Base branch:** `stack/6-47-api-v2-simulations`
- **Stack:** #42 → #43 → #44 → #45 → #46 → #47 → **#48** → #49
- **Stacked on:** #64
- **Blocks:** #66 (#49 — the export relies on the immutable parameter snapshot and the retention window)

Targets `main` but is cut from `stack/6-47-api-v2-simulations`, so **the diff against `main` is cumulative** until #64 merges. Review against the base branch.

## Summary

Gives the v2 surface operational limits an operator can set, a sweep that actually reclaims what expired simulations leave behind, and metrics to see both. Until now the knobs were scattered `LazyLock`s reading their own environment variables, nothing ever called `cleanup`, and the repository had **no `.env.example` at all**.

## The distinction the change turns on

**Retention is real time, unrelated to the months or years a simulation's simulated clock spans.** A simulation with a three-year horizon is still walked one request at a time, so losing it to a thirty-minute idle timeout would make the horizon unusable.

v2 therefore gets its own window — an hour by default rather than inheriting v1's 1800 s — measured from the last **write**: peeking a snapshot persists nothing, so a client that only peeks does not refresh it. Both backends apply the same number from **one** constant, because ADR §9.1 requires them to agree and two independently-named defaults are exactly how that agreement drifts.

## Validation that fails instead of falling back

`SimulationV2Config` loads at startup and **fails** on an invalid value, naming the variable. That is a deliberate departure from `api::rest::limits`, which warns and defaults:

- a bad `OCS_MAX_STEPS` degrades **one request**;
- a retention window silently reset would **expire simulations a client is still walking**, and a cache bound silently reset would change the service's memory profile with nothing to show for it.

The parsers take the raw value rather than reading the environment themselves, so the bounds are tested directly. Mutating the process environment in a test would need `unsafe` in this edition — which the rules forbid — and would race every other test in the binary.

## The sweep

Runs on its own interval. Each pass reaps expired simulations, evicts the factor tapes and snapshots they left behind, and publishes what it did. A failed pass logs and waits for the next tick rather than stopping the loop: Redis expires its own keys regardless, so nothing leaks in the meantime except the cache entries that pass would have dropped.

## Metrics

`v2_tape_cache_size` and `v2_snapshot_cache_size` are reported **separately**, because the two caches behave very differently — a tape is `O(steps)` small rows, a snapshot holds every strike of every live expiration — and reporting them together would hide which bound needs moving. `v2_simulations_expired_total` is a counter rather than a gauge, since the interesting question is how many are being expired over time.

## `.env.example`

The repository has never had one despite `rules/global_rules.md` requiring it. It now documents **every** variable the service reads — not only the new ones — with its default, its accepted range, and which of the two failure behaviours it follows.

## Tests — 13 new

Every parsing path and bound on both kinds of knob: an unset variable takes its default; an unparseable, zero, or over-ceiling value fails by name; the ambient environment loads; and both stores reach the same configured retention.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `LOGLEVEL=WARN cargo test --workspace` — **580 passed, 0 failed, 13 ignored**, up from 567; plus 16 golden contract tests and 2 doctests
- `cargo build --release`
- `make readme` — regenerated from the new `src/lib.rs` configuration section

No new dependency. New env vars: `OCS_V2_RETENTION_SECS`, `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`, `OCS_MAX_CACHED_SNAPSHOTS` — all documented in `.env.example` and `src/lib.rs`. **v1 TTL and cache behaviour are unchanged.**

Closes #48