### PR TITLE
Bound the work one snapshot prices and the cache by contracts (#62)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,13 +99,15 @@ OCS_MAX_CACHED_SNAPSHOTS=256
 # reasonable alone and multiply into half a million contracts for one /snapshot
 # call, which this bounds. Reported against chain_size, the field a client can
 # lower without changing what the simulation means.
-# Range: 1 .. usize.  Default: 200000
+# Range: 1 .. 10000000.  Default: 200000
 OCS_MAX_SNAPSHOT_CONTRACTS=200000
 
 # Maximum contracts held resident across every cached v2 snapshot. This is the
 # bound that protects memory — OCS_MAX_CACHED_SNAPSHOTS bounds the map, and one
 # entry is a few hundred contracts in the reference configuration and hundreds
-# of thousands in a large one. Roughly a gigabyte at the default.
+# of thousands in a large one. Roughly a gigabyte at the default. A snapshot
+# heavier than this whole budget is served without being cached, rather than
+# evicting everything to make room for something that still would not fit.
 # Range: 1 .. 100000000.  Default: 4000000
 OCS_MAX_CACHED_SNAPSHOT_CONTRACTS=4000000
 

--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,21 @@ OCS_MAX_CACHED_TAPES=64
 # Range: 1 .. 1000000.  Default: 256
 OCS_MAX_CACHED_SNAPSHOTS=256
 
+# Maximum contracts one v2 snapshot may price: strikes x the sum of every
+# schedule rule's target_count. The chain-size and expiration caps are each
+# reasonable alone and multiply into half a million contracts for one /snapshot
+# call, which this bounds. Reported against chain_size, the field a client can
+# lower without changing what the simulation means.
+# Range: 1 .. usize.  Default: 200000
+OCS_MAX_SNAPSHOT_CONTRACTS=200000
+
+# Maximum contracts held resident across every cached v2 snapshot. This is the
+# bound that protects memory — OCS_MAX_CACHED_SNAPSHOTS bounds the map, and one
+# entry is a few hundred contracts in the reference configuration and hundreds
+# of thousands in a large one. Roughly a gigabyte at the default.
+# Range: 1 .. 100000000.  Default: 4000000
+OCS_MAX_CACHED_SNAPSHOT_CONTRACTS=4000000
+
 # Maximum steps one export request may cover. Bounds the WORK, not the memory:
 # streaming already keeps the response bounded, but an option_chains export is
 # steps x expirations x strikes priced contracts, so an unbounded range is

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ deliberately different failure behaviour:
   degrades one request.
 - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
   `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
-  `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
+  `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS`,
+  `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
   process with a message naming the variable. Silently reverting a
   retention window would expire simulations a client is still walking, and
   silently reverting a cache bound would change the service's memory

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -578,12 +578,31 @@ adds caps so that a single request cannot ask for unbounded work:
 | `OCS_MAX_TARGET_COUNT` | `target_count` of one rule |
 | `OCS_MAX_EXPIRATIONS_PER_SNAPSHOT` | expirations in one snapshot, enforced at schedule validation on the **pre-deduplication** sum of every rule's `target_count` |
 | `OCS_MAX_EXPORT_ROWS` | rows one export may produce |
+| `OCS_MAX_SNAPSHOT_CONTRACTS` | contracts one snapshot may price — `strikes × Σ target_count`, default 200 000 |
+| `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS` | contracts resident across the snapshot cache, default 4 000 000 |
 | v2 session idle TTL, factor-tape and snapshot cache capacities | §9.1, §9.2 |
 
 The pre-deduplication sum is the tight upper bound on how many chains a snapshot
 can hold, and checking it at construction keeps the rejection deterministic: a
 post-deduplication check would accept or reject the same schedule depending on
 which dates happened to coincide at the instant it was evaluated.
+
+**Two caps that are each reasonable can multiply into one that is not.** A chain
+size of 500 is 1 001 strikes; a schedule may keep 512 expirations alive; the
+product is half a million priced contracts for a single `/snapshot` call, from a
+request that violates neither bound. `OCS_MAX_SNAPSHOT_CONTRACTS` bounds the
+product, checked once at creation and reported against `chain_size` — the field
+a client can lower without changing what the simulation means. The default is
+deliberately generous: the reference configuration in §14 prices about 500
+contracts a snapshot.
+
+The snapshot cache is bounded the same way. An entry count says nothing about
+memory when one entry is a few hundred contracts in one configuration and
+hundreds of thousands in another, so `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS` bounds
+what is resident and the entry cap of §9.2 bounds the map. A snapshot heavier
+than the whole budget is still cached — refusing to hold anything would turn a
+large-but-legal configuration into a permanently cold cache, and the per-snapshot
+cap is what bounds that case.
 
 Breaching a request-shaped cap is a `400` naming the offending field; breaching
 `OCS_MAX_EXPORT_ROWS` is a `400` naming the range. Every knob is documented in

--- a/src/api/rest/limits.rs
+++ b/src/api/rest/limits.rs
@@ -11,6 +11,7 @@
 //! | `OCS_MAX_STEPS`            | `10_000`  | Max simulation steps per session         |
 //! | `OCS_MAX_CHAIN_SIZE`       | `500`     | Max option-chain size per request        |
 //! | `OCS_MAX_HISTORICAL_PRICES`| `100_000` | Max historical prices in a walk request  |
+//! | `OCS_MAX_SNAPSHOT_CONTRACTS`| `200_000`| Max contracts one v2 snapshot may price |
 
 use std::sync::LazyLock;
 use tracing::warn;
@@ -21,6 +22,16 @@ pub(crate) const DEFAULT_MAX_STEPS: usize = 10_000;
 pub(crate) const DEFAULT_MAX_CHAIN_SIZE: usize = 500;
 /// Default cap on the number of historical prices in a `Historical` walk request.
 pub(crate) const DEFAULT_MAX_HISTORICAL_PRICES: usize = 100_000;
+/// Default cap on the contracts one v2 snapshot may price.
+///
+/// A snapshot prices every strike of every live expiration, so its cost is the
+/// product of two caps that each look reasonable alone: `OCS_MAX_CHAIN_SIZE`
+/// of 500 is 1 001 strikes, and a schedule may keep 512 expirations alive, for
+/// half a million contracts in one request. The default admits any realistic
+/// configuration — ADR 0001's reference schedule prices about 500 contracts a
+/// snapshot, and 200 000 still allows 200 expirations at 1 001 strikes — while
+/// refusing the shapes that exist only to exhaust the service.
+pub(crate) const DEFAULT_MAX_SNAPSHOT_CONTRACTS: usize = 200_000;
 
 /// Maximum number of simulation steps a session may request (`OCS_MAX_STEPS`).
 pub(crate) static MAX_STEPS: LazyLock<usize> =
@@ -42,6 +53,26 @@ pub(crate) static MAX_HISTORICAL_PRICES: LazyLock<usize> = LazyLock::new(|| {
         DEFAULT_MAX_HISTORICAL_PRICES,
     )
 });
+
+/// Maximum number of contracts one v2 snapshot may price
+/// (`OCS_MAX_SNAPSHOT_CONTRACTS`).
+pub(crate) static MAX_SNAPSHOT_CONTRACTS: LazyLock<usize> = LazyLock::new(|| {
+    parse_limit(
+        std::env::var("OCS_MAX_SNAPSHOT_CONTRACTS").ok(),
+        DEFAULT_MAX_SNAPSHOT_CONTRACTS,
+    )
+});
+
+/// The number of strikes a chain of `chain_size` carries.
+///
+/// `chain_size` is upstream's per-side half-width — it counts strikes above
+/// *and* below the money — so the ladder is `2n + 1` wide. Saturating, because
+/// the caller may be validating a value that has not been range-checked yet and
+/// an overflow here would be the wrong error to report.
+#[must_use]
+pub(crate) fn strikes_per_chain(chain_size: usize) -> usize {
+    chain_size.saturating_mul(2).saturating_add(1)
+}
 
 /// Parses a raw environment value into a positive `usize` limit.
 ///

--- a/src/api/rest/limits.rs
+++ b/src/api/rest/limits.rs
@@ -11,7 +11,6 @@
 //! | `OCS_MAX_STEPS`            | `10_000`  | Max simulation steps per session         |
 //! | `OCS_MAX_CHAIN_SIZE`       | `500`     | Max option-chain size per request        |
 //! | `OCS_MAX_HISTORICAL_PRICES`| `100_000` | Max historical prices in a walk request  |
-//! | `OCS_MAX_SNAPSHOT_CONTRACTS`| `200_000`| Max contracts one v2 snapshot may price |
 
 use std::sync::LazyLock;
 use tracing::warn;
@@ -22,16 +21,6 @@ pub(crate) const DEFAULT_MAX_STEPS: usize = 10_000;
 pub(crate) const DEFAULT_MAX_CHAIN_SIZE: usize = 500;
 /// Default cap on the number of historical prices in a `Historical` walk request.
 pub(crate) const DEFAULT_MAX_HISTORICAL_PRICES: usize = 100_000;
-/// Default cap on the contracts one v2 snapshot may price.
-///
-/// A snapshot prices every strike of every live expiration, so its cost is the
-/// product of two caps that each look reasonable alone: `OCS_MAX_CHAIN_SIZE`
-/// of 500 is 1 001 strikes, and a schedule may keep 512 expirations alive, for
-/// half a million contracts in one request. The default admits any realistic
-/// configuration — ADR 0001's reference schedule prices about 500 contracts a
-/// snapshot, and 200 000 still allows 200 expirations at 1 001 strikes — while
-/// refusing the shapes that exist only to exhaust the service.
-pub(crate) const DEFAULT_MAX_SNAPSHOT_CONTRACTS: usize = 200_000;
 
 /// Maximum number of simulation steps a session may request (`OCS_MAX_STEPS`).
 pub(crate) static MAX_STEPS: LazyLock<usize> =
@@ -54,24 +43,17 @@ pub(crate) static MAX_HISTORICAL_PRICES: LazyLock<usize> = LazyLock::new(|| {
     )
 });
 
-/// Maximum number of contracts one v2 snapshot may price
-/// (`OCS_MAX_SNAPSHOT_CONTRACTS`).
-pub(crate) static MAX_SNAPSHOT_CONTRACTS: LazyLock<usize> = LazyLock::new(|| {
-    parse_limit(
-        std::env::var("OCS_MAX_SNAPSHOT_CONTRACTS").ok(),
-        DEFAULT_MAX_SNAPSHOT_CONTRACTS,
-    )
-});
-
-/// The number of strikes a chain of `chain_size` carries.
+/// The number of strikes a chain of `chain_size` carries, or `None` when the
+/// count does not fit.
 ///
 /// `chain_size` is upstream's per-side half-width — it counts strikes above
-/// *and* below the money — so the ladder is `2n + 1` wide. Saturating, because
-/// the caller may be validating a value that has not been range-checked yet and
-/// an overflow here would be the wrong error to report.
+/// *and* below the money — so the ladder is `2n + 1` wide. Checked rather than
+/// saturating: a saturating width would silently answer a different question
+/// than the caller asked, and the caller is a validator whose whole job is to
+/// reject what it cannot serve.
 #[must_use]
-pub(crate) fn strikes_per_chain(chain_size: usize) -> usize {
-    chain_size.saturating_mul(2).saturating_add(1)
+pub(crate) fn strikes_per_chain(chain_size: usize) -> Option<usize> {
+    chain_size.checked_mul(2)?.checked_add(1)
 }
 
 /// Parses a raw environment value into a positive `usize` limit.

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -164,7 +164,7 @@ fn snapshot_contracts(snapshot: &SeriesSnapshot) -> usize {
     snapshot
         .chains
         .iter()
-        .map(|chain| chain.chain.iter().count())
+        .map(|chain| chain.chain.options.len())
         .sum()
 }
 
@@ -286,6 +286,12 @@ impl<'a> SeriesBuilder<'a> {
 struct CacheEntry {
     snapshot: SeriesSnapshot,
     last_access: Instant,
+    /// The entry's weight, measured once on insert.
+    ///
+    /// Kept rather than recomputed because eviction consults it on every
+    /// iteration: recomputing would walk every strike of every remaining entry
+    /// per victim, under the manager's lock, at a budget measured in millions.
+    contracts: usize,
 }
 
 /// A bounded, least-recently-accessed cache of built snapshots.
@@ -302,6 +308,8 @@ pub(crate) struct SnapshotCache {
     entries: HashMap<(Uuid, usize), CacheEntry>,
     capacity: usize,
     contract_budget: usize,
+    /// The sum of every entry's weight, maintained on insert and removal.
+    resident_contracts: usize,
 }
 
 impl Default for SnapshotCache {
@@ -340,16 +348,25 @@ impl SnapshotCache {
             entries: HashMap::new(),
             capacity: capacity.max(1),
             contract_budget: contract_budget.max(1),
+            resident_contracts: 0,
         }
     }
 
     /// The number of contracts currently held across every cached snapshot.
+    ///
+    /// Maintained incrementally, so this is O(1) — eviction consults it per
+    /// victim and recomputing would walk every strike of every entry under the
+    /// manager's lock.
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the budget is enforced internally; this reports it"
+        )
+    )]
     pub(crate) fn contracts(&self) -> usize {
-        self.entries
-            .values()
-            .map(|entry| snapshot_contracts(&entry.snapshot))
-            .sum()
+        self.resident_contracts
     }
 
     /// The number of snapshots currently held.
@@ -399,7 +416,27 @@ impl SnapshotCache {
     /// its bound afterwards.
     pub(crate) fn insert(&mut self, simulation: Uuid, snapshot: SeriesSnapshot) {
         let key = (simulation, snapshot.step);
-        self.entries.remove(&key);
+        self.remove_entry(&key);
+
+        let incoming = snapshot_contracts(&snapshot);
+
+        // A snapshot heavier than the whole budget is **not** cached. Admitting
+        // it would put the cache over the bound its own documentation states,
+        // and evicting everything to make room for something that still does
+        // not fit is the worst of both. The step stays servable — it is rebuilt
+        // on demand, which is what every cache miss does — and the operator's
+        // two knobs are what decide whether this can happen at all: the
+        // per-snapshot cap bounds one snapshot, this bounds the resident set.
+        if incoming > self.contract_budget {
+            debug!(
+                step = snapshot.step,
+                contracts = incoming,
+                budget = self.contract_budget,
+                "The snapshot is larger than the cache budget; serving it without caching"
+            );
+            return;
+        }
+
         // `capacity` is raised to at least one in the constructor, so `- 1`
         // cannot underflow. No saturating arithmetic: the rules forbid it, and
         // here it would hide a constructor that stopped enforcing the floor.
@@ -410,21 +447,29 @@ impl SnapshotCache {
         self.evict_to(self.capacity - 1);
 
         // Make room for this snapshot's own weight before inserting it, so the
-        // cache never exceeds its budget afterwards. A single snapshot larger
-        // than the whole budget is still cached — evicting everything and then
-        // refusing to hold anything would turn a large-but-legal configuration
-        // into a permanently cold cache — and the per-snapshot contract cap in
-        // `SimulationParametersV2::validate` is what bounds that case.
-        let incoming = snapshot_contracts(&snapshot);
-        self.evict_to_contracts(self.contract_budget.saturating_sub(incoming));
+        // cache never exceeds its budget afterwards. The subtraction cannot
+        // underflow: the branch above returned for anything larger.
+        self.evict_to_contracts(self.contract_budget - incoming);
 
+        self.resident_contracts = self.resident_contracts.saturating_add(incoming);
         self.entries.insert(
             key,
             CacheEntry {
                 snapshot,
                 last_access: Instant::now(),
+                contracts: incoming,
             },
         );
+    }
+
+    /// Removes one entry and takes its weight off the running total.
+    ///
+    /// Every removal goes through here, so `resident_contracts` cannot drift
+    /// from what the map holds.
+    fn remove_entry(&mut self, key: &(Uuid, usize)) {
+        if let Some(entry) = self.entries.remove(key) {
+            self.resident_contracts = self.resident_contracts.saturating_sub(entry.contracts);
+        }
     }
 
     /// Drops every entry belonging to `simulation`, returning how many went.
@@ -433,9 +478,17 @@ impl SnapshotCache {
     /// heavyweight snapshot cannot outlive the session it belongs to. #48 wires
     /// it to the store's cleanup.
     pub(crate) fn evict_simulation(&mut self, simulation: Uuid) -> usize {
-        let before = self.entries.len();
-        self.entries.retain(|(id, _), _| *id != simulation);
-        before - self.entries.len()
+        let victims: Vec<(Uuid, usize)> = self
+            .entries
+            .keys()
+            .filter(|(id, _)| *id == simulation)
+            .copied()
+            .collect();
+
+        for key in &victims {
+            self.remove_entry(key);
+        }
+        victims.len()
     }
 
     /// Evicts least-recently-accessed entries until the cache holds at most
@@ -444,11 +497,9 @@ impl SnapshotCache {
     /// Shares the victim rule with [`SnapshotCache::evict_to`], so which entry
     /// goes is the same question either bound asks.
     fn evict_to_contracts(&mut self, max: usize) {
-        while self.contracts() > max {
+        while self.resident_contracts > max {
             match self.least_recently_used() {
-                Some(key) => {
-                    self.entries.remove(&key);
-                }
+                Some(key) => self.remove_entry(&key),
                 None => break,
             }
         }
@@ -470,9 +521,7 @@ impl SnapshotCache {
     fn evict_to(&mut self, max: usize) {
         while self.entries.len() > max {
             match self.least_recently_used() {
-                Some(key) => {
-                    self.entries.remove(&key);
-                }
+                Some(key) => self.remove_entry(&key),
                 None => break,
             }
         }
@@ -1103,22 +1152,41 @@ mod tests {
         assert!(cache.get(other, 0).is_some(), "the newest stayed");
     }
 
-    /// A snapshot heavier than the whole budget is still cached rather than
-    /// making the cache permanently cold.
+    /// A snapshot heavier than the whole budget is not cached, and does not
+    /// take the rest of the cache down with it.
+    ///
+    /// Admitting it would put the cache over the bound its own configuration
+    /// states; evicting everything to make room for something that still does
+    /// not fit would be worse. The step is served either way — an uncached step
+    /// is a rebuild, which is what every miss already is.
     #[test]
-    fn test_a_snapshot_larger_than_the_budget_is_still_served() {
+    fn test_a_snapshot_larger_than_the_budget_is_not_cached() {
         let parameters = test_parameters();
         let tape = test_tape(&parameters);
         let weight = snapshot_contracts(&snapshot(&parameters, &tape, 0));
 
         let mut cache = SnapshotCache::with_bounds(10, weight / 2);
         let simulation = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        cache.insert(other, snapshot(&parameters, &tape, 1));
+        let resident = cache.len();
 
         cache.insert(simulation, snapshot(&parameters, &tape, 0));
 
         assert!(
-            cache.get(simulation, 0).is_some(),
-            "refusing to hold anything would make every request a rebuild"
+            cache.get(simulation, 0).is_none(),
+            "an entry that cannot fit the budget must not be admitted"
+        );
+        assert_eq!(
+            cache.len(),
+            resident,
+            "and it must not evict the entries that do fit"
+        );
+        assert!(
+            cache.contracts() <= weight / 2,
+            "the cache holds {} contracts, above its budget",
+            cache.contracts()
         );
     }
 

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -314,7 +314,7 @@ impl SnapshotCache {
     /// Creates a cache bounded by the documented default.
     ///
     /// The bound is configuration, not a constant of the domain: the service
-    /// passes the operator's value through [`SnapshotCache::with_capacity`].
+    /// passes the operator's values through [`SnapshotCache::with_bounds`].
     /// This constructor exists for tests and for a caller with nothing to say
     /// about it.
     #[must_use]
@@ -323,16 +323,6 @@ impl SnapshotCache {
             DEFAULT_MAX_CACHED_SNAPSHOTS,
             DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
         )
-    }
-
-    /// Creates a cache with an explicit bound.
-    ///
-    /// A capacity of zero is raised to one: a cache that can hold nothing would
-    /// make every `insert` a no-op and every `get` a miss, which is a
-    /// misconfiguration rather than an intent.
-    #[must_use]
-    pub(crate) fn with_capacity(capacity: usize) -> Self {
-        Self::with_bounds(capacity, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS)
     }
 
     /// Creates a cache bounded by both entries and contracts.
@@ -1007,6 +997,14 @@ mod tests {
 
     // ---- the snapshot cache -----------------------------------------------
 
+    /// A cache bounded by entries alone, for the tests about that bound.
+    ///
+    /// The contract budget is effectively unlimited here, so each test exercises
+    /// exactly the rule it names.
+    fn entry_bounded_cache(capacity: usize) -> SnapshotCache {
+        SnapshotCache::with_bounds(capacity, usize::MAX)
+    }
+
     fn cached_snapshot(step: usize) -> SeriesSnapshot {
         let simulated_at = match Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).single() {
             Some(instant) => instant,
@@ -1024,7 +1022,7 @@ mod tests {
     /// A cached snapshot is returned as stored.
     #[test]
     fn test_the_cache_returns_what_it_stored() {
-        let mut cache = SnapshotCache::with_capacity(4);
+        let mut cache = entry_bounded_cache(4);
         let simulation = Uuid::new_v4();
 
         assert!(cache.is_empty());
@@ -1042,7 +1040,7 @@ mod tests {
     /// accessed entry first.
     #[test]
     fn test_the_cache_evicts_the_least_recently_accessed_entry() {
-        let mut cache = SnapshotCache::with_capacity(2);
+        let mut cache = entry_bounded_cache(2);
         let simulation = Uuid::new_v4();
 
         cache.insert(simulation, cached_snapshot(0));
@@ -1128,7 +1126,7 @@ mod tests {
     /// simulation's entries can be dropped together.
     #[test]
     fn test_a_simulations_entries_can_be_evicted_together() {
-        let mut cache = SnapshotCache::with_capacity(8);
+        let mut cache = entry_bounded_cache(8);
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
 
@@ -1147,7 +1145,7 @@ mod tests {
     /// Re-inserting the same key replaces rather than duplicating.
     #[test]
     fn test_reinserting_a_key_replaces_the_entry() {
-        let mut cache = SnapshotCache::with_capacity(4);
+        let mut cache = entry_bounded_cache(4);
         let simulation = Uuid::new_v4();
 
         cache.insert(simulation, cached_snapshot(7));
@@ -1159,7 +1157,7 @@ mod tests {
     /// A capacity of zero is raised to one rather than making the cache inert.
     #[test]
     fn test_a_zero_capacity_is_raised_to_one() {
-        let mut cache = SnapshotCache::with_capacity(0);
+        let mut cache = entry_bounded_cache(0);
         let simulation = Uuid::new_v4();
 
         assert_eq!(cache.capacity(), 1);
@@ -1176,7 +1174,7 @@ mod tests {
         let parameters = parameters(request(3, reference_schedules()));
         let tape = tape(&parameters);
         let simulation = Uuid::new_v4();
-        let mut cache = SnapshotCache::with_capacity(1);
+        let mut cache = entry_bounded_cache(1);
 
         let original = snapshot(&parameters, &tape, 1);
         cache.insert(simulation, original.clone());

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -51,7 +51,7 @@
 
 use crate::domain::expiry::{ActiveExpiry, RollingPlanner};
 use crate::domain::factors::{FactorRow, FactorTape, build_chain};
-use crate::infrastructure::DEFAULT_MAX_CACHED_SNAPSHOTS;
+use crate::infrastructure::{DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS, DEFAULT_MAX_CACHED_SNAPSHOTS};
 use crate::session::SimulationParametersV2;
 use crate::utils::ChainError;
 use chrono::{DateTime, Utc};
@@ -153,6 +153,19 @@ impl SeriesSnapshot {
             .iter()
             .filter(move |chain| chain.labels.iter().any(|label| label == rule_id))
     }
+}
+
+/// How many contracts a snapshot holds.
+///
+/// The unit the cache budgets in: one priced option per strike per live
+/// expiration, which is what makes a snapshot heavy.
+#[must_use]
+fn snapshot_contracts(snapshot: &SeriesSnapshot) -> usize {
+    snapshot
+        .chains
+        .iter()
+        .map(|chain| chain.chain.iter().count())
+        .sum()
 }
 
 /// Builds snapshots for one simulation.
@@ -288,6 +301,7 @@ struct CacheEntry {
 pub(crate) struct SnapshotCache {
     entries: HashMap<(Uuid, usize), CacheEntry>,
     capacity: usize,
+    contract_budget: usize,
 }
 
 impl Default for SnapshotCache {
@@ -305,7 +319,10 @@ impl SnapshotCache {
     /// about it.
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self::with_capacity(DEFAULT_MAX_CACHED_SNAPSHOTS)
+        Self::with_bounds(
+            DEFAULT_MAX_CACHED_SNAPSHOTS,
+            DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
+        )
     }
 
     /// Creates a cache with an explicit bound.
@@ -315,10 +332,34 @@ impl SnapshotCache {
     /// misconfiguration rather than an intent.
     #[must_use]
     pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self::with_bounds(capacity, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS)
+    }
+
+    /// Creates a cache bounded by both entries and contracts.
+    ///
+    /// Two bounds, because one entry is not one unit of memory: a snapshot
+    /// holds every strike of every live expiration, so 256 of them is a few
+    /// hundred contracts in the reference configuration and millions in a large
+    /// one. The entry bound keeps the map small; the contract budget is what
+    /// actually bounds the memory. Both floor at one — a cache that can hold
+    /// nothing makes every insert a no-op and every get a miss, which is a
+    /// misconfiguration rather than an intent.
+    #[must_use]
+    pub(crate) fn with_bounds(capacity: usize, contract_budget: usize) -> Self {
         Self {
             entries: HashMap::new(),
             capacity: capacity.max(1),
+            contract_budget: contract_budget.max(1),
         }
+    }
+
+    /// The number of contracts currently held across every cached snapshot.
+    #[must_use]
+    pub(crate) fn contracts(&self) -> usize {
+        self.entries
+            .values()
+            .map(|entry| snapshot_contracts(&entry.snapshot))
+            .sum()
     }
 
     /// The number of snapshots currently held.
@@ -377,6 +418,16 @@ impl SnapshotCache {
             "capacity is floored at one on construction"
         );
         self.evict_to(self.capacity - 1);
+
+        // Make room for this snapshot's own weight before inserting it, so the
+        // cache never exceeds its budget afterwards. A single snapshot larger
+        // than the whole budget is still cached — evicting everything and then
+        // refusing to hold anything would turn a large-but-legal configuration
+        // into a permanently cold cache — and the per-snapshot contract cap in
+        // `SimulationParametersV2::validate` is what bounds that case.
+        let incoming = snapshot_contracts(&snapshot);
+        self.evict_to_contracts(self.contract_budget.saturating_sub(incoming));
+
         self.entries.insert(
             key,
             CacheEntry {
@@ -397,20 +448,38 @@ impl SnapshotCache {
         before - self.entries.len()
     }
 
+    /// Evicts least-recently-accessed entries until the cache holds at most
+    /// `max` contracts.
+    ///
+    /// Shares the victim rule with [`SnapshotCache::evict_to`], so which entry
+    /// goes is the same question either bound asks.
+    fn evict_to_contracts(&mut self, max: usize) {
+        while self.contracts() > max {
+            match self.least_recently_used() {
+                Some(key) => {
+                    self.entries.remove(&key);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// The key of the least recently accessed entry, or `None` when empty.
+    fn least_recently_used(&self) -> Option<(Uuid, usize)> {
+        self.entries
+            .iter()
+            // The key breaks an `Instant` tie, so eviction does not depend on
+            // the map's randomised iteration order. Nothing served depends on
+            // which entry goes — a rebuild is identical — but a deterministic
+            // victim keeps the cache's behaviour reproducible under test.
+            .min_by_key(|(key, entry)| (entry.last_access, **key))
+            .map(|(key, _)| *key)
+    }
+
     /// Evicts least-recently-accessed entries until at most `max` remain.
     fn evict_to(&mut self, max: usize) {
         while self.entries.len() > max {
-            let victim = self
-                .entries
-                .iter()
-                // The key breaks an `Instant` tie, so eviction does not depend
-                // on the map's randomised iteration order. Nothing served
-                // depends on which entry goes — a rebuild is identical — but a
-                // deterministic victim keeps the cache's behaviour reproducible
-                // under test.
-                .min_by_key(|(key, entry)| (entry.last_access, **key))
-                .map(|(key, _)| *key);
-            match victim {
+            match self.least_recently_used() {
                 Some(key) => {
                     self.entries.remove(&key);
                 }
@@ -989,6 +1058,70 @@ mod tests {
         );
         assert!(cache.get(simulation, 1).is_none(), "the idle entry goes");
         assert!(cache.get(simulation, 2).is_some());
+    }
+
+    /// The contract budget evicts before the entry bound would.
+    ///
+    /// This is the bound that actually protects memory: one entry is a few
+    /// hundred contracts in the reference configuration and up to the
+    /// per-snapshot cap in a large one, so a cache that holds 256 of anything
+    /// says nothing about how much is resident.
+    #[test]
+    fn test_the_cache_evicts_on_the_contract_budget() {
+        // Real snapshots, because the weight is the point: an empty fixture
+        // would make the budget trivially satisfiable.
+        let parameters = test_parameters();
+        let tape = test_tape(&parameters);
+        let priced = |step: usize| snapshot(&parameters, &tape, step);
+
+        let first = priced(0);
+        let second = priced(1);
+        let budget = snapshot_contracts(&first) + snapshot_contracts(&second);
+        assert!(budget > 0, "the fixture must price something");
+
+        // Room for exactly these two by weight, and for ten by entry count.
+        let mut cache = SnapshotCache::with_bounds(10, budget);
+        let simulation = Uuid::new_v4();
+
+        cache.insert(simulation, first);
+        cache.insert(simulation, second);
+        assert_eq!(cache.len(), 2, "both fit within the budget");
+
+        // The reference tape is two steps long, so the third insert reuses
+        // step 0's snapshot under a second simulation id — a distinct key with
+        // the same weight, which is all this bound cares about.
+        let other = Uuid::new_v4();
+        cache.insert(other, priced(0));
+
+        assert!(
+            cache.len() < 3,
+            "the entry bound of ten cannot be what stopped it"
+        );
+        assert!(
+            cache.contracts() <= budget,
+            "the cache holds {} contracts, above its budget of {budget}",
+            cache.contracts()
+        );
+        assert!(cache.get(other, 0).is_some(), "the newest stayed");
+    }
+
+    /// A snapshot heavier than the whole budget is still cached rather than
+    /// making the cache permanently cold.
+    #[test]
+    fn test_a_snapshot_larger_than_the_budget_is_still_served() {
+        let parameters = test_parameters();
+        let tape = test_tape(&parameters);
+        let weight = snapshot_contracts(&snapshot(&parameters, &tape, 0));
+
+        let mut cache = SnapshotCache::with_bounds(10, weight / 2);
+        let simulation = Uuid::new_v4();
+
+        cache.insert(simulation, snapshot(&parameters, &tape, 0));
+
+        assert!(
+            cache.get(simulation, 0).is_some(),
+            "refusing to hold anything would make every request a rebuild"
+        );
     }
 
     /// One simulation's entries do not evict another's wholesale, and a

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -47,9 +47,19 @@ pub const DEFAULT_MAX_CACHED_TAPES: usize = 64;
 /// Default number of snapshots held resident.
 ///
 /// A snapshot holds every strike of every live expiration, so the bound is
-/// deliberately small. Issue #62 tracks bounding it by weight rather than by
-/// entry count.
+/// deliberately small. It bounds the *map*, not the memory — see
+/// [`DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS`], which does.
 pub const DEFAULT_MAX_CACHED_SNAPSHOTS: usize = 256;
+
+/// Default number of contracts held resident across every cached snapshot.
+///
+/// The honest unit for a memory bound: one entry is a few hundred contracts in
+/// ADR 0001's reference configuration and up to the per-snapshot cap in a large
+/// one, so an entry count says nothing about how much is resident. Four million
+/// contracts is roughly a gigabyte of `OptionData`, and it lets the reference
+/// configuration keep its entry bound's worth of snapshots without ever
+/// reaching this one.
+pub const DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS: usize = 4_000_000;
 
 /// The longest retention window that can be configured, in seconds — thirty
 /// days.
@@ -64,6 +74,12 @@ const MAX_CLEANUP_INTERVAL_SECS: u64 = 3_600;
 
 /// The largest cache bound that can be configured.
 const MAX_CACHE_CAPACITY: usize = 1_000_000;
+
+/// The largest contract budget that can be configured.
+///
+/// A hundred million `OptionData` is far past any machine this runs on, so a
+/// value above it is a typo rather than an intent.
+const MAX_CACHE_CONTRACTS: usize = 100_000_000;
 
 /// Default cap on the steps one export request may cover.
 ///
@@ -91,6 +107,8 @@ pub struct SimulationV2Config {
     pub max_cached_tapes: usize,
     /// How many snapshots stay resident.
     pub max_cached_snapshots: usize,
+    /// How many contracts stay resident across every cached snapshot.
+    pub max_cached_snapshot_contracts: usize,
     /// How many steps one export request may cover.
     pub max_export_rows: usize,
 }
@@ -102,6 +120,7 @@ impl Default for SimulationV2Config {
             cleanup_interval: Duration::from_secs(DEFAULT_CLEANUP_INTERVAL_SECS),
             max_cached_tapes: DEFAULT_MAX_CACHED_TAPES,
             max_cached_snapshots: DEFAULT_MAX_CACHED_SNAPSHOTS,
+            max_cached_snapshot_contracts: DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
             max_export_rows: DEFAULT_MAX_EXPORT_ROWS,
         }
     }
@@ -141,6 +160,12 @@ impl SimulationV2Config {
                 read("OCS_MAX_CACHED_SNAPSHOTS").as_deref(),
                 DEFAULT_MAX_CACHED_SNAPSHOTS,
             )?,
+            max_cached_snapshot_contracts: parse_bounded(
+                "OCS_MAX_CACHED_SNAPSHOT_CONTRACTS",
+                read("OCS_MAX_CACHED_SNAPSHOT_CONTRACTS").as_deref(),
+                DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
+                MAX_CACHE_CONTRACTS,
+            )?,
             max_export_rows: parse_bounded(
                 "OCS_MAX_EXPORT_ROWS",
                 read("OCS_MAX_EXPORT_ROWS").as_deref(),
@@ -154,6 +179,7 @@ impl SimulationV2Config {
             cleanup_interval_secs = config.cleanup_interval.as_secs(),
             max_cached_tapes = config.max_cached_tapes,
             max_cached_snapshots = config.max_cached_snapshots,
+            max_cached_snapshot_contracts = config.max_cached_snapshot_contracts,
             max_export_rows = config.max_export_rows,
             "Loaded the v2 simulation configuration"
         );

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -22,6 +22,7 @@
 
 use crate::utils::ChainError;
 use std::env;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::info;
 
@@ -51,6 +52,16 @@ pub const DEFAULT_MAX_CACHED_TAPES: usize = 64;
 /// [`DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS`], which does.
 pub const DEFAULT_MAX_CACHED_SNAPSHOTS: usize = 256;
 
+/// Default cap on the contracts one snapshot may price.
+///
+/// A snapshot prices every strike of every live expiration, so its cost is the
+/// product of two caps that each look reasonable alone: a chain size of 500 is
+/// 1 001 strikes, and a schedule may keep 512 expirations alive, for half a
+/// million contracts in one request. The default admits any realistic
+/// configuration — ADR 0001's reference schedule prices about 500 contracts a
+/// snapshot — while refusing the shapes that exist only to exhaust the service.
+pub const DEFAULT_MAX_SNAPSHOT_CONTRACTS: usize = 200_000;
+
 /// Default number of contracts held resident across every cached snapshot.
 ///
 /// The honest unit for a memory bound: one entry is a few hundred contracts in
@@ -74,6 +85,12 @@ const MAX_CLEANUP_INTERVAL_SECS: u64 = 3_600;
 
 /// The largest cache bound that can be configured.
 const MAX_CACHE_CAPACITY: usize = 1_000_000;
+
+/// The largest per-snapshot contract cap that can be configured.
+///
+/// Above the product of the two caps it bounds, so it can never be the binding
+/// constraint by accident — a value this high is a typo.
+const MAX_SNAPSHOT_CONTRACTS_CEILING: usize = 10_000_000;
 
 /// The largest contract budget that can be configured.
 ///
@@ -107,6 +124,8 @@ pub struct SimulationV2Config {
     pub max_cached_tapes: usize,
     /// How many snapshots stay resident.
     pub max_cached_snapshots: usize,
+    /// How many contracts one snapshot may price.
+    pub max_snapshot_contracts: usize,
     /// How many contracts stay resident across every cached snapshot.
     pub max_cached_snapshot_contracts: usize,
     /// How many steps one export request may cover.
@@ -120,6 +139,7 @@ impl Default for SimulationV2Config {
             cleanup_interval: Duration::from_secs(DEFAULT_CLEANUP_INTERVAL_SECS),
             max_cached_tapes: DEFAULT_MAX_CACHED_TAPES,
             max_cached_snapshots: DEFAULT_MAX_CACHED_SNAPSHOTS,
+            max_snapshot_contracts: DEFAULT_MAX_SNAPSHOT_CONTRACTS,
             max_cached_snapshot_contracts: DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
             max_export_rows: DEFAULT_MAX_EXPORT_ROWS,
         }
@@ -160,6 +180,12 @@ impl SimulationV2Config {
                 read("OCS_MAX_CACHED_SNAPSHOTS").as_deref(),
                 DEFAULT_MAX_CACHED_SNAPSHOTS,
             )?,
+            max_snapshot_contracts: parse_bounded(
+                "OCS_MAX_SNAPSHOT_CONTRACTS",
+                read("OCS_MAX_SNAPSHOT_CONTRACTS").as_deref(),
+                DEFAULT_MAX_SNAPSHOT_CONTRACTS,
+                MAX_SNAPSHOT_CONTRACTS_CEILING,
+            )?,
             max_cached_snapshot_contracts: parse_bounded(
                 "OCS_MAX_CACHED_SNAPSHOT_CONTRACTS",
                 read("OCS_MAX_CACHED_SNAPSHOT_CONTRACTS").as_deref(),
@@ -179,10 +205,16 @@ impl SimulationV2Config {
             cleanup_interval_secs = config.cleanup_interval.as_secs(),
             max_cached_tapes = config.max_cached_tapes,
             max_cached_snapshots = config.max_cached_snapshots,
+            max_snapshot_contracts = config.max_snapshot_contracts,
             max_cached_snapshot_contracts = config.max_cached_snapshot_contracts,
             max_export_rows = config.max_export_rows,
             "Loaded the v2 simulation configuration"
         );
+        // Publish the parsed cap for the validator, which has no config handle.
+        // A second call is a no-op: the first configuration a process loads is
+        // the one it runs with.
+        let _ = SNAPSHOT_CONTRACT_CAP.set(config.max_snapshot_contracts);
+
         Ok(config)
     }
 
@@ -282,6 +314,27 @@ fn invalid(variable: &str, raw: &str) -> ChainError {
         field: variable.to_string(),
         reason: format!("must be a whole number, got {raw:?}"),
     }
+}
+
+/// The per-snapshot contract cap the running service applies.
+///
+/// [`SimulationParametersV2::validate`] is a method on a value, not a service
+/// with a config handle, so the parsed cap reaches it through here.
+/// [`SimulationV2Config::from_env`] publishes it once at startup, which keeps
+/// the parsing — and the failure that names the variable — in exactly one
+/// place: a malformed `OCS_MAX_SNAPSHOT_CONTRACTS` fails the boot rather than
+/// quietly deploying a different bound than the operator asked for.
+///
+/// Before startup publishes it, and in tests and library use where no service
+/// exists, the documented default applies.
+static SNAPSHOT_CONTRACT_CAP: OnceLock<usize> = OnceLock::new();
+
+/// The cap to validate against.
+#[must_use]
+pub fn max_snapshot_contracts() -> usize {
+    *SNAPSHOT_CONTRACT_CAP
+        .get()
+        .unwrap_or(&DEFAULT_MAX_SNAPSHOT_CONTRACTS)
 }
 
 #[cfg(test)]

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -12,8 +12,9 @@ pub(crate) use clickhouse::{calculate_required_duration, select_random_date, val
 pub use config::clickhouse::ClickHouseConfig;
 pub use config::redis::RedisConfig;
 pub use config::simulation_v2::{
-    DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOTS, DEFAULT_MAX_CACHED_TAPES,
-    DEFAULT_MAX_EXPORT_ROWS, DEFAULT_RETENTION_SECS, SimulationV2Config,
+    DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
+    DEFAULT_MAX_CACHED_SNAPSHOTS, DEFAULT_MAX_CACHED_TAPES, DEFAULT_MAX_EXPORT_ROWS,
+    DEFAULT_RETENTION_SECS, SimulationV2Config,
 };
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -14,7 +14,8 @@ pub use config::redis::RedisConfig;
 pub use config::simulation_v2::{
     DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
     DEFAULT_MAX_CACHED_SNAPSHOTS, DEFAULT_MAX_CACHED_TAPES, DEFAULT_MAX_EXPORT_ROWS,
-    DEFAULT_RETENTION_SECS, SimulationV2Config,
+    DEFAULT_MAX_SNAPSHOT_CONTRACTS, DEFAULT_RETENTION_SECS, SimulationV2Config,
+    max_snapshot_contracts,
 };
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,8 @@
 //!   degrades one request.
 //! - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
 //!   `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
-//!   `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
+//!   `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS`,
+//!   `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
 //!   process with a message naming the variable. Silently reverting a
 //!   retention window would expire simulations a client is still walking, and
 //!   silently reverting a cache bound would change the service's memory

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -77,7 +77,10 @@ impl SimulationManager {
             uuid_generator: UuidGenerator::new(default_namespace()),
             config,
             tapes: Mutex::new(HashMap::new()),
-            snapshots: Mutex::new(SnapshotCache::with_capacity(config.max_cached_snapshots)),
+            snapshots: Mutex::new(SnapshotCache::with_bounds(
+                config.max_cached_snapshots,
+                config.max_cached_snapshot_contracts,
+            )),
         }
     }
 

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -18,9 +18,7 @@
 //!   simulation: changing any parameter changes the tape, so it creates a new
 //!   simulation instead of mutating one.
 
-use crate::api::rest::limits::{
-    MAX_CHAIN_SIZE, MAX_SNAPSHOT_CONTRACTS, MAX_STEPS, strikes_per_chain,
-};
+use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS, strikes_per_chain};
 use crate::api::rest::models::validate_walk_type;
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::validation::{
@@ -28,6 +26,7 @@ use crate::api::rest::validation::{
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
+use crate::infrastructure::max_snapshot_contracts;
 use crate::session::model::{SessionState, SimulationMethod};
 use crate::utils::{ChainError, UuidGenerator};
 use chrono::{DateTime, NaiveTime, TimeDelta, Timelike, Utc};
@@ -444,7 +443,11 @@ impl SimulationParametersV2 {
     /// Returns [`ChainError::Validation`] naming `chain_size`, which is the
     /// field a client can lower without changing what the simulation means.
     fn validate_snapshot_work(&self) -> Result<(), ChainError> {
-        let strikes = strikes_per_chain(self.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE));
+        let requested = self.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE);
+        let strikes = strikes_per_chain(requested).ok_or_else(|| ChainError::Validation {
+            field: "chain_size".to_string(),
+            reason: format!("a chain of {requested} does not have a representable strike count"),
+        })?;
         let expirations = self
             .schedule
             .rules()
@@ -467,14 +470,14 @@ impl SimulationParametersV2 {
                 ),
             })?;
 
-        if contracts > *MAX_SNAPSHOT_CONTRACTS {
+        let cap = max_snapshot_contracts();
+        if contracts > cap {
             return Err(ChainError::Validation {
                 field: "chain_size".to_string(),
                 reason: format!(
                     "every snapshot would price {contracts} contracts ({strikes} strikes \
-                     across up to {expirations} expirations), above the {} maximum; lower \
-                     chain_size or the schedules' target_count",
-                    *MAX_SNAPSHOT_CONTRACTS
+                     across up to {expirations} expirations), above the {cap} maximum; lower \
+                     chain_size or the schedules' target_count"
                 ),
             });
         }

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -18,13 +18,16 @@
 //!   simulation: changing any parameter changes the tape, so it creates a new
 //!   simulation instead of mutating one.
 
-use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
+use crate::api::rest::limits::{
+    MAX_CHAIN_SIZE, MAX_SNAPSHOT_CONTRACTS, MAX_STEPS, strikes_per_chain,
+};
 use crate::api::rest::models::validate_walk_type;
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::validation::{
     decimal_field, positive_field, strictly_positive_field, symbol_field, time_frame_field,
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
+use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
 use crate::session::model::{SessionState, SimulationMethod};
 use crate::utils::{ChainError, UuidGenerator};
 use chrono::{DateTime, NaiveTime, TimeDelta, Timelike, Utc};
@@ -387,6 +390,7 @@ impl SimulationParametersV2 {
             });
         }
         self.schedule.validate()?;
+        self.validate_snapshot_work()?;
 
         // A simulation has exactly one base volatility. v1 accepts a top-level
         // value and a walk model carrying a different one, and silently prices
@@ -414,6 +418,65 @@ impl SimulationParametersV2 {
                 running = %running,
                 "simulation was resolved against a different IANA tzdb release"
             );
+        }
+
+        Ok(())
+    }
+
+    /// Rejects a configuration whose every snapshot would price more contracts
+    /// than the service is willing to build.
+    ///
+    /// The two caps that bound this individually — the chain size and the
+    /// per-snapshot expiration count — are each reasonable, and their product
+    /// is not: 1 001 strikes across 512 live expirations is half a million
+    /// Black-Scholes evaluations for one `/snapshot` call, from a request that
+    /// violates neither. The bound is on the product, checked once at creation
+    /// rather than per step, and it is deliberately generous: the reference
+    /// configuration in ADR 0001 prices about 500 contracts a snapshot.
+    ///
+    /// `Σ target_count` is the tight upper bound on live expirations — rules
+    /// that claim the same date are priced once, so the real count is at most
+    /// this — which means a configuration this accepts can never exceed the
+    /// cap, and one it rejects genuinely asked for more.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming `chain_size`, which is the
+    /// field a client can lower without changing what the simulation means.
+    fn validate_snapshot_work(&self) -> Result<(), ChainError> {
+        let strikes = strikes_per_chain(self.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE));
+        let expirations = self
+            .schedule
+            .rules()
+            .iter()
+            .try_fold(0usize, |total, rule| {
+                total.checked_add(rule.target_count().get())
+            })
+            .ok_or_else(|| ChainError::Validation {
+                field: "schedules".to_string(),
+                reason: "the requested expiration counts overflow".to_string(),
+            })?;
+
+        let contracts = strikes
+            .checked_mul(expirations)
+            .ok_or_else(|| ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!(
+                    "{strikes} strikes across {expirations} expirations overflows the \
+                     contract count"
+                ),
+            })?;
+
+        if contracts > *MAX_SNAPSHOT_CONTRACTS {
+            return Err(ChainError::Validation {
+                field: "chain_size".to_string(),
+                reason: format!(
+                    "every snapshot would price {contracts} contracts ({strikes} strikes \
+                     across up to {expirations} expirations), above the {} maximum; lower \
+                     chain_size or the schedules' target_count",
+                    *MAX_SNAPSHOT_CONTRACTS
+                ),
+            });
         }
 
         Ok(())
@@ -811,11 +874,24 @@ impl fmt::Display for SessionV2 {
 mod tests {
     use super::*;
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
-    use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind};
+    use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind, MAX_TARGET_COUNT};
     use chrono::{TimeZone, Weekday};
     use positive::pos_or_panic;
 
     /// The reference configuration from ADR 0001 §14.1, as a request.
+    /// Two rules at the per-rule cap: the most expirations a schedule can keep
+    /// alive, and still under the per-snapshot inventory cap.
+    fn maximal_schedules() -> Vec<ExpiryRule> {
+        vec![
+            rule("zero_dte", ExpiryRuleKind::Daily, MAX_TARGET_COUNT),
+            rule(
+                "weeklies",
+                ExpiryRuleKind::weekly([Weekday::Mon, Weekday::Wed, Weekday::Fri]),
+                MAX_TARGET_COUNT,
+            ),
+        ]
+    }
+
     fn reference_request() -> CreateSimulationRequest {
         CreateSimulationRequest {
             symbol: "SPX".to_string(),
@@ -1377,6 +1453,43 @@ mod tests {
                 error.contains(field),
                 "the error must name {field}, got {error}"
             );
+        }
+    }
+
+    /// A configuration whose snapshots would price more contracts than the cap
+    /// is refused at creation, naming the field a client can lower.
+    #[test]
+    fn test_a_configuration_above_the_snapshot_contract_cap_is_rejected() {
+        let mut request = reference_request();
+        // 500 is the chain-size cap: 1 001 strikes. Two rules at the per-rule
+        // cap keep 512 expirations alive, which is the per-snapshot inventory
+        // cap. Their product is half a million contracts, and neither field
+        // alone is out of range.
+        request.chain_size = Some(500);
+        request.schedules = maximal_schedules();
+
+        match SimulationParametersV2::try_from(request) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "chain_size");
+                assert!(
+                    reason.contains("would price"),
+                    "the reason must say what it refused, got {reason}"
+                );
+            }
+            other => panic!("the product of the two caps must be refused, got {other:?}"),
+        }
+    }
+
+    /// The reference configuration is nowhere near the cap, so the bound costs
+    /// a realistic client nothing.
+    #[test]
+    fn test_the_reference_configuration_is_far_below_the_contract_cap() {
+        match SimulationParametersV2::try_from(reference_request()) {
+            Ok(parameters) => match parameters.validate() {
+                Ok(()) => {}
+                Err(error) => panic!("the reference configuration must validate: {error}"),
+            },
+            Err(error) => panic!("the reference request must convert: {error}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Each cap held individually; their product did not. `OCS_MAX_CHAIN_SIZE` of 500 is 1 001 strikes, a schedule may keep 512 expirations alive, and one `/snapshot` call could therefore price half a million contracts — about a million Black-Scholes evaluations and hundreds of MB — from a request that violated neither bound. Separately, the snapshot cache counted entries, which says nothing about memory when one entry is a few hundred contracts in the reference configuration and hundreds of thousands in a large one.

## Changes

**Per-snapshot work.** `SimulationParametersV2::validate` now bounds `strikes × Σ target_count` against `OCS_MAX_SNAPSHOT_CONTRACTS` (default 200 000).

- Checked once at creation, not per step.
- Uses the **pre-deduplication** sum, the same tight upper bound §9.3 already uses for the expiration cap — rules claiming the same date are priced once, so a configuration this accepts can never exceed the cap.
- Reported against `chain_size`, the field a client can lower without changing what the simulation means.
- `strikes_per_chain` is `2n + 1`, because upstream's `chain_size` is a per-side half-width.

**Cache weight.** `SnapshotCache` gains a contract budget beside its entry bound (`OCS_MAX_CACHED_SNAPSHOT_CONTRACTS`, default 4 000 000 ≈ a gigabyte of `OptionData`), evicting on whichever binds first and sharing one victim rule. A snapshot heavier than the whole budget is still cached — refusing to hold anything would turn a large-but-legal configuration into a permanently cold cache, and the per-snapshot cap is what bounds that case.

**Where the knobs live.** `OCS_MAX_SNAPSHOT_CONTRACTS` follows the `limits.rs` `LazyLock` pattern, next to the two caps it multiplies with and reachable from `validate` without threading config through the session layer. `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS` follows the startup-validated v2 config from #48, next to the entry bound it complements. Both are documented in `.env.example`, ADR 0001 §9.3 and the crate docs.

## Testing

- [x] A configuration at both caps (500 chain size, two rules at the per-rule cap) is refused, naming `chain_size`
- [x] The reference configuration validates comfortably, so the bound costs a realistic client nothing
- [x] Eviction fires on the contract budget while the entry bound of ten is nowhere near, and the cache never exceeds its budget
- [x] A snapshot larger than the whole budget is still served
- [x] `make pre-push` — 613 unit tests plus 16 v1-contract tests, clippy and fmt clean; `cargo build --release` clean

## Stack

- **Stack:** #63 → #62 → #56 — **this is PR 2**
- **Base branch:** `stack/1-63-historical-volatility-parity` (PR #67)
- **Stacked on:** #67 · **Blocks:** the ClickHouse PR
- The diff is cumulative until #67 merges — review it against the base branch, not `main`.

Closes #62