### PR TITLE
State how a historical v2 walk is priced (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ which means another writer committed first.
 changing the seed, the start, the schedules or the chain shape changes the
 tape, so it creates a new simulation instead of mutating one.
 
+**A historical v2 walk is priced at the volatility you send.** A
+`Historical` method carries no volatility of its own, and v2 does not enter
+the upstream walk driver that estimates one per step, so every step of a
+historical v2 simulation prices at the request's constant `volatility`. v1
+uses a rolling causal estimate for the same series, so the two produce the
+same price path and different premiums. It is a stated difference, tracked
+in issue #63 and asked for upstream in optionstratlib#423.
+
 **Replay.** The creation response echoes the effective seed, effective
 start, step interval, time frame, timezone, calendar version, IANA tzdb
 release and normalised schedules — everything needed to reproduce the run

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -484,6 +484,25 @@ unversioned would be a false guarantee, so the effective tzdb release
 the seed. A replay against a different tzdb is still a replay — it is just one
 the client can now detect.
 
+**What a `Historical` walk is priced at.** A historical walk carries no
+volatility of its own — it is a price series, and `WalkType::volatility()`
+returns `None` for it. v1 prices one with a rolling causal estimate, because its
+walk driver computes an expanding-window realized volatility per step. v2 never
+enters that driver — the factor tape exists precisely to stop materialising a
+chain per step — and upstream keeps the estimator private to it, so **every step
+of a historical v2 tape is priced at the constant `volatility` the request
+supplied**.
+
+This is part of the contract, not an accident. The same series and the same seed
+produce the *same price path* under v1 and v2, and *different premiums*, because
+the volatility pricing them differs. A client comparing the two should expect
+that. Closing the gap needs the estimator reachable from outside the driver,
+which is asked for in optionstratlib#423; porting a second copy of the
+mathematics into the tape would contradict the module's stated premise of not
+reimplementing upstream. Issue #63 tracks it, and if the estimator lands the
+per-step value goes into `FactorRow.base_volatility`, which is already defined
+as the exact number that step's chains are priced at.
+
 Three properties keep the guarantee honest, and each is a test in the issues
 that implement it:
 

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -1058,9 +1058,12 @@ mod tests {
     /// would break it.
     #[test]
     fn test_a_longer_series_leaves_earlier_steps_untouched() {
-        let build = |steps: usize, observations: usize| {
+        // The observation count is a `u32` so the index converts to `f64`
+        // losslessly and infallibly — no conversion to swallow, which is what a
+        // fallback of zero would have done, quietly flattening the series.
+        let build = |steps: usize, observations: u32| {
             let prices: Vec<f64> = (0..observations)
-                .map(|i| 5000.0 + (f64::from(u32::try_from(i).unwrap_or(0)) * 7.0).sin() * 250.0)
+                .map(|i| 5000.0 + (f64::from(i) * 7.0).sin() * 250.0)
                 .collect();
             let mut historical = request(steps, brownian(0.18), 0.18);
             historical.method = ApiWalkType::Historical {

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -38,6 +38,24 @@
 //!   seeded [`Walker`] for the same `WalkParams` v1 builds, and reads the price
 //!   path from `generate_with_vol`. It does not reimplement the mathematics, so
 //!   there is no second copy to diverge.
+//!
+//! # Where v2 knowingly differs from v1: historical volatility
+//!
+//! A `Historical` walk carries no volatility of its own — it is a price series,
+//! and `WalkType::volatility()` returns `None` for it. v1 prices such a walk
+//! with a rolling causal estimate, because `walk_steps_par` computes one with
+//! upstream's `expanding_window_vols`. v2 never enters that driver, and the
+//! estimator is private to it, so **every step of a historical v2 tape is
+//! priced at the constant `volatility` the request supplied**.
+//!
+//! This is a stated behaviour, not an oversight. The same series and seed run
+//! through v1 and v2 produce the same price path — the tape pins that — and
+//! different premiums, because the volatility pricing them differs. Closing the
+//! gap needs the estimator to be reachable from outside the driver, which is
+//! asked for upstream in optionstratlib#423; porting a second copy of the
+//! mathematics into this module would contradict the property directly above
+//! it. Issue #63 tracks it here, and ADR 0001 §8 records it as part of the
+//! contract rather than leaving a client to infer it from two runs.
 
 use crate::domain::Walker;
 use crate::domain::simulator::{
@@ -1026,6 +1044,46 @@ mod tests {
                 expected,
                 "step {} must replay its own observation",
                 row.step
+            );
+        }
+    }
+
+    /// Later observations cannot change an earlier step's base volatility.
+    ///
+    /// The property the estimator question turns on (#63): whatever prices a
+    /// historical step, it must be a function of that step and what came before
+    /// it. Today the answer is the requested constant, so extending the series
+    /// changes nothing — and if optionstratlib#423 lands and a causal estimate
+    /// replaces the constant, this test keeps holding while a look-ahead one
+    /// would break it.
+    #[test]
+    fn test_a_longer_series_leaves_earlier_steps_untouched() {
+        let build = |steps: usize, observations: usize| {
+            let prices: Vec<f64> = (0..observations)
+                .map(|i| 5000.0 + (f64::from(u32::try_from(i).unwrap_or(0)) * 7.0).sin() * 250.0)
+                .collect();
+            let mut historical = request(steps, brownian(0.18), 0.18);
+            historical.method = ApiWalkType::Historical {
+                timeframe: ApiTimeFrame::Day,
+                prices,
+                symbol: Some("SPX".to_string()),
+            };
+            tape(&parameters(historical))
+        };
+
+        let short = build(15, 20);
+        let long = build(15, 400);
+
+        for (early, later) in short.rows().iter().zip(long.rows()) {
+            assert_eq!(
+                early.base_volatility, later.base_volatility,
+                "step {} must not depend on observations after it",
+                early.step
+            );
+            assert_eq!(
+                early.spot, later.spot,
+                "step {} replayed differently",
+                early.step
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,14 @@
 //! changing the seed, the start, the schedules or the chain shape changes the
 //! tape, so it creates a new simulation instead of mutating one.
 //!
+//! **A historical v2 walk is priced at the volatility you send.** A
+//! `Historical` method carries no volatility of its own, and v2 does not enter
+//! the upstream walk driver that estimates one per step, so every step of a
+//! historical v2 simulation prices at the request's constant `volatility`. v1
+//! uses a rolling causal estimate for the same series, so the two produce the
+//! same price path and different premiums. It is a stated difference, tracked
+//! in issue #63 and asked for upstream in optionstratlib#423.
+//!
 //! **Replay.** The creation response echoes the effective seed, effective
 //! start, step interval, time frame, timezone, calendar version, IANA tzdb
 //! release and normalised schedules — everything needed to reproduce the run


### PR DESCRIPTION
## Summary

A `Historical` walk carries no volatility of its own — `WalkType::volatility()` returns `None` for it, because the volatility has to be estimated from the price series. v1 gets an estimate: its walk driver computes an expanding-window realized volatility per step. v2 never enters that driver, and the estimator is private to it, so every step of a historical v2 tape prices at the constant `volatility` the request supplied.

The consequence is visible to a client: the same series and the same seed run through v1 and v2 produce the **same price path** and **different premiums**. That was documented on one private function and nowhere anyone would look for it.

## The decision

Of the three options the issue lays out, this PR takes the third and half of the first: **document the difference as part of the contract, and ask upstream for the estimator**.

- Porting `expanding_window_vols` into the factor tape was rejected. That module's stated premise is that it does not reimplement upstream mathematics, and this repo already carries one mirror — the seeded walk kernels — whose re-sync burden `CLAUDE.md` records. Doubling it to avoid a small upstream change is the wrong trade.
- Refusing `Historical` for v2 was rejected because it removes a model v1 offers, for a difference that is defensible once stated.
- **optionstratlib#423** asks for `expanding_window_vols` to be reachable from outside the driver. If it lands, the per-step value goes into `FactorRow.base_volatility` — which is already defined as the exact number that step's chains are priced at — and nothing else in the contract moves.

## Changes

- `src/domain/factors.rs`: a module-doc section stating the behaviour, why it is not a mirror, and where it is tracked. The function-level note stays.
- `doc/adr/0001-v2-rolling-simulation-contract.md` §8: the same, recorded with the replay contract, so the v1/v2 relationship is part of the specification rather than folklore.
- `src/lib.rs` (and the regenerated `README.md`): one paragraph in the v2 section, because this is the level a client reads before comparing two runs.
- A test for the property the whole question turns on: extending the price series leaves every earlier step's base volatility and spot untouched. It passes for today's constant and would keep passing for a causal estimate — a look-ahead one would break it.

## Testing

- [x] `make pre-push` — 609 unit tests plus 16 v1-contract tests, clippy and fmt clean
- [x] `cargo build --release` clean
- [x] `README.md` regenerated via cargo-readme, not hand-edited

## Stack

- **Stack:** #63 → #62 → #56 — **this is PR 1 (bottom)**
- **Base branch:** `main`
- **Blocks:** the next PR in the chain
- The diff is exactly this issue's; nothing below it to read against.

Refs #63