### PR TITLE
Persist v2 simulation snapshots in ClickHouse (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,10 +133,14 @@ OCS_MAX_EXPORT_ROWS=100000
 # Values: true/false/1/0/yes/no/on/off.  Default: false
 OCS_SNAPSHOT_PERSISTENCE_ENABLED=false
 
-# Rows per insert batch. Every quote row of one snapshot goes in ONE insert, so
-# this bounds a single statement, not the snapshot.
-# Range: 1 .. 5000000.  Default: 100000
-OCS_SNAPSHOT_BATCH_ROWS=100000
+# Maximum quote rows one snapshot may carry into storage. Every quote row of a
+# snapshot goes in ONE insert, so this bounds the snapshot and the statement
+# alike: a snapshot above it is rejected before a row is written. It must be at
+# least OCS_MAX_SNAPSHOT_CONTRACTS, or the API would accept simulations the
+# warehouse could never persist — startup refuses that combination rather than
+# leaving it to be found in the logs.
+# Range: 1 .. 5000000.  Default: 200000 (matches OCS_MAX_SNAPSHOT_CONTRACTS)
+OCS_SNAPSHOT_BATCH_ROWS=200000
 
 # Maximum rows one read may return, so a range query cannot be unbounded.
 # Range: 1 .. 10000000.  Default: 1000000

--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,40 @@ OCS_MAX_CACHED_SNAPSHOT_CONTRACTS=4000000
 # Range: 1 .. 10000000.  Default: 100000
 OCS_MAX_EXPORT_ROWS=100000
 
+# ---------------------------------------------------------------------------
+# v2 snapshot persistence (ClickHouse)
+# ---------------------------------------------------------------------------
+# Files every ADVANCED v2 step in ClickHouse as an immutable, queryable tape:
+# one metadata row per step plus one flattened row per expiration and strike.
+# A peek and an export replay and persist nothing.
+# OFF by default — a deployment without ClickHouse does not have to name the
+# feature to not use it, and with it off nothing is added to the serving path.
+# Turning it ON makes ClickHouse a HARD STARTUP DEPENDENCY: the tables are
+# created at boot, so a schema or connectivity problem fails the boot rather
+# than surfacing later as a warning. Writes themselves are detached from the
+# request, so a warehouse that degrades later cannot delay a response.
+# Values: true/false/1/0/yes/no/on/off.  Default: false
+OCS_SNAPSHOT_PERSISTENCE_ENABLED=false
+
+# Rows per insert batch. Every quote row of one snapshot goes in ONE insert, so
+# this bounds a single statement, not the snapshot.
+# Range: 1 .. 5000000.  Default: 100000
+OCS_SNAPSHOT_BATCH_ROWS=100000
+
+# Maximum rows one read may return, so a range query cannot be unbounded.
+# Range: 1 .. 10000000.  Default: 1000000
+OCS_SNAPSHOT_MAX_READ_ROWS=1000000
+
+# How long an insert may take before it is an error the advance tolerates.
+# Range: 1 .. 600.  Default: 30
+OCS_SNAPSHOT_INSERT_TIMEOUT_SECS=30
+
+# How long persisted snapshots are kept, as a row-level TTL. Anchored on the
+# ingestion timestamp, so a backfilled step is kept for its full window.
+# Changing this on a live deployment needs an explicit ALTER TABLE MODIFY TTL.
+# Range: 1 .. 3650.  Default: 90
+OCS_SNAPSHOT_RETENTION_DAYS=90
+
 
 # ---------------------------------------------------------------------------
 # Redis — session and simulation storage

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ uses a rolling causal estimate for the same series, so the two produce the
 same price path and different premiums. It is a stated difference, tracked
 in issue #63 and asked for upstream in optionstratlib#423.
 
+**Advanced steps can be filed in ClickHouse.** With
+`OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is
+written as one metadata row plus one flattened row per expiration and
+strike, so a client can query one contract across time instead of unwinding
+whole documents. A peek and an export replay and persist nothing — only the
+advance, which is the call that moves the cursor, files anything.
+
+Filing happens **after** the cursor commits and off the request's clock, so
+a degraded warehouse can neither fail a response nor delay one. Row identity
+is derived from `(simulation, tape generation, step)`, which makes a retry
+replace a row rather than duplicate it, and a reader never sees a snapshot
+whose quote rows are missing — the metadata row carries the expected count
+and a mismatch reads as absent. Turning the knob on makes ClickHouse a hard
+startup dependency: the tables are created at boot, so a schema or
+connectivity problem fails the boot rather than surfacing later. MongoDB
+stays event and audit only.
+
 **Replay.** The creation response echoes the effective seed, effective
 start, step interval, time frame, timezone, calendar version, IANA tzdb
 release and normalised schedules — everything needed to reproduce the run
@@ -171,8 +188,8 @@ deliberately different failure behaviour:
 - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
   `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
   `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS`,
-  `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
-  process with a message naming the variable. Silently reverting a
+  `OCS_MAX_EXPORT_ROWS`, `OCS_SNAPSHOT_*` — are **validated at startup** and
+  fail the process with a message naming the variable. Silently reverting a
   retention window would expire simulations a client is still walking, and
   silently reverting a cache bound would change the service's memory
   profile with nothing to show for it.

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -781,6 +781,42 @@ v1 JSON is never reinterpreted as rolling configuration, and a v1 session
 written by an older binary keeps loading unchanged. Breaking either stored shape
 remains a semver event.
 
+### 12.2b Persisted snapshots (amends the warehouse decision)
+
+Served snapshots may additionally be **filed in ClickHouse**, opt-in via
+`OCS_SNAPSHOT_PERSISTENCE_ENABLED`. This amends what §10 assumed — that
+deterministic replay is the only way to obtain a past step — without weakening
+it: replay stays canonical, and the warehouse is a materialisation of what
+replay would produce.
+
+Two tables, because the two query patterns are different shapes. One metadata
+row per step in `simulation_snapshots`, and one flattened row per
+`(step, expiration, strike)` in `simulation_option_quotes` — which is what makes
+"this contract's premium across time" a range scan rather than an unwind of
+nested documents. Both are `ReplacingMergeTree`, ordered by the coordinate that
+identifies a row, and partitioned by `toYYYYMM(simulated_at)`: a **content**
+key, not an ingestion one, because the engine only deduplicates within a
+partition and a backfilled step written a month later would otherwise survive as
+a permanent duplicate. Retention is a row-level TTL anchored on the ingestion
+timestamp, so a backfill keeps its full window.
+
+Four properties make it safe to read:
+
+- **Identity is derived, not generated.** A row's id is a v5 UUID over
+  `(simulation, tape generation, step)`, so retrying a step replaces its rows
+  instead of adding a second copy. The generation is the *tape's*, not the
+  session's compare-and-swap revision — that changes on every advance, and
+  filing under it would scatter one simulation across as many generations as it
+  has steps.
+- **A partial write never reads as complete.** Quote rows go first, in one
+  insert; the metadata row carrying the expected count goes last. Every read
+  compares what it got against that count and treats a mismatch as absent.
+- **Filing cannot fail an advance.** It happens after the cursor commits, and a
+  failure is logged with the step rather than returned: the client already holds
+  its snapshot, and the missing row is exactly what replay can rewrite.
+- **Nothing about v1 moves.** MongoDB stays event and audit only; no v2 chain is
+  written as a nested document.
+
 ### 12.3 OpenAPI
 
 `actix_extras` remains unavailable — optionstratlib enables

--- a/src/api/rest/controller.rs
+++ b/src/api/rest/controller.rs
@@ -14,6 +14,9 @@ use crate::infrastructure::{MetricsCollector, MetricsMiddleware, MongoDBReposito
 ///
 /// * `session_manager` - A shared reference to the `SessionManager`, used to manage user sessions.
 /// * `metrics_collector` - A shared reference to the `MetricsCollector`, used for collecting server metrics.
+/// * `snapshots` - The v2 snapshot warehouse, when snapshot persistence is enabled. It is the same
+///   repository the manager files snapshots into, shared so the v2 export can read them back and
+///   prefer a persisted step over replaying it. `None` leaves the export replaying every step.
 /// * `listen_on` - The address or hostname where the server will listen, typically an IP address or hostname.
 /// * `port` - The port number on which the server will accept requests.
 ///

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -26,6 +26,21 @@
 //! receiver so the producer's next send fails and the task ends. Cancellation
 //! costs one row of wasted work.
 //!
+//! # Where the chains come from
+//!
+//! When snapshot persistence is on, an `option_chains` export prefers the
+//! **persisted** snapshot of a step and replays only the steps the warehouse
+//! does not have. The decision is per step, never per export: a warehouse that
+//! is missing a step, or missing entirely, or down, costs the export nothing
+//! but the pricing it would have done anyway. That is the whole point of a
+//! deterministic replay — a gap in the tape is not an incident, so the fallback
+//! logs at `DEBUG`.
+//!
+//! Both sources go through one adapter ([`StepChains`]) that yields the same
+//! per-quote view, so a row is byte-identical whichever side produced it. The
+//! factor row still comes from the tape either way: the underlying and
+//! volatility datasets are built from it, and it is cheap next to a chain.
+//!
 //! # Determinism
 //!
 //! Two exports of the same simulation are byte-identical. Every value is a
@@ -37,17 +52,24 @@
 use crate::api::rest::error::map_error;
 use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot};
+use crate::infrastructure::{
+    CURRENT_SNAPSHOT_GENERATION, QuoteRow, SimulationSnapshotRepository, SnapshotRecord,
+};
 use crate::session::{SimulationManager, SimulationParametersV2};
 use crate::utils::ChainError;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use chrono::{DateTime, SecondsFormat, Utc};
 use futures::stream::Stream;
+use optionstratlib::chains::OptionData;
+use optionstratlib::chains::chain::OptionChain;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -57,6 +79,21 @@ use uuid::Uuid;
 /// producer blocks on the next send, and no unbounded queue of priced chains
 /// accumulates in memory.
 const CHANNEL_CAPACITY: usize = 16;
+
+/// How many steps one warehouse round trip asks for.
+///
+/// Neither extreme is acceptable. One read per step turns a hundred-thousand
+/// step export into a hundred thousand round trips; one read of the whole range
+/// materialises the entire tape in memory, which is exactly what the streaming
+/// producer exists to avoid — a snapshot can hold two hundred thousand
+/// contracts.
+///
+/// Sixty-four amortises the round trip over a window whose memory cost is
+/// bounded by sixty-four snapshots, and it is the *starting* width: a window
+/// that a deployment's `OCS_SNAPSHOT_MAX_READ_ROWS` refuses is halved and
+/// retried, so a service with very large chains narrows to a width that works
+/// instead of silently replaying everything.
+const SNAPSHOT_WINDOW_STEPS: usize = 64;
 
 /// Which dataset an export request asks for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -252,6 +289,304 @@ fn render_optional(value: Option<f64>) -> String {
     value.map(|value| value.to_string()).unwrap_or_default()
 }
 
+/// One strike of one expiration, flattened to exactly what a row carries.
+///
+/// The common view both sources are reduced to. Every conversion from a source
+/// value to the wire's `f64` happens here and only here, which is what makes a
+/// persisted row and a replayed row byte-identical rather than merely similar.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct QuoteView {
+    strike: f64,
+    implied_volatility: f64,
+    call_bid: Option<f64>,
+    call_ask: Option<f64>,
+    call_mid: Option<f64>,
+    call_delta: Option<f64>,
+    put_bid: Option<f64>,
+    put_ask: Option<f64>,
+    put_mid: Option<f64>,
+    put_delta: Option<f64>,
+    gamma: Option<f64>,
+}
+
+impl QuoteView {
+    /// Views a strike that was just priced.
+    #[must_use]
+    fn replayed(data: &OptionData) -> Self {
+        Self {
+            strike: data.strike_price.to_f64(),
+            implied_volatility: data.implied_volatility.to_f64(),
+            call_bid: data.call_bid.map(|value| value.to_f64()),
+            call_ask: data.call_ask.map(|value| value.to_f64()),
+            call_mid: data.call_middle.map(|value| value.to_f64()),
+            call_delta: data.delta_call.and_then(decimal_to_f64),
+            put_bid: data.put_bid.map(|value| value.to_f64()),
+            put_ask: data.put_ask.map(|value| value.to_f64()),
+            put_mid: data.put_middle.map(|value| value.to_f64()),
+            put_delta: data.delta_put.and_then(decimal_to_f64),
+            gamma: data.gamma.and_then(decimal_to_f64),
+        }
+    }
+
+    /// Views a strike that was read back from the warehouse.
+    #[must_use]
+    fn stored(row: &QuoteRow) -> Self {
+        Self {
+            strike: row.strike.to_f64(),
+            implied_volatility: row.implied_volatility.to_f64(),
+            call_bid: row.call_bid.map(|value| value.to_f64()),
+            call_ask: row.call_ask.map(|value| value.to_f64()),
+            call_mid: row.call_mid.map(|value| value.to_f64()),
+            call_delta: row.delta_call.and_then(decimal_to_f64),
+            put_bid: row.put_bid.map(|value| value.to_f64()),
+            put_ask: row.put_ask.map(|value| value.to_f64()),
+            put_mid: row.put_mid.map(|value| value.to_f64()),
+            put_delta: row.delta_put.and_then(decimal_to_f64),
+            gamma: row.gamma.and_then(decimal_to_f64),
+        }
+    }
+}
+
+/// The strikes of one expiration, from whichever source produced them.
+#[derive(Debug, Clone, Copy)]
+enum QuoteSource<'a> {
+    /// Upstream's priced chain, iterated by ascending strike.
+    Replayed(&'a OptionChain),
+    /// The stored rows, which the repository returns by ascending strike.
+    Stored(&'a [QuoteRow]),
+}
+
+impl<'a> QuoteSource<'a> {
+    /// The strikes, ascending.
+    ///
+    /// Exactly one of the two options is `Some`, so concatenating them with
+    /// [`Iterator::chain`] *is* the branch — one concrete iterator type, no
+    /// boxing on a path that runs once per contract.
+    fn quotes(self) -> impl Iterator<Item = QuoteView> + 'a {
+        let replayed = match self {
+            QuoteSource::Replayed(chain) => Some(chain.iter()),
+            QuoteSource::Stored(_) => None,
+        };
+        let stored = match self {
+            QuoteSource::Replayed(_) => None,
+            QuoteSource::Stored(quotes) => Some(quotes.iter()),
+        };
+
+        replayed
+            .into_iter()
+            .flatten()
+            .map(QuoteView::replayed)
+            .chain(stored.into_iter().flatten().map(QuoteView::stored))
+    }
+}
+
+/// One expiration of one step, from whichever source produced it.
+#[derive(Debug, Clone, Copy)]
+struct ExpirationView<'a> {
+    expires_at: DateTime<Utc>,
+    days_to_expiration: f64,
+    labels: &'a [String],
+    quotes: QuoteSource<'a>,
+}
+
+/// The chains of one step, from whichever source produced them.
+///
+/// The adapter the whole preference rests on: a stored snapshot and a replayed
+/// one are the same simulated market, so they must render the same rows. Giving
+/// the two sources one view — instead of two row builders that happen to agree
+/// today — is what makes preferring the warehouse safe.
+#[derive(Debug, Clone, Copy)]
+enum StepChains<'a> {
+    /// Priced here and now, from the effective parameters.
+    Replayed(&'a SeriesSnapshot),
+    /// Read back from the warehouse exactly as it was served.
+    Stored(&'a SnapshotRecord),
+}
+
+impl<'a> StepChains<'a> {
+    /// The live expirations, ascending — the order both sources guarantee.
+    fn expirations(self) -> impl Iterator<Item = ExpirationView<'a>> {
+        let replayed = match self {
+            StepChains::Replayed(snapshot) => Some(snapshot.chains.iter()),
+            StepChains::Stored(_) => None,
+        };
+        let stored = match self {
+            StepChains::Replayed(_) => None,
+            StepChains::Stored(record) => Some(record.expirations.iter()),
+        };
+
+        replayed
+            .into_iter()
+            .flatten()
+            .map(|chain| ExpirationView {
+                expires_at: chain.expires_at,
+                days_to_expiration: chain.days_to_expiration.to_f64(),
+                labels: &chain.labels,
+                quotes: QuoteSource::Replayed(&chain.chain),
+            })
+            .chain(
+                stored
+                    .into_iter()
+                    .flatten()
+                    .map(|expiration| ExpirationView {
+                        expires_at: expiration.expires_at,
+                        days_to_expiration: expiration.days_to_expiration.to_f64(),
+                        labels: &expiration.labels,
+                        quotes: QuoteSource::Stored(&expiration.quotes),
+                    }),
+            )
+    }
+}
+
+/// The last step a window starting at `from` covers.
+///
+/// Clamped to `last` so a window never asks for steps past the range, and
+/// checked so a `from` near `usize::MAX` cannot wrap into a reversed range.
+#[must_use]
+#[inline]
+fn window_end(from: usize, window: usize, last: usize) -> usize {
+    match window
+        .checked_sub(1)
+        .and_then(|span| from.checked_add(span))
+    {
+        Some(end) => end.min(last),
+        None => last,
+    }
+}
+
+/// Reads persisted snapshots ahead of the producer, a window of steps at a time.
+///
+/// Lives on the blocking thread that produces the rows, so its reads have to
+/// cross back onto the runtime — hence the [`Handle`]. Blocking on a future from
+/// a `spawn_blocking` thread is sound (it is not an async context); doing it
+/// from an Actix worker would not be, which is exactly why the whole producer
+/// runs off the runtime.
+struct StoredSteps {
+    repository: Arc<dyn SimulationSnapshotRepository>,
+    runtime: Handle,
+    simulation: Uuid,
+    /// What the current window found, ascending by step and consumed in order.
+    loaded: VecDeque<SnapshotRecord>,
+    /// The last step the current window covered; `None` before the first read.
+    window_end: Option<usize>,
+    /// How many steps a window asks for. Narrows on a refused read.
+    window: usize,
+    /// Set once a read fails for a reason a narrower window cannot fix.
+    ///
+    /// After that the export replays everything. A warehouse that is down will
+    /// be down for the next window too, and a failed round trip per window
+    /// would add latency to an export that is already producing correct rows
+    /// without it.
+    degraded: bool,
+}
+
+impl StoredSteps {
+    /// Prepares to read one simulation's persisted tape.
+    #[must_use]
+    fn new(
+        repository: Arc<dyn SimulationSnapshotRepository>,
+        simulation: Uuid,
+        runtime: Handle,
+    ) -> Self {
+        Self {
+            repository,
+            runtime,
+            simulation,
+            loaded: VecDeque::new(),
+            window_end: None,
+            window: SNAPSHOT_WINDOW_STEPS,
+            degraded: false,
+        }
+    }
+
+    /// The persisted snapshot of `step`, when the warehouse has a complete one.
+    ///
+    /// `last` bounds the prefetch, so a window never reads past the export's
+    /// range. Steps are requested in ascending order, which is what lets the
+    /// window be consumed from the front instead of indexed.
+    fn take(&mut self, step: usize, last: usize) -> Option<SnapshotRecord> {
+        if self.degraded {
+            return None;
+        }
+        if self.window_end.is_none_or(|end| step > end) {
+            self.load(step, last);
+        }
+
+        // Anything below `step` belongs to a step already produced: the
+        // repository skips what was never completed, so a gap is normal.
+        while self.loaded.front().is_some_and(|record| record.step < step) {
+            self.loaded.pop_front();
+        }
+        match self.loaded.front() {
+            Some(record) if record.step == step => self.loaded.pop_front(),
+            _ => None,
+        }
+    }
+
+    /// Fills the window that starts at `from`.
+    ///
+    /// A window refused as too wide is halved and retried: that failure is a
+    /// property of this deployment's snapshot size against
+    /// `OCS_SNAPSHOT_MAX_READ_ROWS`, so a narrower window keeps working for the
+    /// rest of the export. Every other failure degrades to replay. The loop
+    /// terminates because the width strictly decreases and stops at one.
+    fn load(&mut self, from: usize, last: usize) {
+        self.loaded.clear();
+        loop {
+            let to = window_end(from, self.window, last);
+            match self.read(from, to) {
+                Ok(records) => {
+                    debug!(
+                        simulation_id = %self.simulation,
+                        from_step = from,
+                        to_step = to,
+                        found = records.len(),
+                        "Prefetched persisted snapshots for an export window"
+                    );
+                    self.loaded = VecDeque::from(records);
+                    self.window_end = Some(to);
+                    return;
+                }
+                Err(ChainError::Validation { field, reason }) if self.window > 1 => {
+                    // Integer division by a non-zero constant, bottoming out at
+                    // one: no saturation, no zero-width window.
+                    self.window /= 2;
+                    debug!(
+                        simulation_id = %self.simulation,
+                        window = self.window,
+                        field = %field,
+                        reason = %reason,
+                        "Narrowed the snapshot read window and retried"
+                    );
+                }
+                Err(error) => {
+                    // DEBUG, not WARN: a cold or absent warehouse is the default
+                    // configuration, and replay produces the same rows.
+                    debug!(
+                        simulation_id = %self.simulation,
+                        from_step = from,
+                        error = %error,
+                        "Could not read persisted snapshots; the export replays instead"
+                    );
+                    self.degraded = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Runs one range read on the runtime and waits for it.
+    fn read(&self, from: usize, to: usize) -> Result<Vec<SnapshotRecord>, ChainError> {
+        let repository = Arc::clone(&self.repository);
+        let simulation = self.simulation;
+        self.runtime.block_on(async move {
+            repository
+                .read_range(simulation, CURRENT_SNAPSHOT_GENERATION, from, to)
+                .await
+        })
+    }
+}
+
 /// Streams rows from a bounded channel as an HTTP body.
 ///
 /// Dropping this — which is what actix does when the client disconnects —
@@ -287,9 +622,11 @@ impl Stream for RowStream {
     description = "Export a simulation's complete tape, or a step range of it, as JSON or CSV. \
         Read-only: it replays from an immutable snapshot of the effective parameters and never \
         advances the cursor, changes the state or version, or alters what the next peek returns. \
-        A simulation that has not been walked at all exports its whole tape. JSON is a single \
-        array of row objects; CSV is RFC 4180 with a header row and CRLF line endings. Repeating \
-        the same export yields byte-identical output.",
+        A simulation that has not been walked at all exports its whole tape. Where snapshot \
+        persistence is enabled, an option_chains export serves the steps the warehouse holds from \
+        it and replays the rest; the rows are identical either way. JSON is a single array of row \
+        objects; CSV is RFC 4180 with a header row and CRLF line endings. Repeating the same \
+        export yields byte-identical output.",
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
         ("dataset" = String, Query, description = "underlying | volatility | option_chains"),
@@ -304,10 +641,14 @@ impl Stream for RowStream {
         (status = 500, description = "Internal server error")
     )
 )]
-#[instrument(skip(manager, query), level = "debug")]
+#[instrument(skip(manager, snapshots, query), level = "debug")]
 pub(crate) async fn export_simulation(
     req: HttpRequest,
     manager: web::Data<Arc<SimulationManager>>,
+    // Absent unless the operator turned snapshot persistence on, which is why
+    // this is an `Option` rather than a required dependency: a deployment
+    // without ClickHouse must not have to register anything to not use it.
+    snapshots: Option<web::Data<Arc<dyn SimulationSnapshotRepository>>>,
     path: web::Path<super::handlers_v2::SimulationPath>,
     query: web::Query<ExportQuery>,
 ) -> impl Responder {
@@ -342,10 +683,19 @@ pub(crate) async fn export_simulation(
     let format = query.format;
     let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
 
+    // Only the chains dataset can be served from storage; the other two read the
+    // factor tape and would pay a round trip for nothing. The handle is taken
+    // here, on the runtime, because the producer that uses it will not be on one.
+    let stored = snapshots
+        .filter(|_| dataset.needs_chains())
+        .map(|repository| {
+            StoredSteps::new(Arc::clone(repository.get_ref()), id, Handle::current())
+        });
+
     // Priced chains are minutes of CPU for a long horizon. Producing them on an
     // Actix worker would block every other request on that thread.
     tokio::task::spawn_blocking(move || {
-        if let Err(error) = produce(&parameters, dataset, format, range, &sender) {
+        if let Err(error) = produce(&parameters, dataset, format, range, stored, &sender) {
             // A send failure means the client went away, which is not an error
             // worth reporting to anyone.
             let _ = sender.blocking_send(Err(error));
@@ -369,15 +719,20 @@ pub(crate) async fn export_simulation(
         .streaming(RowStream { receiver })
 }
 
-/// Replays the range and sends every chunk.
+/// Produces the range and sends every chunk.
 ///
 /// Runs on a blocking thread. Returns as soon as a send fails, which is how a
 /// disconnected client stops the work.
+///
+/// Each step takes its chains from the warehouse when `stored` has them and
+/// replays them otherwise, so a partially persisted tape costs exactly the
+/// pricing of its gaps.
 fn produce(
     parameters: &SimulationParametersV2,
     dataset: Dataset,
     format: Format,
     range: StepRange,
+    mut stored: Option<StoredSteps>,
     sender: &mpsc::Sender<Result<Vec<u8>, ChainError>>,
 ) -> Result<(), ChainError> {
     let tape = FactorTape::build(parameters, &parameters.method)?;
@@ -394,16 +749,34 @@ fn produce(
         return Ok(());
     }
 
+    let mut served_from_storage: usize = 0;
     for step in range.steps() {
         let row = tape
             .row(step)
             .ok_or_else(|| ChainError::Internal(format!("the tape has no row at step {step}")))?;
-        let snapshot = match &builder {
-            Some(builder) => Some(builder.snapshot(step)?),
+
+        // A persisted step is the same snapshot, already priced: prefer it, and
+        // price only what the warehouse does not have.
+        let record = match &mut stored {
+            Some(stored) => stored.take(step, range.to),
             None => None,
         };
+        let replayed = match (&record, &builder) {
+            (None, Some(builder)) => Some(builder.snapshot(step)?),
+            _ => None,
+        };
+        let chains = match (&record, &replayed) {
+            (Some(record), _) => Some(StepChains::Stored(record)),
+            (None, Some(snapshot)) => Some(StepChains::Replayed(snapshot)),
+            (None, None) => None,
+        };
+        if record.is_some() {
+            served_from_storage = served_from_storage
+                .checked_add(1)
+                .ok_or_else(|| ChainError::Internal("the step counter overflowed".to_string()))?;
+        }
 
-        let chunk = writer.rows(parameters, row.step, row, snapshot.as_ref())?;
+        let chunk = writer.rows(parameters, row.step, row, chains)?;
         if !chunk.is_empty() && sender.blocking_send(Ok(chunk)).is_err() {
             return Ok(());
         }
@@ -413,6 +786,15 @@ fn produce(
         && sender.blocking_send(Ok(chunk)).is_err()
     {
         return Ok(());
+    }
+
+    if stored.is_some() {
+        debug!(
+            from_step = range.from,
+            to_step = range.to,
+            served_from_storage,
+            "Finished a v2 export"
+        );
     }
     Ok(())
 }
@@ -460,19 +842,24 @@ impl Writer {
     }
 
     /// Encodes every row one step contributes.
+    ///
+    /// `simulated_at` comes from the factor row whichever source produced the
+    /// chains: it is the tape's instant, the same one a stored record was
+    /// written from, and taking it from one place keeps the two sources
+    /// rendering identically by construction.
     fn rows(
         &mut self,
         parameters: &SimulationParametersV2,
         step: usize,
         row: &crate::domain::factors::FactorRow,
-        snapshot: Option<&SeriesSnapshot>,
+        chains: Option<StepChains<'_>>,
     ) -> Result<Vec<u8>, ChainError> {
         let simulated_at = render_instant(row.simulated_at);
         let symbol = parameters.symbol.as_str();
 
         match self {
             Writer::Json { dataset, first } => {
-                let values = json_rows(*dataset, step, &simulated_at, symbol, row, snapshot);
+                let values = json_rows(*dataset, step, &simulated_at, symbol, row, chains);
                 let mut chunk = Vec::new();
                 for value in values {
                     if !*first {
@@ -487,7 +874,7 @@ impl Writer {
                 Ok(chunk)
             }
             Writer::Csv { dataset } => {
-                let records = csv_rows(*dataset, step, &simulated_at, symbol, row, snapshot);
+                let records = csv_rows(*dataset, step, &simulated_at, symbol, row, chains);
                 encode_csv(&records)
             }
         }
@@ -524,7 +911,7 @@ fn json_rows(
     simulated_at: &str,
     symbol: &str,
     row: &crate::domain::factors::FactorRow,
-    snapshot: Option<&SeriesSnapshot>,
+    chains: Option<StepChains<'_>>,
 ) -> Vec<serde_json::Value> {
     match dataset {
         Dataset::Underlying => vec![serde_json::json!({
@@ -540,32 +927,32 @@ fn json_rows(
             "base_volatility": row.base_volatility.to_f64(),
         })],
         Dataset::OptionChains => {
-            let Some(snapshot) = snapshot else {
+            let Some(chains) = chains else {
                 return Vec::new();
             };
             let mut rows = Vec::new();
-            for chain in &snapshot.chains {
-                let expires_at = render_instant(chain.expires_at);
-                let labels = chain.labels.join("|");
-                for data in chain.chain.iter() {
+            for expiration in chains.expirations() {
+                let expires_at = render_instant(expiration.expires_at);
+                let labels = expiration.labels.join("|");
+                for quote in expiration.quotes.quotes() {
                     rows.push(serde_json::json!({
                         "step": step,
                         "simulated_at": simulated_at,
                         "symbol": symbol,
                         "expires_at": expires_at,
                         "labels": labels,
-                        "days_to_expiration": chain.days_to_expiration.to_f64(),
-                        "strike": data.strike_price.to_f64(),
-                        "implied_volatility": data.implied_volatility.to_f64(),
-                        "call_bid": data.call_bid.map(|v| v.to_f64()),
-                        "call_ask": data.call_ask.map(|v| v.to_f64()),
-                        "call_mid": data.call_middle.map(|v| v.to_f64()),
-                        "call_delta": data.delta_call.and_then(decimal_to_f64),
-                        "put_bid": data.put_bid.map(|v| v.to_f64()),
-                        "put_ask": data.put_ask.map(|v| v.to_f64()),
-                        "put_mid": data.put_middle.map(|v| v.to_f64()),
-                        "put_delta": data.delta_put.and_then(decimal_to_f64),
-                        "gamma": data.gamma.and_then(decimal_to_f64),
+                        "days_to_expiration": expiration.days_to_expiration,
+                        "strike": quote.strike,
+                        "implied_volatility": quote.implied_volatility,
+                        "call_bid": quote.call_bid,
+                        "call_ask": quote.call_ask,
+                        "call_mid": quote.call_mid,
+                        "call_delta": quote.call_delta,
+                        "put_bid": quote.put_bid,
+                        "put_ask": quote.put_ask,
+                        "put_mid": quote.put_mid,
+                        "put_delta": quote.put_delta,
+                        "gamma": quote.gamma,
                     }));
                 }
             }
@@ -581,7 +968,7 @@ fn csv_rows(
     simulated_at: &str,
     symbol: &str,
     row: &crate::domain::factors::FactorRow,
-    snapshot: Option<&SeriesSnapshot>,
+    chains: Option<StepChains<'_>>,
 ) -> Vec<Vec<String>> {
     match dataset {
         Dataset::Underlying => vec![vec![
@@ -597,34 +984,34 @@ fn csv_rows(
             row.base_volatility.to_f64().to_string(),
         ]],
         Dataset::OptionChains => {
-            let Some(snapshot) = snapshot else {
+            let Some(chains) = chains else {
                 return Vec::new();
             };
             let mut records = Vec::new();
-            for chain in &snapshot.chains {
-                let expires_at = render_instant(chain.expires_at);
+            for expiration in chains.expirations() {
+                let expires_at = render_instant(expiration.expires_at);
                 // Joined with `|` rather than `,` so a multi-label chain stays
                 // one column without depending on quoting to do it.
-                let labels = chain.labels.join("|");
-                for data in chain.chain.iter() {
+                let labels = expiration.labels.join("|");
+                for quote in expiration.quotes.quotes() {
                     records.push(vec![
                         step.to_string(),
                         simulated_at.to_string(),
                         symbol.to_string(),
                         expires_at.clone(),
                         labels.clone(),
-                        chain.days_to_expiration.to_f64().to_string(),
-                        data.strike_price.to_f64().to_string(),
-                        data.implied_volatility.to_f64().to_string(),
-                        render_optional(data.call_bid.map(|v| v.to_f64())),
-                        render_optional(data.call_ask.map(|v| v.to_f64())),
-                        render_optional(data.call_middle.map(|v| v.to_f64())),
-                        render_optional(data.delta_call.and_then(decimal_to_f64)),
-                        render_optional(data.put_bid.map(|v| v.to_f64())),
-                        render_optional(data.put_ask.map(|v| v.to_f64())),
-                        render_optional(data.put_middle.map(|v| v.to_f64())),
-                        render_optional(data.delta_put.and_then(decimal_to_f64)),
-                        render_optional(data.gamma.and_then(decimal_to_f64)),
+                        expiration.days_to_expiration.to_string(),
+                        quote.strike.to_string(),
+                        quote.implied_volatility.to_string(),
+                        render_optional(quote.call_bid),
+                        render_optional(quote.call_ask),
+                        render_optional(quote.call_mid),
+                        render_optional(quote.call_delta),
+                        render_optional(quote.put_bid),
+                        render_optional(quote.put_ask),
+                        render_optional(quote.put_mid),
+                        render_optional(quote.put_delta),
+                        render_optional(quote.gamma),
                     ]);
                 }
             }
@@ -680,14 +1067,23 @@ mod tests {
         })
     }
 
+    /// Mounts the real v2 routes over an in-memory store, with no warehouse.
+    ///
+    /// The argument form mounts one, which is how the tests below exercise the
+    /// stored path over the very same route registration production uses.
     macro_rules! v2_service {
-        () => {{
+        () => {
+            v2_service!(None)
+        };
+        ($snapshots:expr) => {{
             let manager = Arc::new(crate::session::SimulationManager::new(
                 Arc::new(InMemorySimulationStore::new()),
                 SimulationV2Config::default(),
             ));
+            let snapshots: Option<Arc<dyn SimulationSnapshotRepository>> = $snapshots;
             actix_test::init_service(
-                App::new().configure(|cfg| configure_v2_routes(cfg, manager.clone())),
+                App::new()
+                    .configure(|cfg| configure_v2_routes(cfg, manager.clone(), snapshots.clone())),
             )
             .await
         }};
@@ -1200,6 +1596,395 @@ mod tests {
                 "{symbol:?} must be rejected at the boundary"
             );
         }
+    }
+
+    // ---- the persisted source --------------------------------------------
+
+    /// A warehouse that answers from memory, standing in for ClickHouse.
+    ///
+    /// Hermetic on purpose: what these tests are about is the *export's*
+    /// decision between the two sources and the adapter that renders them, not
+    /// the SQL — a live warehouse would test the driver and hide the branch.
+    #[derive(Default)]
+    struct FakeWarehouse {
+        stored: std::sync::Mutex<std::collections::BTreeMap<usize, SnapshotRecord>>,
+        /// When set, every read fails the way an unreachable warehouse does.
+        failing: bool,
+        /// How many range reads the export asked for — the windowing evidence.
+        reads: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FakeWarehouse {
+        /// A warehouse that is down.
+        fn failing() -> Self {
+            Self {
+                failing: true,
+                ..Self::default()
+            }
+        }
+
+        /// How many range reads it has answered.
+        fn reads(&self) -> usize {
+            self.reads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        /// Files records after the fact.
+        ///
+        /// Lets a test create the simulation first and persist its real id
+        /// afterwards, which is the order production works in.
+        fn fill(&self, records: Vec<SnapshotRecord>) {
+            let mut stored = match self.stored.lock() {
+                Ok(stored) => stored,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            for record in records {
+                stored.insert(record.step, record);
+            }
+        }
+
+        /// The records it holds, ascending by step.
+        fn range(&self, from: usize, to: usize) -> Vec<SnapshotRecord> {
+            match self.stored.lock() {
+                Ok(stored) => stored
+                    .range(from..=to)
+                    .map(|(_, record)| record.clone())
+                    .collect(),
+                Err(poisoned) => poisoned
+                    .into_inner()
+                    .range(from..=to)
+                    .map(|(_, record)| record.clone())
+                    .collect(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SimulationSnapshotRepository for FakeWarehouse {
+        async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
+            match self.stored.lock() {
+                Ok(mut stored) => {
+                    stored.insert(record.step, record);
+                }
+                Err(poisoned) => {
+                    poisoned.into_inner().insert(record.step, record);
+                }
+            }
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Ok(self.range(step, step).into_iter().next())
+        }
+
+        async fn read_range(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            from_step: usize,
+            to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            self.reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.failing {
+                return Err(ChainError::ClickHouseError(
+                    "the warehouse is unreachable".to_string(),
+                ));
+            }
+            Ok(self.range(from_step, to_step))
+        }
+
+        async fn contract_series(
+            &self,
+            _query: crate::infrastructure::ContractSeriesQuery,
+        ) -> Result<Vec<crate::infrastructure::ContractQuote>, ChainError> {
+            // The export never projects a single contract; an empty history is
+            // an honest answer rather than a panic waiting to be reached.
+            Ok(Vec::new())
+        }
+    }
+
+    /// The effective parameters of [`reference_body`].
+    ///
+    /// Parsed from the very same JSON the tests create with, so the replayed
+    /// tape here cannot drift from the simulation under test.
+    fn reference_parameters() -> SimulationParametersV2 {
+        let request: crate::api::rest::requests_v2::CreateSimulationRequest =
+            match serde_json::from_value(reference_body()) {
+                Ok(request) => request,
+                Err(error) => panic!("the reference body must deserialize: {error}"),
+            };
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the reference body must convert: {error}"),
+        }
+    }
+
+    /// The snapshot record of `step`, as the session layer would have filed it.
+    ///
+    /// The conversion is re-stated here rather than reused because
+    /// `session::snapshot_record` is a private module: the api layer cannot name
+    /// it. That is a feature for this test — the fixture is built from the
+    /// domain snapshot independently of the writer, so the assertion below is
+    /// about the reader, not about a shared helper agreeing with itself.
+    fn stored_record(simulation: Uuid, step: usize) -> SnapshotRecord {
+        let parameters = reference_parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let builder = match SeriesBuilder::new(&parameters, &tape) {
+            Ok(builder) => builder,
+            Err(error) => panic!("the builder must accept the parameters: {error}"),
+        };
+        let snapshot = match builder.snapshot(step) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the snapshot must build: {error}"),
+        };
+
+        SnapshotRecord::new(
+            simulation,
+            CURRENT_SNAPSHOT_GENERATION,
+            snapshot.step,
+            snapshot.simulated_at,
+            parameters.symbol.clone(),
+            snapshot.spot,
+            snapshot.base_volatility,
+            snapshot
+                .chains
+                .iter()
+                .map(|chain| {
+                    crate::infrastructure::ExpirationRecord::new(
+                        chain.expires_at,
+                        chain.days_to_expiration,
+                        chain.labels.clone(),
+                        chain
+                            .chain
+                            .iter()
+                            .map(|data| QuoteRow {
+                                strike: data.strike_price,
+                                implied_volatility: data.implied_volatility,
+                                call_bid: data.call_bid,
+                                call_ask: data.call_ask,
+                                call_mid: data.call_middle,
+                                put_bid: data.put_bid,
+                                put_ask: data.put_ask,
+                                put_mid: data.put_middle,
+                                delta_call: data.delta_call,
+                                delta_put: data.delta_put,
+                                gamma: data.gamma,
+                            })
+                            .collect(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// Every step of the reference simulation, as persisted records.
+    fn stored_tape(simulation: Uuid) -> Vec<SnapshotRecord> {
+        (0..3).map(|step| stored_record(simulation, step)).collect()
+    }
+
+    /// The id the export will use, parsed back from the create response.
+    fn parse_id(id: &str) -> Uuid {
+        match Uuid::parse_str(id) {
+            Ok(id) => id,
+            Err(error) => panic!("the created id must be a UUID: {error}"),
+        }
+    }
+
+    /// A step served from the warehouse renders exactly like one replayed —
+    /// byte for byte, in both encodings.
+    ///
+    /// This is what makes preferring the warehouse safe at all: the two sources
+    /// go through one adapter, so a client cannot tell which produced its rows.
+    #[actix_web::test]
+    async fn test_a_persisted_step_renders_exactly_like_a_replayed_one() {
+        let warehouse = Arc::new(FakeWarehouse::default());
+        let app = v2_service!(Some(
+            Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>
+        ));
+        let id = create!(app);
+
+        // The same app, the same simulation, exported either side of the moment
+        // the warehouse learns the tape: the only thing that changes is which
+        // source answers.
+        let mut replayed = Vec::new();
+        for format in ["json", "csv"] {
+            let (status, body) = export!(app, id, format!("dataset=option_chains&format={format}"));
+            assert_eq!(status, StatusCode::OK, "{format}");
+            replayed.push(body);
+        }
+
+        warehouse.fill(stored_tape(parse_id(&id)));
+
+        for (format, replayed) in ["json", "csv"].iter().zip(replayed) {
+            let (status, stored) =
+                export!(app, id, format!("dataset=option_chains&format={format}"));
+
+            assert_eq!(status, StatusCode::OK, "{format}");
+            assert_eq!(
+                replayed, stored,
+                "{format}: a persisted step must render identically to a replayed one"
+            );
+        }
+        assert!(
+            warehouse.reads() >= 4,
+            "every chains export must have consulted the warehouse"
+        );
+    }
+
+    /// The persisted snapshot is what the export serves, not a replay of it.
+    ///
+    /// Without this the test above would pass on an export that ignored the
+    /// warehouse entirely, since both sources agree by construction. A stored
+    /// row carrying a value replay could never produce is the only way to see
+    /// which side answered.
+    #[actix_web::test]
+    async fn test_the_export_prefers_the_persisted_snapshot() {
+        let warehouse = Arc::new(FakeWarehouse::default());
+        let app = v2_service!(Some(
+            Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>
+        ));
+        let id = create!(app);
+
+        let (_, replayed) = export!(app, id, "dataset=option_chains&format=json");
+        assert!(
+            !replayed.contains("1234.5"),
+            "the marker must be impossible to reach by replay"
+        );
+
+        let mut records = stored_tape(parse_id(&id));
+        for record in &mut records {
+            for expiration in &mut record.expirations {
+                for quote in &mut expiration.quotes {
+                    quote.call_bid = Some(positive::pos_or_panic!(1_234.5));
+                }
+            }
+        }
+        warehouse.fill(records);
+
+        let (status, stored) = export!(app, id, "dataset=option_chains&format=json");
+
+        assert_eq!(status, StatusCode::OK);
+        let rows = json_rows_of(&stored);
+        assert!(!rows.is_empty());
+        for row in &rows {
+            assert_eq!(
+                row.get("call_bid"),
+                Some(&json!(1234.5)),
+                "every chains row must come from the warehouse: {row}"
+            );
+        }
+    }
+
+    /// A step the warehouse does not hold is replayed, and the export is
+    /// indistinguishable from a full replay.
+    #[actix_web::test]
+    async fn test_a_missing_step_falls_back_to_replay() {
+        let warehouse = Arc::new(FakeWarehouse::default());
+        let app = v2_service!(Some(
+            Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>
+        ));
+        let id = create!(app);
+
+        let mut replayed = Vec::new();
+        for format in ["json", "csv"] {
+            let (_, body) = export!(app, id, format!("dataset=option_chains&format={format}"));
+            replayed.push(body);
+        }
+
+        // Only the middle step is persisted; the ends are gaps.
+        warehouse.fill(vec![stored_record(parse_id(&id), 1)]);
+
+        for (format, replayed) in ["json", "csv"].iter().zip(replayed) {
+            let (status, mixed) =
+                export!(app, id, format!("dataset=option_chains&format={format}"));
+
+            assert_eq!(status, StatusCode::OK, "{format}");
+            assert_eq!(
+                replayed, mixed,
+                "{format}: a partially persisted tape must export the whole range"
+            );
+        }
+    }
+
+    /// A warehouse that is down does not fail the export, and does not change
+    /// what it produces.
+    #[actix_web::test]
+    async fn test_a_failing_warehouse_does_not_fail_the_export() {
+        let replaying = v2_service!();
+        let id = create!(replaying);
+
+        // A different app, hence a different simulation id — but the same
+        // parameters and the same seed, which is all a tape depends on.
+        let warehouse = Arc::new(FakeWarehouse::failing());
+        let storing = v2_service!(Some(
+            Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>
+        ));
+        let stored_id = create!(storing);
+
+        let (_, replayed) = export!(replaying, id, "dataset=option_chains&format=csv");
+        let (status, degraded) = export!(storing, stored_id, "dataset=option_chains&format=csv");
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(replayed, degraded, "a failed read must fall back to replay");
+        assert_eq!(
+            warehouse.reads(),
+            1,
+            "a warehouse that failed once must not be asked again for this export"
+        );
+    }
+
+    /// Only the chains dataset consults the warehouse, and it consults it once
+    /// per window rather than once per step.
+    #[actix_web::test]
+    async fn test_only_the_chains_dataset_reads_the_warehouse() {
+        let warehouse = Arc::new(FakeWarehouse::default());
+        let app = v2_service!(Some(
+            Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>
+        ));
+        let id = create!(app);
+
+        for dataset in ["underlying", "volatility"] {
+            let (status, _) = export!(app, id, format!("dataset={dataset}&format=json"));
+            assert_eq!(status, StatusCode::OK);
+        }
+        assert_eq!(
+            warehouse.reads(),
+            0,
+            "the tape-only datasets must not pay for a warehouse lookup"
+        );
+
+        let (status, _) = export!(app, id, "dataset=option_chains&format=json");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            warehouse.reads(),
+            1,
+            "three steps fit in one window, so one read serves them all"
+        );
+    }
+
+    /// A window covers at most its width, and never reaches past the range.
+    #[test]
+    fn test_a_window_is_bounded_by_its_width_and_by_the_range() {
+        assert_eq!(window_end(0, SNAPSHOT_WINDOW_STEPS, 1_000), 63);
+        assert_eq!(window_end(64, SNAPSHOT_WINDOW_STEPS, 1_000), 127);
+        assert_eq!(
+            window_end(0, SNAPSHOT_WINDOW_STEPS, 10),
+            10,
+            "a short range must not be read past its end"
+        );
+        assert_eq!(window_end(7, 1, 1_000), 7, "a narrowed window is one step");
+        assert_eq!(
+            window_end(usize::MAX, SNAPSHOT_WINDOW_STEPS, usize::MAX),
+            usize::MAX,
+            "the arithmetic must not wrap into a reversed range"
+        );
     }
 
     // ---- ranges and bounds, unit level -----------------------------------

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -349,7 +349,9 @@ mod tests {
                 crate::infrastructure::SimulationV2Config::default(),
             ));
             actix_test::init_service(
-                App::new().configure(|cfg| configure_v2_routes(cfg, manager.clone())),
+                // No warehouse: these tests exercise the lifecycle, which is
+                // identical with and without snapshot persistence.
+                App::new().configure(|cfg| configure_v2_routes(cfg, manager.clone(), None)),
             )
             .await
         }};

--- a/src/api/rest/routes.rs
+++ b/src/api/rest/routes.rs
@@ -9,7 +9,7 @@ use crate::api::rest::handlers_v2::{
 };
 use crate::api::rest::middleware::metrics_endpoint;
 use crate::api::rest::swagger::ApiDoc;
-use crate::infrastructure::{MetricsCollector, MongoDBRepository};
+use crate::infrastructure::{MetricsCollector, MongoDBRepository, SimulationSnapshotRepository};
 use crate::session::{SessionManager, SimulationManager};
 use actix_web::web;
 use std::sync::Arc;
@@ -29,6 +29,8 @@ use utoipa_swagger_ui::SwaggerUi;
 /// * `session_manager` - An `Arc` instance of `SessionManager`. This is wrapped in `web::Data`
 ///   to make it accessible to the route handlers. The `SessionManager` is responsible for managing
 ///   session data and operations.
+/// * `snapshots` - The v2 snapshot warehouse, when the operator enabled persistence. `None` is the
+///   normal case and leaves the v2 export replaying every step.
 ///
 /// # Endpoints
 ///
@@ -65,7 +67,11 @@ pub fn configure_routes(
     metrics_collector: Arc<MetricsCollector>,
     mongodb_repo: Arc<MongoDBRepository>,
 ) {
-    configure_v2_routes(cfg, simulation_manager);
+    // The export reads from the same warehouse the manager files into, taken
+    // off the manager rather than threaded separately: two handles could be
+    // configured differently, and there is only ever one warehouse.
+    let snapshots = simulation_manager.warehouse();
+    configure_v2_routes(cfg, simulation_manager, snapshots);
 
     cfg.app_data(web::Data::new(session_manager))
         .app_data(web::Data::new(metrics_collector.clone()))
@@ -106,10 +112,21 @@ pub fn configure_routes(
 /// - **DELETE** `/api/v2/simulations/{id}` — delete it and evict its caches.
 /// - **GET** `/api/v2/simulations/{id}/export` — stream the complete tape, or a
 ///   step range of it, as JSON or CSV.
+///
+/// `snapshots` is the warehouse the export reads persisted steps from. It is an
+/// `Option` because persistence is opt-in: registered, the export prefers a
+/// stored snapshot over replaying it; absent, nothing about the export changes.
+/// The handler extracts it as `Option<web::Data<_>>`, so a deployment without
+/// ClickHouse registers nothing rather than a null.
 pub(crate) fn configure_v2_routes(
     cfg: &mut web::ServiceConfig,
     simulation_manager: Arc<SimulationManager>,
+    snapshots: Option<Arc<dyn SimulationSnapshotRepository>>,
 ) {
+    if let Some(snapshots) = snapshots {
+        cfg.app_data(web::Data::new(snapshots));
+    }
+
     cfg.app_data(web::Data::new(simulation_manager))
         // A rejected v2 body must come back as the documented `{error, field}`
         // shape. Rule-level failures are raised *inside* deserialization, so

--- a/src/infrastructure/clickhouse/mod.rs
+++ b/src/infrastructure/clickhouse/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 pub(crate) mod interface;
 pub(crate) mod model;
+pub(crate) mod snapshots;
 pub(crate) mod utils;
 
 pub use client::ClickHouseClient;

--- a/src/infrastructure/clickhouse/schema/simulation_option_quotes.sql
+++ b/src/infrastructure/clickhouse/schema/simulation_option_quotes.sql
@@ -1,0 +1,81 @@
+-- One row per (v2 simulation step, physical expiration, strike) — both sides of
+-- the strike, since a call and a put share the strike, the implied volatility
+-- and the gamma (issue #56).
+--
+-- ENGINE — ReplacingMergeTree(inserted_at_ms)
+--   Same reasoning as `simulation_snapshots`: a retried or replayed snapshot
+--   rewrites the same coordinates, and the engine collapses them to the most
+--   recent write. Reads use FINAL (or `uniqExact` over the identity columns
+--   when only a count is needed) so idempotence holds immediately rather than
+--   after the next background merge.
+--
+-- ORDER BY — (simulation_id, simulation_generation, step, expires_at, strike)
+--   The row's identity, and the deduplication key. The prefix is chosen for the
+--   dominant query pattern, whole-snapshot reconstruction: one step of one
+--   simulation is a contiguous run, read as a single range.
+--
+--   PRIMARY KEY stops at `step`, so the sparse primary index stays small: the
+--   two trailing columns still participate in deduplication and in the sort
+--   order, they just do not enlarge the in-memory index.
+--
+-- The second query pattern — one contract across time — filters
+-- (expires_at, strike) while ranging over steps, which the ORDER BY prefix
+-- cannot serve directly. Two things make it cheap anyway. The
+-- (simulation_id, simulation_generation) prefix already restricts the scan to one
+-- simulation, and within each step's block the rows are sorted by expiry and
+-- then strike, so the granules of a block cover contiguous (expiry, strike)
+-- intervals — exactly what a minmax skip index prunes on. Hence idx_contract
+-- with GRANULARITY 1, evaluated per granule.
+--
+-- PARTITION BY — toYYYYMM(simulated_at)
+--   A function of the row's own content, so a backfill written months later
+--   lands in the partition its original did and can be deduplicated against it.
+--   Also keeps one snapshot's rows in one partition, so one snapshot inserts as
+--   one already-sorted part.
+--
+-- Monetary and Greek columns — Decimal(38, 28)
+--   The tape must reconstruct to exactly what was generated; Float64 cannot
+--   promise that for a `rust_decimal` premium. Scale 28 is `rust_decimal`'s
+--   maximum, so nothing written here is ever rounded. See
+--   `src/infrastructure/clickhouse/snapshots/model.rs`.
+--
+-- Snapshot-level columns (snapshot_id, simulated_at, symbol) are repeated on
+-- every row on purpose: they are constant within a part and compress to
+-- nothing, and they let a contract history be served without joining.
+--
+-- TTL — retention measured from INGESTION. See `simulation_snapshots.sql`.
+--
+-- The ids are String rather than the native UUID type, and
+-- `simulation_generation` is not the session's `version`. Both choices are
+-- explained in full in `simulation_snapshots.sql`; the two tables must agree on
+-- them, since they are joined on exactly these columns.
+CREATE TABLE IF NOT EXISTS simulation_option_quotes
+(
+    simulation_id           String CODEC(ZSTD(1)),
+    simulation_generation   UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    step                    UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    expires_at              DateTime64(9, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+    strike                  Decimal(38, 28) CODEC(ZSTD(1)),
+    snapshot_id             String CODEC(ZSTD(1)),
+    simulated_at            DateTime64(9, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+    symbol                  LowCardinality(String) CODEC(ZSTD(1)),
+    days_to_expiration      Decimal(38, 28) CODEC(ZSTD(1)),
+    labels                  Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    implied_volatility      Decimal(38, 28) CODEC(ZSTD(1)),
+    call_bid                Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    call_ask                Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    call_mid                Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    put_bid                 Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    put_ask                 Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    put_mid                 Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    delta_call              Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    delta_put               Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    gamma                   Nullable(Decimal(38, 28)) CODEC(ZSTD(1)),
+    inserted_at_ms          UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    INDEX idx_contract (expires_at, strike) TYPE minmax GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree(inserted_at_ms)
+PARTITION BY toYYYYMM(simulated_at)
+PRIMARY KEY (simulation_id, simulation_generation, step)
+ORDER BY (simulation_id, simulation_generation, step, expires_at, strike)
+TTL toDateTime(intDiv(inserted_at_ms, 1000)) + INTERVAL {{RETENTION_DAYS}} DAY DELETE

--- a/src/infrastructure/clickhouse/schema/simulation_snapshots.sql
+++ b/src/infrastructure/clickhouse/schema/simulation_snapshots.sql
@@ -1,0 +1,82 @@
+-- One row per materialised v2 simulation step: the snapshot's metadata and its
+-- completion marker (issue #56).
+--
+-- ENGINE — ReplacingMergeTree(inserted_at_ms)
+--   A snapshot is immutable and deterministic: rebuilding step N of a given
+--   (simulation, version) always produces the same values. So a retry, a
+--   replay, or a backfill must be able to write the same coordinate again
+--   without ever exposing two rows for it. ReplacingMergeTree collapses rows
+--   sharing the sorting key and keeps the one with the greatest version column;
+--   `inserted_at_ms` (unix milliseconds) makes that "the most recent write".
+--   Two writes inside one millisecond tie, which is harmless — the rows are
+--   identical by construction. Because merges are asynchronous, every read
+--   issued by the service uses FINAL (or an explicit deduplicating aggregate),
+--   so idempotence holds immediately, not eventually.
+--
+-- ORDER BY — (simulation_id, simulation_generation, step)
+--   The identity of a snapshot, and therefore the deduplication key. It is also
+--   the access path of both query patterns: reconstructing one step, and
+--   scanning a step range of one simulation.
+--
+-- PARTITION BY — toYYYYMM(simulated_at)
+--   Deliberately a function of the row's OWN content rather than of when it was
+--   written. ReplacingMergeTree only deduplicates within a partition, so a
+--   partition key derived from the ingestion time would let a backfill written
+--   a month after the original land in a different partition and survive as a
+--   duplicate forever. `simulated_at` is deterministic for a coordinate, so a
+--   retry always lands in the partition its original did. It also keeps one
+--   snapshot's rows in exactly one partition (every row shares the instant), so
+--   an insert creates one part.
+--
+-- CODECs
+--   The columns are overwhelmingly low-entropy within a part: a block holds one
+--   simulation, one version, consecutive steps, one symbol. Delta/DoubleDelta
+--   turns the counters and the timestamps into runs of near-zeros, and ZSTD(1)
+--   compresses the residue and the repeated identifiers to almost nothing.
+--
+-- TTL — retention measured from INGESTION, not from simulated time
+--   A simulation's clock may sit years in the future, so a TTL on
+--   `simulated_at` would either never fire or fire immediately depending on the
+--   scenario. `inserted_at_ms` is real time. Row-level rather than
+--   partition-level for the same reason the partition key is what it is.
+--   Changing the retention of an EXISTING table needs an explicit
+--   `ALTER TABLE ... MODIFY TTL`: `CREATE TABLE IF NOT EXISTS` will not alter
+--   a table that is already there.
+--
+-- The ids are String, not the native UUID type, DELIBERATELY
+--   Native UUID would halve the sorting key (16 bytes against 36) and would
+--   read back fine, but the INSERT path cannot use it: the driver validates
+--   every RowBinary column against the Rust field type, and mapping a UUID
+--   column needs `clickhouse/serde::uuid`, which lives behind a crate feature
+--   this workspace does not enable. Turning it on is a `[workspace.dependencies]`
+--   change, so it is a deliberate follow-up rather than something to smuggle in
+--   here. The cost is bounded in practice: the value is constant across every
+--   row of a part and ZSTD collapses it, and it is only the leading key column,
+--   never a scanned one.
+--
+-- `simulation_generation` is NOT the session's `version`
+--   A v2 session's `version` is its optimistic-concurrency revision and changes
+--   on every advance; feeding it in here would scatter one tape across hundreds
+--   of coordinates and defeat deduplication. The generation changes only when
+--   the crate would produce different values for the same step — see
+--   CURRENT_SNAPSHOT_GENERATION in
+--   `src/infrastructure/clickhouse/snapshots/record.rs`.
+CREATE TABLE IF NOT EXISTS simulation_snapshots
+(
+    simulation_id           String CODEC(ZSTD(1)),
+    simulation_generation   UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    step                    UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    snapshot_id             String CODEC(ZSTD(1)),
+    simulated_at            DateTime64(9, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+    symbol                  LowCardinality(String) CODEC(ZSTD(1)),
+    underlying_price        Decimal(38, 28) CODEC(ZSTD(1)),
+    base_volatility         Decimal(38, 28) CODEC(ZSTD(1)),
+    quote_count             UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    expiration_count        UInt64 CODEC(DoubleDelta, ZSTD(1)),
+    complete                Bool CODEC(ZSTD(1)),
+    inserted_at_ms          UInt64 CODEC(DoubleDelta, ZSTD(1))
+)
+ENGINE = ReplacingMergeTree(inserted_at_ms)
+PARTITION BY toYYYYMM(simulated_at)
+ORDER BY (simulation_id, simulation_generation, step)
+TTL toDateTime(intDiv(inserted_at_ms, 1000)) + INTERVAL {{RETENTION_DAYS}} DAY DELETE

--- a/src/infrastructure/clickhouse/snapshots/interface.rs
+++ b/src/infrastructure/clickhouse/snapshots/interface.rs
@@ -1,0 +1,485 @@
+//! The storage-agnostic contract for the v2 snapshot tape.
+//!
+//! One trait with four operations, in the shape the two real query patterns
+//! need: reconstruct a whole snapshot (or a range of them) for #49's exports,
+//! and follow one `(expiration, strike, side)` across simulated time for a
+//! chart or a backtest.
+//!
+//! # What a reader is promised
+//!
+//! * **Never a partial snapshot.** A snapshot becomes visible only once every
+//!   one of its quote rows has been accepted *and* a completion marker carrying
+//!   the expected row count has been written after them. A read that finds the
+//!   marker but not the rows it promises reports the snapshot as absent, so a
+//!   half-written step reads exactly like a step that was never written.
+//! * **Never a duplicate.** Persisting the same `(simulation, generation, step)`
+//!   twice is idempotent from every read path here, including immediately after
+//!   the second write and before any background merge has run.
+//! * **A stable order.** Snapshots come back by step ascending, expirations by
+//!   expiry ascending, strikes ascending; a contract history comes back by
+//!   simulated time ascending. Two calls with the same arguments return the
+//!   same rows in the same order.
+//! * **A bounded answer.** Every read is capped by `OCS_SNAPSHOT_MAX_READ_ROWS`.
+//!   A request that would exceed it is a typed error naming the knob, never a
+//!   silently truncated tape — a short answer is indistinguishable from a gap
+//!   in the data, and #49's exports page rather than guess.
+
+use super::record::{ContractQuote, ContractSide, SnapshotRecord};
+use crate::utils::ChainError;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use positive::Positive;
+use uuid::Uuid;
+
+/// Which contract's history to read, and over which steps.
+///
+/// A struct rather than seven positional arguments: the three `u64`-ish fields
+/// would otherwise be trivially transposable at a call site, and transposing
+/// `from_step` and `to_step` is a silent empty result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContractSeriesQuery {
+    /// The simulation to read.
+    pub simulation: Uuid,
+    /// The generation the rows were written under —
+    /// [`super::record::CURRENT_SNAPSHOT_GENERATION`] for anything this build
+    /// materialised. Not the session's `version`.
+    pub generation: u64,
+    /// The contract's absolute expiration, exactly as persisted.
+    pub expires_at: DateTime<Utc>,
+    /// The contract's strike, exactly as persisted.
+    pub strike: Positive,
+    /// Which side to project.
+    pub side: ContractSide,
+    /// First step to consider, inclusive.
+    pub from_step: usize,
+    /// Last step to consider, inclusive.
+    pub to_step: usize,
+}
+
+impl ContractSeriesQuery {
+    /// Creates a contract-history query.
+    #[must_use]
+    pub fn new(
+        simulation: Uuid,
+        generation: u64,
+        expires_at: DateTime<Utc>,
+        strike: Positive,
+        side: ContractSide,
+        from_step: usize,
+        to_step: usize,
+    ) -> Self {
+        Self {
+            simulation,
+            generation,
+            expires_at,
+            strike,
+            side,
+            from_step,
+            to_step,
+        }
+    }
+}
+
+/// Persists and reads the v2 snapshot tape.
+///
+/// Object-safe: the service holds an `Arc<dyn SimulationSnapshotRepository>`
+/// when persistence is configured and nothing at all when it is not, so an
+/// absent warehouse costs a branch rather than a failing call.
+#[async_trait]
+pub trait SimulationSnapshotRepository: Send + Sync {
+    /// Persists one complete snapshot.
+    ///
+    /// Writes every quote row as **one** bounded batch and only then the
+    /// completion marker, so a reader can never observe the marker without the
+    /// rows it promises. Retrying the same `(simulation, generation, step)` is
+    /// safe: the rows carry a deterministic identity and replace rather than
+    /// accumulate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the record is malformed or
+    /// larger than `OCS_SNAPSHOT_BATCH_ROWS`, and
+    /// [`ChainError::ClickHouseError`] when the warehouse rejects or times out
+    /// the write. Callers on the advance path treat a failure as non-fatal: the
+    /// snapshot is deterministic, so a later replay can persist the same step.
+    async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError>;
+
+    /// Reads back one snapshot, or `None` when it was never completed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the snapshot is larger than one
+    /// read may return, and [`ChainError::ClickHouseError`] when the warehouse
+    /// is unreachable or a stored value is unreadable.
+    async fn get(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        step: usize,
+    ) -> Result<Option<SnapshotRecord>, ChainError>;
+
+    /// Reads an inclusive range of steps, ascending.
+    ///
+    /// Steps that were never completed are **skipped**, not faked: the caller
+    /// sees which steps are present and can replay the rest deterministically.
+    ///
+    /// The whole range is materialised, bounded by `OCS_SNAPSHOT_MAX_READ_ROWS`
+    /// — hence `read_`, not `stream_`. A caller exporting a multi-year
+    /// simulation pages the range rather than asking for a stream this does not
+    /// provide.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the range is reversed or would
+    /// exceed `OCS_SNAPSHOT_MAX_READ_ROWS`, and
+    /// [`ChainError::ClickHouseError`] when the warehouse is unreachable or a
+    /// stored value is unreadable.
+    async fn read_range(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        from_step: usize,
+        to_step: usize,
+    ) -> Result<Vec<SnapshotRecord>, ChainError>;
+
+    /// Reads one contract's history, ordered by simulated time.
+    ///
+    /// Only steps whose snapshot is complete contribute, so a chart never shows
+    /// a point that came from a half-written step.
+    ///
+    /// # Errors
+    ///
+    /// As [`SimulationSnapshotRepository::read_range`].
+    async fn contract_series(
+        &self,
+        query: ContractSeriesQuery,
+    ) -> Result<Vec<ContractQuote>, ChainError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::record::{CURRENT_SNAPSHOT_GENERATION, ExpirationRecord, QuoteRow};
+    use super::*;
+    use chrono::TimeZone;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    /// A hermetic implementation of the contract, standing in for the
+    /// warehouse.
+    ///
+    /// Exists to prove two things without a server: that the trait is
+    /// object-safe behind an `Arc<dyn _>` — which is how the service holds it —
+    /// and that the documented ordering and idempotence are expressible.
+    #[derive(Default)]
+    struct InMemorySnapshotRepository {
+        stored: Mutex<BTreeMap<(Uuid, u64, usize), SnapshotRecord>>,
+    }
+
+    #[async_trait]
+    impl SimulationSnapshotRepository for InMemorySnapshotRepository {
+        async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
+            record.validate()?;
+            let key = (record.simulation, record.generation, record.step);
+            self.stored.lock().await.insert(key, record);
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            simulation: Uuid,
+            generation: u64,
+            step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Ok(self
+                .stored
+                .lock()
+                .await
+                .get(&(simulation, generation, step))
+                .cloned())
+        }
+
+        async fn read_range(
+            &self,
+            simulation: Uuid,
+            generation: u64,
+            from_step: usize,
+            to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            Ok(self
+                .stored
+                .lock()
+                .await
+                .range((simulation, generation, from_step)..=(simulation, generation, to_step))
+                .map(|(_, record)| record.clone())
+                .collect())
+        }
+
+        async fn contract_series(
+            &self,
+            query: ContractSeriesQuery,
+        ) -> Result<Vec<ContractQuote>, ChainError> {
+            let stored = self.stored.lock().await;
+            let mut series = Vec::new();
+            for record in stored
+                .range(
+                    (query.simulation, query.generation, query.from_step)
+                        ..=(query.simulation, query.generation, query.to_step),
+                )
+                .map(|(_, record)| record)
+            {
+                for expiration in &record.expirations {
+                    if expiration.expires_at != query.expires_at {
+                        continue;
+                    }
+                    for quote in &expiration.quotes {
+                        if quote.strike != query.strike {
+                            continue;
+                        }
+                        // The side is a projection, exactly as it is in the SQL
+                        // implementation: one stored row, two ways to read it.
+                        let (bid, ask, mid, delta) = match query.side {
+                            ContractSide::Call => (
+                                quote.call_bid,
+                                quote.call_ask,
+                                quote.call_mid,
+                                quote.delta_call,
+                            ),
+                            ContractSide::Put => {
+                                (quote.put_bid, quote.put_ask, quote.put_mid, quote.delta_put)
+                            }
+                        };
+                        series.push(ContractQuote {
+                            step: record.step,
+                            simulated_at: record.simulated_at,
+                            expires_at: expiration.expires_at,
+                            days_to_expiration: expiration.days_to_expiration,
+                            strike: quote.strike,
+                            side: query.side,
+                            implied_volatility: quote.implied_volatility,
+                            bid,
+                            ask,
+                            mid,
+                            delta,
+                            gamma: quote.gamma,
+                        });
+                    }
+                }
+            }
+            Ok(series)
+        }
+    }
+
+    fn instant(day: u32) -> DateTime<Utc> {
+        match Utc.with_ymd_and_hms(2026, 1, day, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        }
+    }
+
+    /// One strike whose two sides are told apart by every value, including a
+    /// missing put mid.
+    ///
+    /// Deliberately asymmetric: a projection that ignored the requested side
+    /// would return the call's numbers, and a fixture with matching sides could
+    /// not tell the difference.
+    fn quote() -> QuoteRow {
+        QuoteRow::new(pos_or_panic!(5000.0), pos_or_panic!(0.18))
+            .with_call(
+                Some(pos_or_panic!(1.0)),
+                Some(pos_or_panic!(1.2)),
+                Some(pos_or_panic!(1.1)),
+                Some(dec!(0.51)),
+            )
+            .with_put(
+                Some(pos_or_panic!(0.8)),
+                Some(pos_or_panic!(1.0)),
+                None,
+                Some(dec!(-0.49)),
+            )
+            .with_gamma(Some(dec!(0.003)))
+    }
+
+    fn record(simulation: Uuid, step: usize) -> SnapshotRecord {
+        SnapshotRecord::new(
+            simulation,
+            CURRENT_SNAPSHOT_GENERATION,
+            step,
+            instant(5),
+            "SPX".to_string(),
+            pos_or_panic!(5000.0),
+            pos_or_panic!(0.18),
+            vec![ExpirationRecord::new(
+                instant(9),
+                pos_or_panic!(4.0),
+                vec!["weeklies".to_string()],
+                vec![quote()],
+            )],
+        )
+    }
+
+    /// A history query for one side of the fixture's strike.
+    fn series_query(simulation: Uuid, side: ContractSide) -> ContractSeriesQuery {
+        ContractSeriesQuery::new(
+            simulation,
+            CURRENT_SNAPSHOT_GENERATION,
+            instant(9),
+            pos_or_panic!(5000.0),
+            side,
+            0,
+            2,
+        )
+    }
+
+    /// The trait is usable behind a trait object, which is how the service
+    /// holds it — and how a deployment without ClickHouse holds nothing.
+    #[tokio::test]
+    async fn test_the_repository_is_object_safe() {
+        let simulation = Uuid::from_u128(5);
+        let repository: Arc<dyn SimulationSnapshotRepository> =
+            Arc::new(InMemorySnapshotRepository::default());
+
+        match repository.persist(record(simulation, 0)).await {
+            Ok(()) => {}
+            Err(error) => panic!("the snapshot must persist: {error}"),
+        }
+        match repository
+            .get(simulation, CURRENT_SNAPSHOT_GENERATION, 0)
+            .await
+        {
+            Ok(Some(found)) => assert_eq!(found.step, 0),
+            other => panic!("the snapshot must be readable, got {other:?}"),
+        }
+    }
+
+    /// A missing snapshot is `None`, not an error: an unpersisted step is a
+    /// normal state that deterministic replay can fill.
+    #[tokio::test]
+    async fn test_a_missing_snapshot_reads_as_absent() {
+        let repository = InMemorySnapshotRepository::default();
+
+        match repository
+            .get(Uuid::from_u128(5), CURRENT_SNAPSHOT_GENERATION, 3)
+            .await
+        {
+            Ok(None) => {}
+            other => panic!("expected an absent snapshot, got {other:?}"),
+        }
+    }
+
+    /// A range comes back ascending by step.
+    #[tokio::test]
+    async fn test_a_range_comes_back_ascending() {
+        let simulation = Uuid::from_u128(5);
+        let repository = InMemorySnapshotRepository::default();
+        for step in [2, 0, 1] {
+            match repository.persist(record(simulation, step)).await {
+                Ok(()) => {}
+                Err(error) => panic!("the snapshot must persist: {error}"),
+            }
+        }
+
+        match repository
+            .read_range(simulation, CURRENT_SNAPSHOT_GENERATION, 0, 2)
+            .await
+        {
+            Ok(range) => {
+                let steps: Vec<usize> = range.iter().map(|record| record.step).collect();
+                assert_eq!(steps, vec![0, 1, 2]);
+            }
+            Err(error) => panic!("the range must read: {error}"),
+        }
+    }
+
+    /// A contract history is addressed by expiration, strike and side, and the
+    /// call side returns the call's numbers.
+    #[tokio::test]
+    async fn test_a_contract_history_selects_the_call_side() {
+        let simulation = Uuid::from_u128(5);
+        let repository = InMemorySnapshotRepository::default();
+        for step in 0..3 {
+            match repository.persist(record(simulation, step)).await {
+                Ok(()) => {}
+                Err(error) => panic!("the snapshot must persist: {error}"),
+            }
+        }
+
+        match repository
+            .contract_series(series_query(simulation, ContractSide::Call))
+            .await
+        {
+            Ok(series) => {
+                assert_eq!(series.len(), 3);
+                for quote in &series {
+                    assert_eq!(quote.side, ContractSide::Call);
+                    assert_eq!(quote.strike, pos_or_panic!(5000.0));
+                    assert_eq!(quote.bid, Some(pos_or_panic!(1.0)));
+                    assert_eq!(quote.mid, Some(pos_or_panic!(1.1)));
+                    assert_eq!(quote.delta, Some(dec!(0.51)));
+                    // Gamma is shared by both sides.
+                    assert_eq!(quote.gamma, Some(dec!(0.003)));
+                }
+            }
+            Err(error) => panic!("the series must read: {error}"),
+        }
+    }
+
+    /// The put side returns the put's numbers, including its missing mid.
+    ///
+    /// The other half of the projection: without it, an implementation that
+    /// always read the call columns would pass every assertion above.
+    #[tokio::test]
+    async fn test_a_contract_history_selects_the_put_side() {
+        let simulation = Uuid::from_u128(5);
+        let repository = InMemorySnapshotRepository::default();
+        match repository.persist(record(simulation, 0)).await {
+            Ok(()) => {}
+            Err(error) => panic!("the snapshot must persist: {error}"),
+        }
+
+        match repository
+            .contract_series(series_query(simulation, ContractSide::Put))
+            .await
+        {
+            Ok(series) => {
+                assert_eq!(series.len(), 1);
+                match series.first() {
+                    Some(quote) => {
+                        assert_eq!(quote.side, ContractSide::Put);
+                        assert_eq!(quote.bid, Some(pos_or_panic!(0.8)));
+                        assert_eq!(quote.ask, Some(pos_or_panic!(1.0)));
+                        assert_eq!(quote.mid, None, "a missing quote stays missing");
+                        assert_eq!(quote.delta, Some(dec!(-0.49)));
+                        assert_eq!(quote.gamma, Some(dec!(0.003)));
+                    }
+                    None => panic!("the series must carry a point"),
+                }
+            }
+            Err(error) => panic!("the series must read: {error}"),
+        }
+    }
+
+    /// Persisting the same coordinate twice leaves one snapshot.
+    #[tokio::test]
+    async fn test_persisting_twice_is_idempotent() {
+        let simulation = Uuid::from_u128(5);
+        let repository = InMemorySnapshotRepository::default();
+
+        for _ in 0..2 {
+            match repository.persist(record(simulation, 0)).await {
+                Ok(()) => {}
+                Err(error) => panic!("the snapshot must persist: {error}"),
+            }
+        }
+
+        match repository
+            .read_range(simulation, CURRENT_SNAPSHOT_GENERATION, 0, 0)
+            .await
+        {
+            Ok(range) => assert_eq!(range.len(), 1),
+            Err(error) => panic!("the range must read: {error}"),
+        }
+    }
+}

--- a/src/infrastructure/clickhouse/snapshots/mod.rs
+++ b/src/infrastructure/clickhouse/snapshots/mod.rs
@@ -1,0 +1,12 @@
+//! The v2 simulation snapshot tape: its contract, its records, and its rows.
+//!
+//! Three files, one concern each. [`interface`] is the storage-agnostic trait
+//! the session layer depends on; [`record`] holds the typed records that cross
+//! it; [`model`] is the serialization boundary where a `Positive` becomes a
+//! `Decimal(38, 28)` column. The ClickHouse implementation lives beside the
+//! other repositories, in
+//! [`crate::infrastructure::ClickHouseSnapshotRepository`].
+
+pub(crate) mod interface;
+pub(crate) mod model;
+pub(crate) mod record;

--- a/src/infrastructure/clickhouse/snapshots/model.rs
+++ b/src/infrastructure/clickhouse/snapshots/model.rs
@@ -1,0 +1,908 @@
+//! The ClickHouse row types for the v2 snapshot tape, and the one place a
+//! typed value becomes a column.
+//!
+//! # Why the columns are `Decimal(38, 28)`
+//!
+//! A persisted snapshot has to reconstruct to **exactly** what was generated —
+//! that is what lets #49's exports read the warehouse instead of replaying the
+//! simulation, and it is an acceptance criterion of issue #56. `Float64` cannot
+//! promise that: a `Decimal` premium round-tripped through a binary float comes
+//! back a different number. A fixed-point column can, as long as the scale is
+//! at least as fine as the values written, and `rust_decimal` carries at most
+//! 28 fractional digits — so 28 is the scale that never truncates.
+//!
+//! On the wire a `Decimal(38, 28)` is an `Int128` holding the value scaled by
+//! `10^28`, which is what [`to_storage_decimal`] produces. The cost is a ten
+//! digit ceiling on the integer part (`10^38 / 10^28`); a price above ten
+//! billion is rejected with a typed error rather than silently wrapping. The
+//! way back is not symmetric — see [`from_storage_decimal`], which has to undo
+//! the scaling rather than read the mantissa verbatim.
+//!
+//! # Why the timestamps are `DateTime64(9)`
+//!
+//! Same reason. `start_at` arrives from a client as RFC 3339 and may carry
+//! sub-millisecond precision, and every simulated instant is derived from it,
+//! so millisecond columns would truncate a value the client can observe. Nanos
+//! cover the years 1678–2262, which is past any simulated horizon; an instant
+//! outside that range is a typed error.
+
+use super::record::{ContractQuote, ContractSide, ExpirationRecord, QuoteRow, SnapshotRecord};
+use crate::utils::ChainError;
+use chrono::{DateTime, Utc};
+use clickhouse::Row;
+use positive::Positive;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// The scale every decimal column is stored at.
+///
+/// Matches `rust_decimal`'s maximum, so no value written here is ever rounded.
+pub(crate) const DECIMAL_SCALE: u32 = 28;
+
+/// The table holding one row per materialised step.
+pub(crate) const SNAPSHOTS_TABLE: &str = "simulation_snapshots";
+
+/// The table holding one row per step, expiration and strike.
+pub(crate) const QUOTES_TABLE: &str = "simulation_option_quotes";
+
+/// One row of [`SNAPSHOTS_TABLE`]: the metadata and completion marker of one
+/// step.
+///
+/// Written **after** every quote row of the same snapshot has been accepted, so
+/// its presence is the signal that the snapshot is whole. `quote_count` is the
+/// audit that goes with the signal.
+#[derive(Debug, Clone, PartialEq, Row, Serialize, Deserialize)]
+pub(crate) struct SnapshotMetaRow {
+    /// The simulation's id, as text.
+    pub(crate) simulation_id: String,
+    /// The generation the snapshot was produced under.
+    pub(crate) simulation_generation: u64,
+    /// The 0-based step.
+    pub(crate) step: u64,
+    /// The deterministic snapshot identity, as text.
+    pub(crate) snapshot_id: String,
+    /// The simulated instant, as unix nanoseconds (`DateTime64(9)`).
+    pub(crate) simulated_at: i64,
+    /// The ticker symbol.
+    pub(crate) symbol: String,
+    /// The underlying price, scaled by `10^28`.
+    pub(crate) underlying_price: i128,
+    /// The base implied volatility, scaled by `10^28`.
+    pub(crate) base_volatility: i128,
+    /// How many quote rows belong to this snapshot.
+    pub(crate) quote_count: u64,
+    /// How many expirations belong to this snapshot.
+    pub(crate) expiration_count: u64,
+    /// The completion marker. Only ever written `true`; a reader that finds no
+    /// row at all, or a row whose `quote_count` disagrees with the rows on
+    /// disk, treats the snapshot as absent.
+    pub(crate) complete: bool,
+    /// Ingestion time, as unix milliseconds.
+    ///
+    /// Doubles as the `ReplacingMergeTree` version — the newest write of a
+    /// coordinate wins — and as the anchor of the retention TTL. Two writes
+    /// inside the same millisecond tie, which is harmless: a snapshot is
+    /// deterministic, so the tied rows are identical.
+    pub(crate) inserted_at_ms: u64,
+}
+
+/// One row of [`QUOTES_TABLE`]: one strike of one expiration at one step.
+///
+/// Snapshot-level values (`snapshot_id`, `simulated_at`, `symbol`) are repeated
+/// on every row deliberately: they cost almost nothing after compression —
+/// every row in a part shares them — and they let a contract history be served
+/// without joining the metadata table.
+#[derive(Debug, Clone, PartialEq, Row, Serialize, Deserialize)]
+pub(crate) struct OptionQuoteRow {
+    /// The simulation's id, as text.
+    pub(crate) simulation_id: String,
+    /// The generation the snapshot was produced under.
+    pub(crate) simulation_generation: u64,
+    /// The 0-based step.
+    pub(crate) step: u64,
+    /// The absolute expiration, as unix nanoseconds (`DateTime64(9)`).
+    pub(crate) expires_at: i64,
+    /// The strike, scaled by `10^28`.
+    pub(crate) strike: i128,
+    /// The deterministic snapshot identity, as text.
+    pub(crate) snapshot_id: String,
+    /// The simulated instant, as unix nanoseconds (`DateTime64(9)`).
+    pub(crate) simulated_at: i64,
+    /// The ticker symbol.
+    pub(crate) symbol: String,
+    /// Fractional days to expiration, scaled by `10^28`.
+    pub(crate) days_to_expiration: i128,
+    /// Every schedule rule this expiration satisfies, sorted.
+    pub(crate) labels: Vec<String>,
+    /// The per-strike implied volatility, scaled by `10^28`.
+    pub(crate) implied_volatility: i128,
+    /// The call bid, scaled by `10^28`.
+    pub(crate) call_bid: Option<i128>,
+    /// The call ask, scaled by `10^28`.
+    pub(crate) call_ask: Option<i128>,
+    /// The call mid, scaled by `10^28`.
+    pub(crate) call_mid: Option<i128>,
+    /// The put bid, scaled by `10^28`.
+    pub(crate) put_bid: Option<i128>,
+    /// The put ask, scaled by `10^28`.
+    pub(crate) put_ask: Option<i128>,
+    /// The put mid, scaled by `10^28`.
+    pub(crate) put_mid: Option<i128>,
+    /// The call delta, scaled by `10^28`.
+    pub(crate) delta_call: Option<i128>,
+    /// The put delta, scaled by `10^28`.
+    pub(crate) delta_put: Option<i128>,
+    /// Gamma, scaled by `10^28`.
+    pub(crate) gamma: Option<i128>,
+    /// Ingestion time, as unix milliseconds. See [`SnapshotMetaRow`].
+    pub(crate) inserted_at_ms: u64,
+}
+
+/// The metadata columns a read selects, in the order the query lists them.
+#[derive(Debug, Clone, PartialEq, Row, Deserialize)]
+pub(crate) struct SnapshotMetaReadRow {
+    /// The 0-based step.
+    pub(crate) step: u64,
+    /// The deterministic snapshot identity, as text.
+    pub(crate) snapshot_id: String,
+    /// The simulated instant, as unix nanoseconds.
+    pub(crate) simulated_at: i64,
+    /// The ticker symbol.
+    pub(crate) symbol: String,
+    /// The underlying price, scaled by `10^28`.
+    pub(crate) underlying_price: i128,
+    /// The base implied volatility, scaled by `10^28`.
+    pub(crate) base_volatility: i128,
+    /// How many quote rows the writer said belong to this snapshot.
+    pub(crate) quote_count: u64,
+}
+
+/// The quote columns a whole-snapshot read selects, in query order.
+#[derive(Debug, Clone, PartialEq, Row, Deserialize)]
+pub(crate) struct QuoteReadRow {
+    /// The 0-based step.
+    pub(crate) step: u64,
+    /// The absolute expiration, as unix nanoseconds.
+    pub(crate) expires_at: i64,
+    /// Fractional days to expiration, scaled by `10^28`.
+    pub(crate) days_to_expiration: i128,
+    /// Every schedule rule this expiration satisfies, sorted.
+    pub(crate) labels: Vec<String>,
+    /// The strike, scaled by `10^28`.
+    pub(crate) strike: i128,
+    /// The per-strike implied volatility, scaled by `10^28`.
+    pub(crate) implied_volatility: i128,
+    /// The call bid, scaled by `10^28`.
+    pub(crate) call_bid: Option<i128>,
+    /// The call ask, scaled by `10^28`.
+    pub(crate) call_ask: Option<i128>,
+    /// The call mid, scaled by `10^28`.
+    pub(crate) call_mid: Option<i128>,
+    /// The put bid, scaled by `10^28`.
+    pub(crate) put_bid: Option<i128>,
+    /// The put ask, scaled by `10^28`.
+    pub(crate) put_ask: Option<i128>,
+    /// The put mid, scaled by `10^28`.
+    pub(crate) put_mid: Option<i128>,
+    /// The call delta, scaled by `10^28`.
+    pub(crate) delta_call: Option<i128>,
+    /// The put delta, scaled by `10^28`.
+    pub(crate) delta_put: Option<i128>,
+    /// Gamma, scaled by `10^28`.
+    pub(crate) gamma: Option<i128>,
+}
+
+/// The columns a contract-history read selects, in query order.
+///
+/// The side is chosen by the query — `call_bid AS bid` or `put_bid AS bid` —
+/// so one row type serves both.
+#[derive(Debug, Clone, PartialEq, Row, Deserialize)]
+pub(crate) struct ContractReadRow {
+    /// The 0-based step.
+    pub(crate) step: u64,
+    /// The simulated instant, as unix nanoseconds.
+    pub(crate) simulated_at: i64,
+    /// The absolute expiration, as unix nanoseconds.
+    pub(crate) expires_at: i64,
+    /// Fractional days to expiration, scaled by `10^28`.
+    pub(crate) days_to_expiration: i128,
+    /// The strike, scaled by `10^28`.
+    pub(crate) strike: i128,
+    /// The per-strike implied volatility, scaled by `10^28`.
+    pub(crate) implied_volatility: i128,
+    /// The selected side's bid, scaled by `10^28`.
+    pub(crate) bid: Option<i128>,
+    /// The selected side's ask, scaled by `10^28`.
+    pub(crate) ask: Option<i128>,
+    /// The selected side's mid, scaled by `10^28`.
+    pub(crate) mid: Option<i128>,
+    /// The selected side's delta, scaled by `10^28`.
+    pub(crate) delta: Option<i128>,
+    /// Gamma, scaled by `10^28`.
+    pub(crate) gamma: Option<i128>,
+}
+
+/// Scales a decimal into the `Int128` a `Decimal(38, 28)` column carries.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] naming `field` when the value's
+/// integer part is too large for the column — above roughly ten billion — since
+/// truncating a price is never the right answer.
+pub(crate) fn to_storage_decimal(value: Decimal, field: &str) -> Result<i128, ChainError> {
+    // `rust_decimal` caps its scale at 28, so the shift is always defined; the
+    // checked form keeps that assumption honest if the crate ever changes.
+    let shift = DECIMAL_SCALE.checked_sub(value.scale()).ok_or_else(|| {
+        ChainError::ClickHouseError(format!(
+            "{field} has scale {} beyond the storable {DECIMAL_SCALE}",
+            value.scale()
+        ))
+    })?;
+    let factor = 10_i128.checked_pow(shift).ok_or_else(|| {
+        ChainError::ClickHouseError(format!("{field} needs an unrepresentable scale factor"))
+    })?;
+
+    value.mantissa().checked_mul(factor).ok_or_else(|| {
+        ChainError::ClickHouseError(format!(
+            "{field} value {value} does not fit a Decimal(38, {DECIMAL_SCALE}) column"
+        ))
+    })
+}
+
+/// Reads back the `Int128` of a `Decimal(38, 28)` column.
+///
+/// # Why this strips zeros before rebuilding
+///
+/// A `Decimal` is a 96-bit mantissa with a scale, so it holds at most ~29
+/// significant digits — it can represent `5000.25`, but *not* the same number
+/// written as `5000.2500000000000000000000000000`, which needs 32. Scaling to
+/// 28 on the way in produces exactly that form, so rebuilding the mantissa
+/// verbatim would reject values the column stores perfectly well.
+///
+/// Stripping the trailing zeros first undoes the scaling: it recovers the
+/// smallest `(mantissa, scale)` pair for the value, which is representable
+/// precisely because the value came from a `Decimal` in the first place. The
+/// result is numerically identical either way — `Decimal` compares by value,
+/// not by representation.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] naming `field` when the stored value
+/// still needs more significant digits than a `Decimal` has — a column written
+/// by something other than this crate.
+pub(crate) fn from_storage_decimal(raw: i128, field: &str) -> Result<Decimal, ChainError> {
+    let mut mantissa = raw;
+    let mut scale = DECIMAL_SCALE;
+    while scale > 0 && mantissa % 10 == 0 {
+        mantissa /= 10;
+        scale -= 1;
+    }
+
+    Decimal::try_from_i128_with_scale(mantissa, scale).map_err(|error| {
+        ChainError::ClickHouseError(format!("{field} holds an unreadable decimal: {error}"))
+    })
+}
+
+/// Scales a positive value into its column form.
+///
+/// # Errors
+///
+/// As [`to_storage_decimal`].
+pub(crate) fn to_storage_positive(value: Positive, field: &str) -> Result<i128, ChainError> {
+    to_storage_decimal(value.to_dec(), field)
+}
+
+/// Reads back a positive value from its column form.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] naming `field` when the stored value
+/// is unreadable or negative — a negative premium means the column was written
+/// by something that is not this crate.
+pub(crate) fn from_storage_positive(raw: i128, field: &str) -> Result<Positive, ChainError> {
+    let value = from_storage_decimal(raw, field)?;
+    Positive::new_decimal(value).map_err(|error| {
+        ChainError::ClickHouseError(format!("{field} holds a non-positive value: {error}"))
+    })
+}
+
+/// Scales an optional decimal into its column form.
+///
+/// # Errors
+///
+/// As [`to_storage_decimal`].
+fn to_storage_optional(value: Option<Decimal>, field: &str) -> Result<Option<i128>, ChainError> {
+    value
+        .map(|value| to_storage_decimal(value, field))
+        .transpose()
+}
+
+/// Scales an optional positive value into its column form.
+///
+/// # Errors
+///
+/// As [`to_storage_decimal`].
+fn to_storage_optional_positive(
+    value: Option<Positive>,
+    field: &str,
+) -> Result<Option<i128>, ChainError> {
+    value
+        .map(|value| to_storage_positive(value, field))
+        .transpose()
+}
+
+/// Reads back an optional decimal.
+///
+/// # Errors
+///
+/// As [`from_storage_decimal`].
+fn from_storage_optional(raw: Option<i128>, field: &str) -> Result<Option<Decimal>, ChainError> {
+    raw.map(|raw| from_storage_decimal(raw, field)).transpose()
+}
+
+/// Reads back an optional positive value.
+///
+/// # Errors
+///
+/// As [`from_storage_positive`].
+fn from_storage_optional_positive(
+    raw: Option<i128>,
+    field: &str,
+) -> Result<Option<Positive>, ChainError> {
+    raw.map(|raw| from_storage_positive(raw, field)).transpose()
+}
+
+/// Converts an instant into the unix nanoseconds a `DateTime64(9)` carries.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] naming `field` when the instant
+/// falls outside 1678–2262, which nanosecond ticks cannot address.
+pub(crate) fn to_storage_instant(value: DateTime<Utc>, field: &str) -> Result<i64, ChainError> {
+    value.timestamp_nanos_opt().ok_or_else(|| {
+        ChainError::ClickHouseError(format!(
+            "{field} instant {value} is outside the storable 1678-2262 range"
+        ))
+    })
+}
+
+/// Reads back an instant from unix nanoseconds.
+///
+/// Infallible, unlike its counterpart: every `i64` tick names a real instant,
+/// so there is nothing left to reject on the way back.
+#[must_use]
+pub(crate) fn from_storage_instant(raw: i64) -> DateTime<Utc> {
+    DateTime::from_timestamp_nanos(raw)
+}
+
+/// Builds the completion marker for a snapshot.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] when a value does not fit its
+/// column, or [`ChainError::Validation`] when the step or a count is too large
+/// for its column.
+pub(crate) fn meta_row(
+    record: &SnapshotRecord,
+    inserted_at_ms: u64,
+) -> Result<SnapshotMetaRow, ChainError> {
+    Ok(SnapshotMetaRow {
+        simulation_id: record.simulation.to_string(),
+        simulation_generation: record.generation,
+        step: to_storage_count(record.step, "step")?,
+        snapshot_id: record.snapshot_id().to_string(),
+        simulated_at: to_storage_instant(record.simulated_at, "simulated_at")?,
+        symbol: record.symbol.clone(),
+        underlying_price: to_storage_positive(record.spot, "underlying_price")?,
+        base_volatility: to_storage_positive(record.base_volatility, "base_volatility")?,
+        quote_count: to_storage_count(record.quote_count(), "quote_count")?,
+        expiration_count: to_storage_count(record.expirations.len(), "expiration_count")?,
+        complete: true,
+        inserted_at_ms,
+    })
+}
+
+/// Flattens a snapshot into its quote rows, in storage order.
+///
+/// The order is the record's own — expirations ascending, strikes ascending —
+/// which is also the table's sorting key, so one snapshot inserts as one
+/// already-sorted block.
+///
+/// # Errors
+///
+/// As [`meta_row`].
+pub(crate) fn quote_rows(
+    record: &SnapshotRecord,
+    inserted_at_ms: u64,
+) -> Result<Vec<OptionQuoteRow>, ChainError> {
+    let simulation_id = record.simulation.to_string();
+    let snapshot_id = record.snapshot_id().to_string();
+    let simulated_at = to_storage_instant(record.simulated_at, "simulated_at")?;
+    let step = to_storage_count(record.step, "step")?;
+
+    let mut rows = Vec::with_capacity(record.quote_count());
+    for expiration in &record.expirations {
+        let expires_at = to_storage_instant(expiration.expires_at, "expires_at")?;
+        let days_to_expiration =
+            to_storage_positive(expiration.days_to_expiration, "days_to_expiration")?;
+
+        for quote in &expiration.quotes {
+            rows.push(OptionQuoteRow {
+                simulation_id: simulation_id.clone(),
+                simulation_generation: record.generation,
+                step,
+                expires_at,
+                strike: to_storage_positive(quote.strike, "strike")?,
+                snapshot_id: snapshot_id.clone(),
+                simulated_at,
+                symbol: record.symbol.clone(),
+                days_to_expiration,
+                labels: expiration.labels.clone(),
+                implied_volatility: to_storage_positive(
+                    quote.implied_volatility,
+                    "implied_volatility",
+                )?,
+                call_bid: to_storage_optional_positive(quote.call_bid, "call_bid")?,
+                call_ask: to_storage_optional_positive(quote.call_ask, "call_ask")?,
+                call_mid: to_storage_optional_positive(quote.call_mid, "call_mid")?,
+                put_bid: to_storage_optional_positive(quote.put_bid, "put_bid")?,
+                put_ask: to_storage_optional_positive(quote.put_ask, "put_ask")?,
+                put_mid: to_storage_optional_positive(quote.put_mid, "put_mid")?,
+                delta_call: to_storage_optional(quote.delta_call, "delta_call")?,
+                delta_put: to_storage_optional(quote.delta_put, "delta_put")?,
+                gamma: to_storage_optional(quote.gamma, "gamma")?,
+                inserted_at_ms,
+            });
+        }
+    }
+
+    Ok(rows)
+}
+
+/// Rebuilds a snapshot from the rows one step selected.
+///
+/// `quotes` must be the rows of exactly that step, ordered by expiration and
+/// then strike — the order every read query asks for. Rows sharing an
+/// expiration are adjacent, which is what lets the grouping be a single pass.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] when a column is unreadable, or when
+/// the stored `snapshot_id` is not the one this coordinate derives — a row
+/// written under a different identity scheme, which must never be served as if
+/// it were this simulation's.
+pub(crate) fn record_from_rows(
+    simulation: Uuid,
+    generation: u64,
+    meta: &SnapshotMetaReadRow,
+    quotes: &[QuoteReadRow],
+) -> Result<SnapshotRecord, ChainError> {
+    let step = usize::try_from(meta.step).map_err(|_| {
+        ChainError::ClickHouseError(format!("step {} is not addressable here", meta.step))
+    })?;
+
+    let expected_id = super::record::snapshot_id(simulation, generation, step);
+    if meta.snapshot_id != expected_id.to_string() {
+        return Err(ChainError::ClickHouseError(format!(
+            "snapshot {simulation}/{generation}/{step} is stored under identity {} instead of \
+             {expected_id}",
+            meta.snapshot_id
+        )));
+    }
+
+    let mut expirations: Vec<ExpirationRecord> = Vec::new();
+    for row in quotes {
+        let expires_at = from_storage_instant(row.expires_at);
+        let quote = quote_from_row(row)?;
+
+        match expirations.last_mut() {
+            Some(current) if current.expires_at == expires_at => current.quotes.push(quote),
+            _ => expirations.push(ExpirationRecord {
+                expires_at,
+                days_to_expiration: from_storage_positive(
+                    row.days_to_expiration,
+                    "days_to_expiration",
+                )?,
+                labels: row.labels.clone(),
+                quotes: vec![quote],
+            }),
+        }
+    }
+
+    Ok(SnapshotRecord {
+        simulation,
+        generation,
+        step,
+        simulated_at: from_storage_instant(meta.simulated_at),
+        symbol: meta.symbol.clone(),
+        spot: from_storage_positive(meta.underlying_price, "underlying_price")?,
+        base_volatility: from_storage_positive(meta.base_volatility, "base_volatility")?,
+        expirations,
+    })
+}
+
+/// Rebuilds one strike from its stored row.
+///
+/// # Errors
+///
+/// As [`from_storage_decimal`].
+fn quote_from_row(row: &QuoteReadRow) -> Result<QuoteRow, ChainError> {
+    Ok(QuoteRow {
+        strike: from_storage_positive(row.strike, "strike")?,
+        implied_volatility: from_storage_positive(row.implied_volatility, "implied_volatility")?,
+        call_bid: from_storage_optional_positive(row.call_bid, "call_bid")?,
+        call_ask: from_storage_optional_positive(row.call_ask, "call_ask")?,
+        call_mid: from_storage_optional_positive(row.call_mid, "call_mid")?,
+        put_bid: from_storage_optional_positive(row.put_bid, "put_bid")?,
+        put_ask: from_storage_optional_positive(row.put_ask, "put_ask")?,
+        put_mid: from_storage_optional_positive(row.put_mid, "put_mid")?,
+        delta_call: from_storage_optional(row.delta_call, "delta_call")?,
+        delta_put: from_storage_optional(row.delta_put, "delta_put")?,
+        gamma: from_storage_optional(row.gamma, "gamma")?,
+    })
+}
+
+/// Rebuilds one point of a contract's history.
+///
+/// # Errors
+///
+/// As [`from_storage_decimal`].
+pub(crate) fn contract_quote_from_row(
+    row: &ContractReadRow,
+    side: ContractSide,
+) -> Result<ContractQuote, ChainError> {
+    Ok(ContractQuote {
+        step: usize::try_from(row.step).map_err(|_| {
+            ChainError::ClickHouseError(format!("step {} is not addressable here", row.step))
+        })?,
+        simulated_at: from_storage_instant(row.simulated_at),
+        expires_at: from_storage_instant(row.expires_at),
+        days_to_expiration: from_storage_positive(row.days_to_expiration, "days_to_expiration")?,
+        strike: from_storage_positive(row.strike, "strike")?,
+        side,
+        implied_volatility: from_storage_positive(row.implied_volatility, "implied_volatility")?,
+        bid: from_storage_optional_positive(row.bid, "bid")?,
+        ask: from_storage_optional_positive(row.ask, "ask")?,
+        mid: from_storage_optional_positive(row.mid, "mid")?,
+        delta: from_storage_optional(row.delta, "delta")?,
+        gamma: from_storage_optional(row.gamma, "gamma")?,
+    })
+}
+
+/// Narrows a count into the `UInt64` its column carries.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `field` when the count does not
+/// fit, which cannot happen on a 64-bit target and is checked anyway rather
+/// than cast.
+fn to_storage_count(value: usize, field: &str) -> Result<u64, ChainError> {
+    u64::try_from(value).map_err(|_| ChainError::Validation {
+        field: field.to_string(),
+        reason: format!("{value} does not fit a UInt64 column"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Timelike};
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+    use std::str::FromStr;
+
+    fn instant(day: u32) -> DateTime<Utc> {
+        match Utc.with_ymd_and_hms(2026, 1, day, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        }
+    }
+
+    /// A quote whose values are deliberately awkward: a 28-digit premium, a
+    /// negative delta, a missing put side.
+    fn quote(strike: f64) -> QuoteRow {
+        let long = match Decimal::from_str("1.2345678901234567890123456789") {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture decimal must parse: {error}"),
+        };
+        let long_positive = match Positive::new_decimal(long) {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture premium must be positive: {error}"),
+        };
+
+        QuoteRow::new(pos_or_panic!(strike), pos_or_panic!(0.185))
+            .with_call(
+                Some(long_positive),
+                Some(pos_or_panic!(1.3)),
+                Some(pos_or_panic!(1.25)),
+                Some(dec!(0.5123)),
+            )
+            .with_put(None, Some(pos_or_panic!(1.1)), None, Some(dec!(-0.4877)))
+            .with_gamma(Some(dec!(0.00312345)))
+    }
+
+    fn expiration(day: u32, strikes: &[f64]) -> ExpirationRecord {
+        ExpirationRecord::new(
+            instant(day),
+            pos_or_panic!(f64::from(day)),
+            vec!["weeklies".to_string(), "zero_dte".to_string()],
+            strikes.iter().copied().map(quote).collect(),
+        )
+    }
+
+    fn record() -> SnapshotRecord {
+        SnapshotRecord::new(
+            Uuid::from_u128(42),
+            3,
+            7,
+            instant(5),
+            "SPX".to_string(),
+            pos_or_panic!(5000.25),
+            pos_or_panic!(0.18),
+            vec![
+                expiration(6, &[4975.0, 5000.0, 5025.0]),
+                expiration(9, &[4975.0, 5000.0]),
+            ],
+        )
+    }
+
+    /// The rows a read would produce for a written snapshot.
+    ///
+    /// The whole point of the round-trip tests: the storage rows are turned
+    /// back into the read rows the SELECTs project, without a server.
+    fn read_rows(record: &SnapshotRecord) -> (SnapshotMetaReadRow, Vec<QuoteReadRow>) {
+        let meta = match meta_row(record, 1_700_000_000_000) {
+            Ok(row) => row,
+            Err(error) => panic!("the fixture must convert: {error}"),
+        };
+        let quotes = match quote_rows(record, 1_700_000_000_000) {
+            Ok(rows) => rows,
+            Err(error) => panic!("the fixture must convert: {error}"),
+        };
+
+        let meta = SnapshotMetaReadRow {
+            step: meta.step,
+            snapshot_id: meta.snapshot_id,
+            simulated_at: meta.simulated_at,
+            symbol: meta.symbol,
+            underlying_price: meta.underlying_price,
+            base_volatility: meta.base_volatility,
+            quote_count: meta.quote_count,
+        };
+        let quotes = quotes
+            .into_iter()
+            .map(|row| QuoteReadRow {
+                step: row.step,
+                expires_at: row.expires_at,
+                days_to_expiration: row.days_to_expiration,
+                labels: row.labels,
+                strike: row.strike,
+                implied_volatility: row.implied_volatility,
+                call_bid: row.call_bid,
+                call_ask: row.call_ask,
+                call_mid: row.call_mid,
+                put_bid: row.put_bid,
+                put_ask: row.put_ask,
+                put_mid: row.put_mid,
+                delta_call: row.delta_call,
+                delta_put: row.delta_put,
+                gamma: row.gamma,
+            })
+            .collect();
+
+        (meta, quotes)
+    }
+
+    /// A decimal survives the column exactly, including all 28 digits.
+    #[test]
+    fn test_a_decimal_round_trips_exactly() {
+        let values = [
+            dec!(0),
+            dec!(5000.25),
+            dec!(-0.4877),
+            dec!(0.00000000000000000000000001),
+            match Decimal::from_str("1.2345678901234567890123456789") {
+                Ok(value) => value,
+                Err(error) => panic!("the fixture decimal must parse: {error}"),
+            },
+        ];
+
+        for value in values {
+            let raw = match to_storage_decimal(value, "test") {
+                Ok(raw) => raw,
+                Err(error) => panic!("{value} must be storable: {error}"),
+            };
+            match from_storage_decimal(raw, "test") {
+                Ok(read) => assert_eq!(read, value, "{value} did not survive the column"),
+                Err(error) => panic!("{value} must be readable: {error}"),
+            }
+        }
+    }
+
+    /// The scale is the one that never truncates a `rust_decimal`.
+    #[test]
+    fn test_the_scale_matches_the_decimal_maximum() {
+        assert_eq!(DECIMAL_SCALE, 28);
+    }
+
+    /// A value past the column's ten-digit integer ceiling is a typed error,
+    /// never a wrapped number.
+    #[test]
+    fn test_an_oversized_decimal_is_rejected() {
+        let huge = match Decimal::from_str("100000000000") {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture decimal must parse: {error}"),
+        };
+
+        match to_storage_decimal(huge, "underlying_price") {
+            Err(ChainError::ClickHouseError(message)) => {
+                assert!(message.contains("underlying_price"), "{message}");
+            }
+            other => panic!("expected a ClickHouse error, got {other:?}"),
+        }
+    }
+
+    /// An instant survives the column to the nanosecond, which is what a
+    /// client-supplied `start_at` can carry.
+    #[test]
+    fn test_an_instant_round_trips_to_the_nanosecond() {
+        let precise = match instant(5).with_nanosecond(123_456_789) {
+            Some(value) => value,
+            None => panic!("the fixture nanosecond must be valid"),
+        };
+
+        let raw = match to_storage_instant(precise, "simulated_at") {
+            Ok(raw) => raw,
+            Err(error) => panic!("the instant must be storable: {error}"),
+        };
+        assert_eq!(from_storage_instant(raw), precise);
+    }
+
+    /// A snapshot flattens into exactly its quote count, in sorted order.
+    #[test]
+    fn test_a_snapshot_flattens_into_its_quote_count() {
+        let record = record();
+        let rows = match quote_rows(&record, 1) {
+            Ok(rows) => rows,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+
+        assert_eq!(rows.len(), record.quote_count());
+        assert_eq!(rows.len(), 5);
+        for pair in rows.windows(2) {
+            if let [left, right] = pair {
+                assert!(
+                    (left.expires_at, left.strike) < (right.expires_at, right.strike),
+                    "rows must be written in the table's sorting order"
+                );
+            }
+        }
+    }
+
+    /// Every row carries the snapshot's identity, so a quote can be traced back
+    /// without joining.
+    #[test]
+    fn test_every_quote_row_carries_the_snapshot_identity() {
+        let record = record();
+        let expected = record.snapshot_id().to_string();
+        let rows = match quote_rows(&record, 9) {
+            Ok(rows) => rows,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+
+        for row in &rows {
+            assert_eq!(row.snapshot_id, expected);
+            assert_eq!(row.simulation_id, record.simulation.to_string());
+            assert_eq!(row.simulation_generation, record.generation);
+            assert_eq!(row.inserted_at_ms, 9);
+        }
+    }
+
+    /// The marker carries the count and the completion flag a reader checks.
+    #[test]
+    fn test_the_marker_carries_the_expected_counts() {
+        let record = record();
+        let meta = match meta_row(&record, 5) {
+            Ok(row) => row,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+
+        assert!(meta.complete);
+        assert_eq!(meta.quote_count, 5);
+        assert_eq!(meta.expiration_count, 2);
+        assert_eq!(meta.snapshot_id, record.snapshot_id().to_string());
+        assert_eq!(meta.inserted_at_ms, 5);
+    }
+
+    /// The acceptance criterion, without a server: a snapshot written and read
+    /// back is the snapshot that was written — every timestamp, label, strike,
+    /// premium, Greek and `None`.
+    #[test]
+    fn test_a_snapshot_round_trips_through_the_row_types() {
+        let original = record();
+        let (meta, quotes) = read_rows(&original);
+
+        match record_from_rows(original.simulation, original.generation, &meta, &quotes) {
+            Ok(reconstructed) => assert_eq!(reconstructed, original),
+            Err(error) => panic!("the snapshot must reconstruct: {error}"),
+        }
+    }
+
+    /// An empty snapshot reconstructs as an empty snapshot rather than failing.
+    #[test]
+    fn test_an_empty_snapshot_round_trips() {
+        let mut original = record();
+        original.expirations.clear();
+        let (meta, quotes) = read_rows(&original);
+
+        assert!(quotes.is_empty());
+        match record_from_rows(original.simulation, original.generation, &meta, &quotes) {
+            Ok(reconstructed) => assert_eq!(reconstructed, original),
+            Err(error) => panic!("the snapshot must reconstruct: {error}"),
+        }
+    }
+
+    /// Rows stored under a different identity scheme are refused rather than
+    /// served as this simulation's.
+    #[test]
+    fn test_a_foreign_snapshot_identity_is_refused() {
+        let original = record();
+        let (mut meta, quotes) = read_rows(&original);
+        meta.snapshot_id = Uuid::from_u128(1).to_string();
+
+        match record_from_rows(original.simulation, original.generation, &meta, &quotes) {
+            Err(ChainError::ClickHouseError(message)) => {
+                assert!(message.contains("stored under identity"), "{message}");
+            }
+            other => panic!("expected a ClickHouse error, got {other:?}"),
+        }
+    }
+
+    /// A contract row rebuilds the side the query selected.
+    #[test]
+    fn test_a_contract_row_rebuilds_its_side() {
+        let row = ContractReadRow {
+            step: 7,
+            simulated_at: match to_storage_instant(instant(5), "simulated_at") {
+                Ok(raw) => raw,
+                Err(error) => panic!("the fixture instant must convert: {error}"),
+            },
+            expires_at: match to_storage_instant(instant(9), "expires_at") {
+                Ok(raw) => raw,
+                Err(error) => panic!("the fixture instant must convert: {error}"),
+            },
+            days_to_expiration: match to_storage_decimal(dec!(4.0), "days_to_expiration") {
+                Ok(raw) => raw,
+                Err(error) => panic!("the fixture decimal must convert: {error}"),
+            },
+            strike: match to_storage_decimal(dec!(5000), "strike") {
+                Ok(raw) => raw,
+                Err(error) => panic!("the fixture decimal must convert: {error}"),
+            },
+            implied_volatility: match to_storage_decimal(dec!(0.18), "implied_volatility") {
+                Ok(raw) => raw,
+                Err(error) => panic!("the fixture decimal must convert: {error}"),
+            },
+            bid: None,
+            ask: None,
+            mid: None,
+            delta: match to_storage_decimal(dec!(-0.4877), "delta") {
+                Ok(raw) => Some(raw),
+                Err(error) => panic!("the fixture decimal must convert: {error}"),
+            },
+            gamma: None,
+        };
+
+        match contract_quote_from_row(&row, ContractSide::Put) {
+            Ok(quote) => {
+                assert_eq!(quote.side, ContractSide::Put);
+                assert_eq!(quote.step, 7);
+                assert_eq!(quote.strike, pos_or_panic!(5000.0));
+                assert_eq!(quote.delta, Some(dec!(-0.4877)));
+                assert_eq!(quote.bid, None);
+            }
+            Err(error) => panic!("the contract row must rebuild: {error}"),
+        }
+    }
+}

--- a/src/infrastructure/clickhouse/snapshots/record.rs
+++ b/src/infrastructure/clickhouse/snapshots/record.rs
@@ -1,0 +1,648 @@
+//! The typed records the snapshot repository persists and returns.
+//!
+//! These are **infrastructure** types, not the domain snapshot. `src/domain` is
+//! a private module and `SeriesSnapshot`/`ExpiryChain` are `pub(crate)` inside
+//! it, so this layer cannot name them — and should not: a storage record has to
+//! survive a schema migration and a driver upgrade without dragging the
+//! simulation's internals along. The session layer, which can see both, owns
+//! the conversion from a built snapshot into a [`SnapshotRecord`].
+//!
+//! Everything here stays typed — `Positive`, `Decimal`, `DateTime<Utc>`,
+//! `Uuid` — up to the serialization boundary in
+//! [`super::model`], which is the single place a value becomes a ClickHouse
+//! column.
+//!
+//! # What identifies a snapshot
+//!
+//! `(simulation, generation, step)`. Deliberately **not** called a version: a
+//! v2 session already has a `version`, the optimistic-concurrency revision that
+//! changes on every advance and travels on the wire. Feeding that number in here
+//! would fragment one tape across hundreds of coordinates and defeat the whole
+//! retry-safe deduplication, so the field carries the name of what it actually
+//! is — see [`CURRENT_SNAPSHOT_GENERATION`].
+//!
+//! Everything in this module treats two writes of the same triple as two
+//! attempts at the *same* immutable snapshot.
+
+use crate::utils::ChainError;
+use chrono::{DateTime, Utc};
+use positive::Positive;
+use rust_decimal::Decimal;
+use std::fmt;
+use uuid::Uuid;
+
+/// The generation every snapshot this build produces is written under.
+///
+/// A snapshot's coordinate is `(simulation, generation, step)`, and the
+/// invariant the storage layer rests on is that the coordinate determines the
+/// snapshot: two writes of it are two attempts at the same immutable rows, and
+/// the second silently replaces the first.
+///
+/// The generation is what keeps that true across time. Bump it when a change to
+/// this crate would make the *same* simulation and step produce *different*
+/// values — a pricing fix, a walk-kernel resync, a change to the schedule
+/// projection. Rows written under the old generation then stay addressable and
+/// are never mixed with the new ones, rather than being half-overwritten by a
+/// replay that no longer agrees with them.
+///
+/// A caller materialising snapshots passes this constant; a caller reading them
+/// back passes the generation the rows were written under, which for everything
+/// this build wrote is this one. It lives here, next to the records, so an
+/// external consumer of the `pub` read API has a name to pass instead of a
+/// hardcoded literal.
+pub const CURRENT_SNAPSHOT_GENERATION: u64 = 1;
+
+/// The namespace every deterministic `snapshot_id` is derived under.
+///
+/// The ASCII bytes of `ocs-snapshot-v1`, padded to sixteen. Fixed forever: a
+/// new namespace would give every already-persisted snapshot a second identity,
+/// and every retry a duplicate.
+const SNAPSHOT_NAMESPACE: Uuid = Uuid::from_u128(0x6f_63_73_2d_73_6e_61_70_73_68_6f_74_2d_76_31_00);
+
+/// The deterministic identity of one materialised snapshot.
+///
+/// A UUID v5 over `(simulation, generation, step)` — the same primitive
+/// [`crate::utils::UuidGenerator`] uses (`Uuid::new_v5`), applied to a
+/// coordinate instead of to a counter, because a retry has to land on the id
+/// the first attempt used. `UuidGenerator` itself cannot serve this: its name
+/// is an internal counter, so two processes replaying the same step would
+/// disagree.
+///
+/// # Examples
+///
+/// ```
+/// use optionchain_simulator::infrastructure::{CURRENT_SNAPSHOT_GENERATION, snapshot_id};
+/// use uuid::Uuid;
+///
+/// let simulation = Uuid::nil();
+/// let generation = CURRENT_SNAPSHOT_GENERATION;
+/// assert_eq!(
+///     snapshot_id(simulation, generation, 7),
+///     snapshot_id(simulation, generation, 7)
+/// );
+/// assert_ne!(
+///     snapshot_id(simulation, generation, 7),
+///     snapshot_id(simulation, generation + 1, 7)
+/// );
+/// ```
+#[must_use]
+#[inline]
+pub fn snapshot_id(simulation: Uuid, generation: u64, step: usize) -> Uuid {
+    // The separators matter: without them `(1, 23)` and `(12, 3)` would hash
+    // to the same name.
+    let name = format!("{simulation}:{generation}:{step}");
+    Uuid::new_v5(&SNAPSHOT_NAMESPACE, name.as_bytes())
+}
+
+/// Which side of a strike a query is about.
+///
+/// Both sides live in one persisted row — they share the strike, the implied
+/// volatility and the gamma — so the side is a projection at read time, never a
+/// storage dimension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum ContractSide {
+    /// The call side.
+    Call,
+    /// The put side.
+    Put,
+}
+
+impl ContractSide {
+    /// The side's lowercase name, for logs and query construction.
+    #[must_use]
+    #[inline]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ContractSide::Call => "call",
+            ContractSide::Put => "put",
+        }
+    }
+}
+
+impl fmt::Display for ContractSide {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One strike of one expiration, both sides.
+///
+/// Mirrors upstream `OptionData` exactly as far as the v2 surface goes:
+/// upstream carries delta per side and one shared gamma, and no other Greek, so
+/// neither does this. A new upstream Greek is a schema change, deliberately.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuoteRow {
+    /// The strike price.
+    pub strike: Positive,
+    /// The per-strike implied volatility, after skew and smile.
+    pub implied_volatility: Positive,
+    /// The call bid, when upstream quoted one.
+    pub call_bid: Option<Positive>,
+    /// The call ask, when upstream quoted one.
+    pub call_ask: Option<Positive>,
+    /// The call mid, when upstream quoted one.
+    pub call_mid: Option<Positive>,
+    /// The put bid, when upstream quoted one.
+    pub put_bid: Option<Positive>,
+    /// The put ask, when upstream quoted one.
+    pub put_ask: Option<Positive>,
+    /// The put mid, when upstream quoted one.
+    pub put_mid: Option<Positive>,
+    /// The call delta.
+    pub delta_call: Option<Decimal>,
+    /// The put delta.
+    pub delta_put: Option<Decimal>,
+    /// Gamma, shared by the call and the put.
+    pub gamma: Option<Decimal>,
+}
+
+impl QuoteRow {
+    /// Creates a quote row with no quotes and no Greeks.
+    ///
+    /// The builder-style setters exist for tests and for a caller that has only
+    /// part of a chain; production callers construct the struct literally from
+    /// an upstream `OptionData`.
+    #[must_use]
+    pub fn new(strike: Positive, implied_volatility: Positive) -> Self {
+        Self {
+            strike,
+            implied_volatility,
+            call_bid: None,
+            call_ask: None,
+            call_mid: None,
+            put_bid: None,
+            put_ask: None,
+            put_mid: None,
+            delta_call: None,
+            delta_put: None,
+            gamma: None,
+        }
+    }
+
+    /// Sets the call side.
+    #[must_use = "builders do nothing unless the value is used"]
+    pub fn with_call(
+        mut self,
+        bid: Option<Positive>,
+        ask: Option<Positive>,
+        mid: Option<Positive>,
+        delta: Option<Decimal>,
+    ) -> Self {
+        self.call_bid = bid;
+        self.call_ask = ask;
+        self.call_mid = mid;
+        self.delta_call = delta;
+        self
+    }
+
+    /// Sets the put side.
+    #[must_use = "builders do nothing unless the value is used"]
+    pub fn with_put(
+        mut self,
+        bid: Option<Positive>,
+        ask: Option<Positive>,
+        mid: Option<Positive>,
+        delta: Option<Decimal>,
+    ) -> Self {
+        self.put_bid = bid;
+        self.put_ask = ask;
+        self.put_mid = mid;
+        self.delta_put = delta;
+        self
+    }
+
+    /// Sets the shared gamma.
+    #[must_use = "builders do nothing unless the value is used"]
+    pub fn with_gamma(mut self, gamma: Option<Decimal>) -> Self {
+        self.gamma = gamma;
+        self
+    }
+}
+
+/// One live expiration at one step, with every strike it quotes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpirationRecord {
+    /// The absolute expiration instant, in UTC. The authoritative expiration:
+    /// it comes from the planner, never from a chain's calendar string.
+    pub expires_at: DateTime<Utc>,
+    /// Fractional days remaining, from the same `(simulated_at, expires_at)`
+    /// pair the planner used.
+    pub days_to_expiration: Positive,
+    /// Every schedule rule this expiration satisfies, sorted. A date claimed by
+    /// two rules appears once, with both labels.
+    pub labels: Vec<String>,
+    /// The strikes, ascending.
+    pub quotes: Vec<QuoteRow>,
+}
+
+impl ExpirationRecord {
+    /// Creates an expiration record.
+    #[must_use]
+    pub fn new(
+        expires_at: DateTime<Utc>,
+        days_to_expiration: Positive,
+        labels: Vec<String>,
+        quotes: Vec<QuoteRow>,
+    ) -> Self {
+        Self {
+            expires_at,
+            days_to_expiration,
+            labels,
+            quotes,
+        }
+    }
+}
+
+/// One materialised simulation step: the whole simulated market at one instant.
+///
+/// This is the unit the repository persists and returns. Reconstructing it from
+/// storage must yield exactly what was written — the same ordering, the same
+/// decimals, the same `None`s — which is what makes the persisted tape usable
+/// as the source for #49's exports instead of a replay.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SnapshotRecord {
+    /// The simulation this snapshot belongs to.
+    pub simulation: Uuid,
+    /// The generation the snapshot was produced under —
+    /// [`CURRENT_SNAPSHOT_GENERATION`] for anything this build materialises.
+    /// Not the session's `version`, which is its CAS revision.
+    pub generation: u64,
+    /// The 0-based step.
+    pub step: usize,
+    /// The simulated instant, from the factor tape.
+    pub simulated_at: DateTime<Utc>,
+    /// The ticker symbol every chain in the snapshot prices.
+    pub symbol: String,
+    /// The underlying price shared by every chain.
+    pub spot: Positive,
+    /// The base implied volatility shared by every chain, before skew and smile
+    /// shape it per strike.
+    pub base_volatility: Positive,
+    /// The live expirations, ordered by `expires_at` ascending.
+    pub expirations: Vec<ExpirationRecord>,
+}
+
+impl SnapshotRecord {
+    /// Creates a snapshot record.
+    ///
+    /// The fields are public as well, so the session layer can build one
+    /// straight from a domain snapshot without an intermediate copy. Nothing is
+    /// validated here — [`SnapshotRecord::validate`] runs at the moment of
+    /// writing, which is the only place an invalid record could do damage.
+    #[must_use]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "a storage record is wide by nature"
+    )]
+    pub fn new(
+        simulation: Uuid,
+        generation: u64,
+        step: usize,
+        simulated_at: DateTime<Utc>,
+        symbol: String,
+        spot: Positive,
+        base_volatility: Positive,
+        expirations: Vec<ExpirationRecord>,
+    ) -> Self {
+        Self {
+            simulation,
+            generation,
+            step,
+            simulated_at,
+            symbol,
+            spot,
+            base_volatility,
+            expirations,
+        }
+    }
+
+    /// This snapshot's deterministic identity.
+    #[must_use]
+    #[inline]
+    pub fn snapshot_id(&self) -> Uuid {
+        snapshot_id(self.simulation, self.generation, self.step)
+    }
+
+    /// How many quote rows this snapshot writes.
+    ///
+    /// The number the completion marker carries and every read verifies.
+    #[must_use]
+    pub fn quote_count(&self) -> usize {
+        self.expirations
+            .iter()
+            .map(|expiration| expiration.quotes.len())
+            .sum()
+    }
+
+    /// Checks the invariants the storage layer depends on.
+    ///
+    /// The fields are public, so a caller can assemble a record that never
+    /// passed through a domain snapshot. Two properties matter enough to
+    /// enforce before anything is written:
+    ///
+    /// * **Ordering.** Expirations ascend and strikes ascend within them. Reads
+    ///   return rows in exactly this order, so a record written unordered would
+    ///   come back reordered and fail its own round-trip.
+    /// * **Uniqueness.** `(expires_at, strike)` identifies a row inside a
+    ///   snapshot, and it is the deduplication key. Two rows sharing it would
+    ///   collapse into one on merge, silently losing a strike.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the offending field.
+    pub fn validate(&self) -> Result<(), ChainError> {
+        if self.symbol.trim().is_empty() {
+            return Err(ChainError::Validation {
+                field: "symbol".to_string(),
+                reason: "must not be empty".to_string(),
+            });
+        }
+
+        let mut previous_expiry: Option<DateTime<Utc>> = None;
+        for expiration in &self.expirations {
+            if let Some(previous) = previous_expiry
+                && expiration.expires_at <= previous
+            {
+                return Err(ChainError::Validation {
+                    field: "expirations".to_string(),
+                    reason: format!(
+                        "must be strictly ascending by expires_at, got {} after {}",
+                        expiration.expires_at, previous
+                    ),
+                });
+            }
+            previous_expiry = Some(expiration.expires_at);
+
+            let mut previous_strike: Option<Positive> = None;
+            for quote in &expiration.quotes {
+                if let Some(previous) = previous_strike
+                    && quote.strike <= previous
+                {
+                    return Err(ChainError::Validation {
+                        field: "quotes".to_string(),
+                        reason: format!(
+                            "strikes must be strictly ascending within {}, got {} after {}",
+                            expiration.expires_at, quote.strike, previous
+                        ),
+                    });
+                }
+                previous_strike = Some(quote.strike);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// One `(expiration, strike, side)` at one step: a row of a contract's history.
+///
+/// What `contract_series` returns, ordered by simulated time — the shape a
+/// frontend chart or a backtest consumes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContractQuote {
+    /// The step this quote came from.
+    pub step: usize,
+    /// The simulated instant of that step.
+    pub simulated_at: DateTime<Utc>,
+    /// The contract's absolute expiration.
+    pub expires_at: DateTime<Utc>,
+    /// Fractional days remaining at this step.
+    pub days_to_expiration: Positive,
+    /// The strike.
+    pub strike: Positive,
+    /// Which side these quotes describe.
+    pub side: ContractSide,
+    /// The per-strike implied volatility, shared by both sides.
+    pub implied_volatility: Positive,
+    /// The bid on this side.
+    pub bid: Option<Positive>,
+    /// The ask on this side.
+    pub ask: Option<Positive>,
+    /// The mid on this side.
+    pub mid: Option<Positive>,
+    /// The delta on this side.
+    pub delta: Option<Decimal>,
+    /// Gamma, shared by both sides.
+    pub gamma: Option<Decimal>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+
+    fn instant(day: u32) -> DateTime<Utc> {
+        match Utc.with_ymd_and_hms(2026, 1, day, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        }
+    }
+
+    fn quote(strike: f64) -> QuoteRow {
+        QuoteRow::new(pos_or_panic!(strike), pos_or_panic!(0.18))
+            .with_call(
+                Some(pos_or_panic!(1.0)),
+                Some(pos_or_panic!(1.2)),
+                Some(pos_or_panic!(1.1)),
+                Some(dec!(0.51)),
+            )
+            .with_put(
+                Some(pos_or_panic!(0.9)),
+                Some(pos_or_panic!(1.1)),
+                Some(pos_or_panic!(1.0)),
+                Some(dec!(-0.49)),
+            )
+            .with_gamma(Some(dec!(0.0031)))
+    }
+
+    fn expiration(day: u32, strikes: &[f64]) -> ExpirationRecord {
+        ExpirationRecord::new(
+            instant(day),
+            pos_or_panic!(f64::from(day)),
+            vec!["weeklies".to_string()],
+            strikes.iter().copied().map(quote).collect(),
+        )
+    }
+
+    fn record(simulation: Uuid, generation: u64, step: usize) -> SnapshotRecord {
+        SnapshotRecord::new(
+            simulation,
+            generation,
+            step,
+            instant(5),
+            "SPX".to_string(),
+            pos_or_panic!(5000.0),
+            pos_or_panic!(0.18),
+            vec![
+                expiration(6, &[4975.0, 5000.0, 5025.0]),
+                expiration(9, &[4975.0, 5000.0]),
+            ],
+        )
+    }
+
+    /// The same coordinate always yields the same id — the property a retry
+    /// depends on.
+    #[test]
+    fn test_the_snapshot_id_is_deterministic() {
+        let simulation = Uuid::from_u128(7);
+
+        assert_eq!(
+            snapshot_id(simulation, 3, 11),
+            snapshot_id(simulation, 3, 11)
+        );
+    }
+
+    /// Every component of the coordinate changes the id, including the two that
+    /// a naive concatenation would confuse.
+    #[test]
+    fn test_the_snapshot_id_separates_its_components() {
+        let simulation = Uuid::from_u128(7);
+        let other = Uuid::from_u128(8);
+
+        assert_ne!(snapshot_id(simulation, 3, 11), snapshot_id(other, 3, 11));
+        assert_ne!(
+            snapshot_id(simulation, 3, 11),
+            snapshot_id(simulation, 4, 11)
+        );
+        assert_ne!(
+            snapshot_id(simulation, 3, 11),
+            snapshot_id(simulation, 3, 12)
+        );
+        // Without the separators, (1, 23) and (12, 3) would collide.
+        assert_ne!(
+            snapshot_id(simulation, 1, 23),
+            snapshot_id(simulation, 12, 3)
+        );
+    }
+
+    /// A caller with no reason to think about generations has a name to pass,
+    /// rather than a literal it would have to guess.
+    #[test]
+    fn test_the_current_generation_is_addressable() {
+        let simulation = Uuid::from_u128(7);
+
+        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 1);
+        assert_eq!(
+            record(simulation, CURRENT_SNAPSHOT_GENERATION, 0).snapshot_id(),
+            snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 0)
+        );
+    }
+
+    /// The id is a name-based v5 UUID, which is what makes it reproducible
+    /// across processes and restarts.
+    #[test]
+    fn test_the_snapshot_id_is_a_v5_uuid() {
+        assert_eq!(
+            snapshot_id(Uuid::from_u128(7), 1, 0).get_version(),
+            Some(uuid::Version::Sha1)
+        );
+    }
+
+    /// A record's id agrees with the free function.
+    #[test]
+    fn test_a_record_derives_its_own_id() {
+        let simulation = Uuid::from_u128(9);
+        let record = record(simulation, 2, 4);
+
+        assert_eq!(record.snapshot_id(), snapshot_id(simulation, 2, 4));
+    }
+
+    /// The quote count is what the completion marker will carry.
+    #[test]
+    fn test_the_quote_count_sums_every_expiration() {
+        assert_eq!(record(Uuid::from_u128(9), 1, 0).quote_count(), 5);
+    }
+
+    /// A well-formed record validates.
+    #[test]
+    fn test_a_well_formed_record_validates() {
+        match record(Uuid::from_u128(9), 1, 0).validate() {
+            Ok(()) => {}
+            Err(error) => panic!("the reference record must validate: {error}"),
+        }
+    }
+
+    /// An empty snapshot is legal: a simulation whose schedule yields nothing
+    /// live at a step still has a step.
+    #[test]
+    fn test_an_empty_snapshot_is_legal() {
+        let mut empty = record(Uuid::from_u128(9), 1, 0);
+        empty.expirations.clear();
+
+        assert_eq!(empty.quote_count(), 0);
+        assert!(empty.validate().is_ok());
+    }
+
+    /// Out-of-order expirations are rejected: reads return them ascending, so an
+    /// unordered write could never round-trip.
+    #[test]
+    fn test_unordered_expirations_are_rejected() {
+        let mut unordered = record(Uuid::from_u128(9), 1, 0);
+        unordered.expirations.reverse();
+
+        match unordered.validate() {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "expirations");
+                assert!(reason.contains("ascending"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A repeated expiration is rejected: it is the deduplication key, so the
+    /// second one would silently replace the first.
+    #[test]
+    fn test_a_repeated_expiration_is_rejected() {
+        let mut repeated = record(Uuid::from_u128(9), 1, 0);
+        repeated.expirations = vec![expiration(6, &[5000.0]), expiration(6, &[5000.0])];
+
+        assert!(repeated.validate().is_err());
+    }
+
+    /// Out-of-order strikes are rejected, for the same reason as expirations.
+    #[test]
+    fn test_unordered_strikes_are_rejected() {
+        let mut unordered = record(Uuid::from_u128(9), 1, 0);
+        unordered.expirations = vec![expiration(6, &[5025.0, 5000.0])];
+
+        match unordered.validate() {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "quotes");
+                assert!(reason.contains("ascending"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A repeated strike inside one expiration is rejected: it collapses on
+    /// merge, losing a contract.
+    #[test]
+    fn test_a_repeated_strike_is_rejected() {
+        let mut repeated = record(Uuid::from_u128(9), 1, 0);
+        repeated.expirations = vec![expiration(6, &[5000.0, 5000.0])];
+
+        assert!(repeated.validate().is_err());
+    }
+
+    /// An empty symbol is rejected.
+    #[test]
+    fn test_an_empty_symbol_is_rejected() {
+        let mut blank = record(Uuid::from_u128(9), 1, 0);
+        blank.symbol = "   ".to_string();
+
+        match blank.validate() {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "symbol"),
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The side renders as the name the query builder and the logs use.
+    #[test]
+    fn test_the_contract_side_renders_its_name() {
+        assert_eq!(ContractSide::Call.to_string(), "call");
+        assert_eq!(ContractSide::Put.as_str(), "put");
+    }
+}

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -4,6 +4,10 @@ pub mod redis;
 /// Operational configuration for v2 rolling simulations: retention, the
 /// cleanup cadence, and the domain-cache capacities.
 pub mod simulation_v2;
+/// Operational configuration for persisting v2 snapshots: whether it happens,
+/// how large a batch may be, how long an insert may take, and how long the rows
+/// are kept.
+pub mod snapshot;
 
 /// Redacts URL userinfo (credentials) from every URL-like substring inside a
 /// larger text (log lines, driver error messages).

--- a/src/infrastructure/config/snapshot.rs
+++ b/src/infrastructure/config/snapshot.rs
@@ -1,0 +1,476 @@
+//! Operational configuration for persisting v2 simulation snapshots.
+//!
+//! The snapshot tape is written to ClickHouse (issue #56) as two flat tables
+//! rather than to MongoDB as nested documents. Everything an operator can tune
+//! about that write path lives here: whether it happens at all, how large one
+//! snapshot may be, how long the service waits for the insert, how much one
+//! read may return, and how long the rows are kept.
+//!
+//! # Why this validates instead of falling back
+//!
+//! Same reasoning as [`crate::infrastructure::SimulationV2Config`]: a
+//! silently-defaulted retention would delete a tape a client still expects to
+//! be able to export, and a silently-defaulted row bound would change the
+//! service's memory profile without anyone noticing. So an unset knob takes its
+//! documented default and a **set-but-invalid** one fails startup with a
+//! message naming the variable.
+//!
+//! # Why persistence is off by default
+//!
+//! ClickHouse is optional in this service — `Simulator::new` already tolerates
+//! its absence — and a deployment without it must not log a failed write on
+//! every advance. Persistence is therefore opt-in: an operator who has the
+//! warehouse turns it on explicitly.
+
+use crate::utils::ChainError;
+use std::env;
+use std::time::Duration;
+use tracing::info;
+
+/// Whether snapshot persistence is on when `OCS_SNAPSHOT_PERSISTENCE_ENABLED`
+/// is unset.
+///
+/// Off: see the module docs.
+pub const DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED: bool = false;
+
+/// Default cap on the quote rows one snapshot may carry, in rows.
+///
+/// A snapshot is `expirations × strikes` rows; ADR 0001's reference
+/// configuration is a few hundred, and the per-snapshot contract budget in
+/// `SimulationParametersV2::validate` already bounds what the domain will
+/// price. This is the *storage* bound: a snapshot larger than it is rejected
+/// before a single row is written, so one pathological simulation cannot turn
+/// into an unbounded insert.
+pub const DEFAULT_SNAPSHOT_BATCH_ROWS: usize = 100_000;
+
+/// Default cap on the rows one read may return, in rows.
+///
+/// Bounds `stream_range` and `contract_series`, which #49's exports page
+/// through. A range that would exceed it is a typed error naming the knob
+/// rather than a truncated answer, because a silently short tape is
+/// indistinguishable from a gap in the data.
+pub const DEFAULT_SNAPSHOT_MAX_READ_ROWS: usize = 1_000_000;
+
+/// Default insert timeout, in seconds.
+///
+/// Covers both sending the batch and waiting for the server to accept it. A
+/// snapshot that cannot be written in half a minute is a degraded warehouse,
+/// and the advance path must not block on it.
+pub const DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS: u64 = 30;
+
+/// Default retention for persisted snapshot rows, in days.
+///
+/// Applied as a row-level `TTL` on the ingestion timestamp when the schema is
+/// created — real time, not simulated time, because a simulation's clock may
+/// sit years in the future.
+pub const DEFAULT_SNAPSHOT_RETENTION_DAYS: u32 = 90;
+
+/// The largest per-snapshot row bound that can be configured.
+///
+/// Five million rows is far past any snapshot the domain will price, so a
+/// larger value is a typo rather than an intent.
+const MAX_BATCH_ROWS: usize = 5_000_000;
+
+/// The largest per-read row bound that can be configured.
+const MAX_READ_ROWS_CEILING: usize = 10_000_000;
+
+/// The longest insert timeout that can be configured, in seconds.
+const MAX_INSERT_TIMEOUT_SECS: u64 = 600;
+
+/// The longest retention that can be configured, in days — ten years.
+const MAX_RETENTION_DAYS: u32 = 3_650;
+
+/// Operational limits for the v2 snapshot tape in ClickHouse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotPersistenceConfig {
+    /// Whether generated snapshots are written to ClickHouse at all.
+    ///
+    /// Consumed at construction:
+    /// [`crate::infrastructure::ClickHouseSnapshotRepository::from_env`] returns
+    /// `None` when this is false, so a disabled deployment never holds a
+    /// repository and never attempts a write.
+    pub enabled: bool,
+    /// The most quote rows one snapshot may carry.
+    pub batch_rows: usize,
+    /// The most rows one read may return.
+    pub max_read_rows: usize,
+    /// How long an insert may take, sending and server-side combined.
+    pub insert_timeout: Duration,
+    /// How long persisted rows are kept, in days, measured from ingestion.
+    pub retention_days: u32,
+}
+
+impl Default for SnapshotPersistenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED,
+            batch_rows: DEFAULT_SNAPSHOT_BATCH_ROWS,
+            max_read_rows: DEFAULT_SNAPSHOT_MAX_READ_ROWS,
+            insert_timeout: Duration::from_secs(DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS),
+            retention_days: DEFAULT_SNAPSHOT_RETENTION_DAYS,
+        }
+    }
+}
+
+impl SnapshotPersistenceConfig {
+    /// Reads the configuration from the environment.
+    ///
+    /// An unset variable takes its documented default. A set-but-invalid one
+    /// fails, rather than falling back — see the module docs for why.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the environment variable when
+    /// its value does not parse, is zero, or exceeds its documented bound.
+    pub fn from_env() -> Result<Self, ChainError> {
+        let config = Self {
+            enabled: parse_bool(
+                "OCS_SNAPSHOT_PERSISTENCE_ENABLED",
+                read("OCS_SNAPSHOT_PERSISTENCE_ENABLED").as_deref(),
+                DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED,
+            )?,
+            batch_rows: parse_bounded_usize(
+                "OCS_SNAPSHOT_BATCH_ROWS",
+                read("OCS_SNAPSHOT_BATCH_ROWS").as_deref(),
+                DEFAULT_SNAPSHOT_BATCH_ROWS,
+                MAX_BATCH_ROWS,
+            )?,
+            max_read_rows: parse_bounded_usize(
+                "OCS_SNAPSHOT_MAX_READ_ROWS",
+                read("OCS_SNAPSHOT_MAX_READ_ROWS").as_deref(),
+                DEFAULT_SNAPSHOT_MAX_READ_ROWS,
+                MAX_READ_ROWS_CEILING,
+            )?,
+            insert_timeout: Duration::from_secs(parse_bounded_u64(
+                "OCS_SNAPSHOT_INSERT_TIMEOUT_SECS",
+                read("OCS_SNAPSHOT_INSERT_TIMEOUT_SECS").as_deref(),
+                DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS,
+                MAX_INSERT_TIMEOUT_SECS,
+            )?),
+            retention_days: parse_bounded_u32(
+                "OCS_SNAPSHOT_RETENTION_DAYS",
+                read("OCS_SNAPSHOT_RETENTION_DAYS").as_deref(),
+                DEFAULT_SNAPSHOT_RETENTION_DAYS,
+                MAX_RETENTION_DAYS,
+            )?,
+        };
+
+        info!(
+            enabled = config.enabled,
+            batch_rows = config.batch_rows,
+            max_read_rows = config.max_read_rows,
+            insert_timeout_secs = config.insert_timeout.as_secs(),
+            retention_days = config.retention_days,
+            "Loaded the v2 snapshot persistence configuration"
+        );
+        Ok(config)
+    }
+}
+
+/// Parses a boolean knob.
+///
+/// Accepts the spellings an operator actually writes in a `.env` file, in
+/// either case. Anything else fails rather than being read as `false`: a
+/// misspelled `OCS_SNAPSHOT_PERSISTENCE_ENABLED=treu` that silently disabled
+/// persistence would be discovered days later, by its absence.
+fn parse_bool(variable: &str, raw: Option<&str>, default: bool) -> Result<bool, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    match raw.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(ChainError::Validation {
+            field: variable.to_string(),
+            reason: format!("must be a boolean (true/false), got {raw:?}"),
+        }),
+    }
+}
+
+/// Parses a positive row count with an explicit ceiling.
+///
+/// Takes the raw value rather than reading it, so the parsing and the bounds
+/// can be tested without mutating the process environment — which would need
+/// `unsafe` in this edition and would race every other test in the binary.
+fn parse_bounded_usize(
+    variable: &str,
+    raw: Option<&str>,
+    default: usize,
+    max: usize,
+) -> Result<usize, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    let value = raw.parse::<usize>().map_err(|_| invalid(variable, raw))?;
+    if value == 0 {
+        return Err(zero(variable));
+    }
+    if value > max {
+        return Err(too_large(variable, &value.to_string(), &max.to_string()));
+    }
+    Ok(value)
+}
+
+/// Parses a positive duration in seconds with an explicit ceiling.
+fn parse_bounded_u64(
+    variable: &str,
+    raw: Option<&str>,
+    default: u64,
+    max: u64,
+) -> Result<u64, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    let value = raw.parse::<u64>().map_err(|_| invalid(variable, raw))?;
+    if value == 0 {
+        return Err(zero(variable));
+    }
+    if value > max {
+        return Err(too_large(variable, &value.to_string(), &max.to_string()));
+    }
+    Ok(value)
+}
+
+/// Parses a positive day count with an explicit ceiling.
+fn parse_bounded_u32(
+    variable: &str,
+    raw: Option<&str>,
+    default: u32,
+    max: u32,
+) -> Result<u32, ChainError> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+
+    let value = raw.parse::<u32>().map_err(|_| invalid(variable, raw))?;
+    if value == 0 {
+        return Err(zero(variable));
+    }
+    if value > max {
+        return Err(too_large(variable, &value.to_string(), &max.to_string()));
+    }
+    Ok(value)
+}
+
+/// The error for a count of zero.
+///
+/// Every knob here is a count, and zero disables something the operator meant
+/// to configure — a zero batch bound rejects every snapshot, a zero retention
+/// deletes the tape as it is written.
+#[cold]
+fn zero(variable: &str) -> ChainError {
+    ChainError::Validation {
+        field: variable.to_string(),
+        reason: "must be at least 1".to_string(),
+    }
+}
+
+/// The error for a count above its documented ceiling.
+///
+/// Takes the two numbers already rendered, so one message serves the three
+/// integer widths without widening arithmetic that would only exist for the
+/// error path.
+#[cold]
+fn too_large(variable: &str, value: &str, max: &str) -> ChainError {
+    ChainError::Validation {
+        field: variable.to_string(),
+        reason: format!("must not exceed {max}, got {value}"),
+    }
+}
+
+/// Reads a variable, treating an empty or whitespace-only value as unset.
+///
+/// A blank value in a `.env` file is how a knob gets "commented out" in
+/// practice; treating it as unset is friendlier than failing startup over it,
+/// and unambiguous either way.
+fn read(variable: &str) -> Option<String> {
+    let raw = env::var(variable).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// The error for a value that does not parse.
+#[cold]
+fn invalid(variable: &str, raw: &str) -> ChainError {
+    ChainError::Validation {
+        field: variable.to_string(),
+        reason: format!("must be a whole number, got {raw:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The defaults are the documented ones.
+    #[test]
+    fn test_the_defaults_are_the_documented_values() {
+        let config = SnapshotPersistenceConfig::default();
+
+        assert_eq!(config.enabled, DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED);
+        assert_eq!(config.batch_rows, DEFAULT_SNAPSHOT_BATCH_ROWS);
+        assert_eq!(config.max_read_rows, DEFAULT_SNAPSHOT_MAX_READ_ROWS);
+        assert_eq!(
+            config.insert_timeout.as_secs(),
+            DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS
+        );
+        assert_eq!(config.retention_days, DEFAULT_SNAPSHOT_RETENTION_DAYS);
+    }
+
+    /// Persistence is opt-in, so a deployment without ClickHouse is unaffected.
+    #[test]
+    fn test_persistence_is_off_by_default() {
+        assert!(!SnapshotPersistenceConfig::default().enabled);
+    }
+
+    /// Every spelling an operator is likely to write is accepted.
+    #[test]
+    fn test_boolean_spellings_are_accepted() {
+        for raw in ["1", "true", "TRUE", "Yes", "on"] {
+            match parse_bool("OCS_SNAPSHOT_PERSISTENCE_ENABLED", Some(raw), false) {
+                Ok(value) => assert!(value, "{raw} must enable persistence"),
+                Err(error) => panic!("{raw} must parse: {error}"),
+            }
+        }
+        for raw in ["0", "false", "FALSE", "No", "off"] {
+            match parse_bool("OCS_SNAPSHOT_PERSISTENCE_ENABLED", Some(raw), true) {
+                Ok(value) => assert!(!value, "{raw} must disable persistence"),
+                Err(error) => panic!("{raw} must parse: {error}"),
+            }
+        }
+    }
+
+    /// A misspelled boolean fails by name rather than silently disabling the
+    /// write path.
+    #[test]
+    fn test_an_unparseable_boolean_fails_by_name() {
+        match parse_bool("OCS_SNAPSHOT_PERSISTENCE_ENABLED", Some("treu"), false) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_PERSISTENCE_ENABLED");
+                assert!(reason.contains("boolean"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// An unset boolean takes its default.
+    #[test]
+    fn test_an_unset_boolean_takes_its_default() {
+        match parse_bool("OCS_SNAPSHOT_PERSISTENCE_ENABLED", None, true) {
+            Ok(value) => assert!(value),
+            Err(error) => panic!("an unset knob must take its default: {error}"),
+        }
+    }
+
+    /// An unset count takes its default; a valid one is accepted verbatim.
+    #[test]
+    fn test_counts_take_their_default_and_accept_valid_values() {
+        match parse_bounded_usize("OCS_SNAPSHOT_BATCH_ROWS", None, 64, 128) {
+            Ok(value) => assert_eq!(value, 64),
+            Err(error) => panic!("an unset knob must take its default: {error}"),
+        }
+        match parse_bounded_usize("OCS_SNAPSHOT_BATCH_ROWS", Some("100"), 64, 128) {
+            Ok(value) => assert_eq!(value, 100),
+            Err(error) => panic!("a valid count must be accepted: {error}"),
+        }
+    }
+
+    /// A zero row bound would make every snapshot unpersistable.
+    #[test]
+    fn test_a_zero_count_is_rejected() {
+        match parse_bounded_usize("OCS_SNAPSHOT_BATCH_ROWS", Some("0"), 64, 128) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_BATCH_ROWS");
+                assert!(reason.contains("at least 1"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A count beyond its ceiling is rejected.
+    #[test]
+    fn test_a_count_beyond_its_ceiling_is_rejected() {
+        match parse_bounded_usize("OCS_SNAPSHOT_MAX_READ_ROWS", Some("999999999"), 64, 128) {
+            Err(ChainError::Validation { reason, .. }) => {
+                assert!(reason.contains("must not exceed"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A count that does not parse fails by name.
+    #[test]
+    fn test_an_unparseable_count_fails_by_name() {
+        match parse_bounded_usize("OCS_SNAPSHOT_BATCH_ROWS", Some("lots"), 64, 128) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_BATCH_ROWS");
+                assert!(reason.contains("whole number"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The timeout knob obeys the same rules as the counts.
+    #[test]
+    fn test_the_timeout_is_bounded() {
+        match parse_bounded_u64("OCS_SNAPSHOT_INSERT_TIMEOUT_SECS", Some("45"), 30, 600) {
+            Ok(value) => assert_eq!(value, 45),
+            Err(error) => panic!("a valid timeout must be accepted: {error}"),
+        }
+        match parse_bounded_u64("OCS_SNAPSHOT_INSERT_TIMEOUT_SECS", Some("6000"), 30, 600) {
+            Err(ChainError::Validation { field, .. }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_INSERT_TIMEOUT_SECS");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The retention knob obeys the same rules, and its ceiling is ten years.
+    #[test]
+    fn test_the_retention_is_bounded() {
+        match parse_bounded_u32(
+            "OCS_SNAPSHOT_RETENTION_DAYS",
+            Some("30"),
+            90,
+            MAX_RETENTION_DAYS,
+        ) {
+            Ok(value) => assert_eq!(value, 30),
+            Err(error) => panic!("a valid retention must be accepted: {error}"),
+        }
+        match parse_bounded_u32(
+            "OCS_SNAPSHOT_RETENTION_DAYS",
+            Some("40000"),
+            90,
+            MAX_RETENTION_DAYS,
+        ) {
+            Err(ChainError::Validation { reason, .. }) => {
+                assert!(reason.contains("must not exceed"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The configuration loads from the ambient environment.
+    ///
+    /// The service is deployed with these unset far more often than not, so the
+    /// path that has to work is the one that takes every default.
+    #[test]
+    fn test_it_loads_from_the_environment() {
+        match SnapshotPersistenceConfig::from_env() {
+            Ok(config) => {
+                assert!(config.batch_rows >= 1);
+                assert!(config.max_read_rows >= 1);
+                assert!(config.retention_days >= 1);
+                assert!(config.insert_timeout.as_secs() >= 1);
+            }
+            Err(error) => panic!("the ambient environment must load: {error}"),
+        }
+    }
+}

--- a/src/infrastructure/config/snapshot.rs
+++ b/src/infrastructure/config/snapshot.rs
@@ -22,6 +22,9 @@
 //! every advance. Persistence is therefore opt-in: an operator who has the
 //! warehouse turns it on explicitly.
 
+use crate::infrastructure::config::simulation_v2::{
+    DEFAULT_MAX_SNAPSHOT_CONTRACTS, max_snapshot_contracts,
+};
 use crate::utils::ChainError;
 use std::env;
 use std::time::Duration;
@@ -36,12 +39,17 @@ pub const DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED: bool = false;
 /// Default cap on the quote rows one snapshot may carry, in rows.
 ///
 /// A snapshot is `expirations × strikes` rows; ADR 0001's reference
-/// configuration is a few hundred, and the per-snapshot contract budget in
-/// `SimulationParametersV2::validate` already bounds what the domain will
-/// price. This is the *storage* bound: a snapshot larger than it is rejected
-/// before a single row is written, so one pathological simulation cannot turn
-/// into an unbounded insert.
-pub const DEFAULT_SNAPSHOT_BATCH_ROWS: usize = 100_000;
+/// configuration is a few hundred. This is the *storage* bound: a snapshot
+/// larger than it is rejected before a single row is written, so one
+/// pathological simulation cannot turn into an unbounded insert.
+///
+/// It defaults to the per-snapshot contract cap the API accepts, and not
+/// lower, on purpose. A storage bound below what creation admits would make
+/// every persist of a perfectly legal simulation fail — the API would say yes
+/// and the warehouse would say no, for every step, forever. `from_env` refuses
+/// that combination outright rather than leaving it to be discovered in the
+/// logs.
+pub const DEFAULT_SNAPSHOT_BATCH_ROWS: usize = DEFAULT_MAX_SNAPSHOT_CONTRACTS;
 
 /// Default cap on the rows one read may return, in rows.
 ///
@@ -154,6 +162,23 @@ impl SnapshotPersistenceConfig {
                 MAX_RETENTION_DAYS,
             )?,
         };
+
+        // The two bounds have to agree, or the service accepts simulations it
+        // can never persist. Checked here rather than at the write, because the
+        // failure is a configuration mistake and belongs at startup with both
+        // variables named.
+        let accepted = max_snapshot_contracts();
+        if config.enabled && config.batch_rows < accepted {
+            return Err(ChainError::Validation {
+                field: "OCS_SNAPSHOT_BATCH_ROWS".to_string(),
+                reason: format!(
+                    "is {} but OCS_MAX_SNAPSHOT_CONTRACTS accepts snapshots of up to \
+                     {accepted} rows, so every persist of a snapshot above {} would fail; \
+                     raise this or lower that",
+                    config.batch_rows, config.batch_rows
+                ),
+            });
+        }
 
         info!(
             enabled = config.enabled,
@@ -307,6 +332,18 @@ fn invalid(variable: &str, raw: &str) -> ChainError {
 
 #[cfg(test)]
 mod tests {
+    /// The storage bound defaults to what creation accepts, so the default
+    /// configuration cannot accept a simulation it could never persist.
+    #[test]
+    fn test_the_default_storage_bound_covers_what_creation_accepts() {
+        const {
+            assert!(
+                DEFAULT_SNAPSHOT_BATCH_ROWS >= DEFAULT_MAX_SNAPSHOT_CONTRACTS,
+                "a storage bound below the accepted snapshot size fails every persist"
+            );
+        }
+    }
+
     use super::*;
 
     /// The defaults are the documented ones.

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -8,6 +8,11 @@ mod telemetry;
 pub use clickhouse::ClickHouseClient;
 pub use clickhouse::interface::HistoricalDataRepository;
 pub use clickhouse::model::{OHLCVData, PriceType};
+pub use clickhouse::snapshots::interface::{ContractSeriesQuery, SimulationSnapshotRepository};
+pub use clickhouse::snapshots::record::{
+    CURRENT_SNAPSHOT_GENERATION, ContractQuote, ContractSide, ExpirationRecord, QuoteRow,
+    SnapshotRecord, snapshot_id,
+};
 pub(crate) use clickhouse::{calculate_required_duration, select_random_date, validate_symbol};
 pub use config::clickhouse::ClickHouseConfig;
 pub use config::redis::RedisConfig;
@@ -17,8 +22,14 @@ pub use config::simulation_v2::{
     DEFAULT_MAX_SNAPSHOT_CONTRACTS, DEFAULT_RETENTION_SECS, SimulationV2Config,
     max_snapshot_contracts,
 };
+pub use config::snapshot::{
+    DEFAULT_SNAPSHOT_BATCH_ROWS, DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS,
+    DEFAULT_SNAPSHOT_MAX_READ_ROWS, DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED,
+    DEFAULT_SNAPSHOT_RETENTION_DAYS, SnapshotPersistenceConfig,
+};
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;
 pub use repositories::mongo_repo::{MongoDBRepository, init_mongodb};
+pub use repositories::snapshot_repo::ClickHouseSnapshotRepository;
 pub use telemetry::collector::MetricsCollector;
 pub use telemetry::middleware::MetricsMiddleware;

--- a/src/infrastructure/repositories/mod.rs
+++ b/src/infrastructure/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod historical_repo;
 pub(crate) mod mongo_repo;
+pub(crate) mod snapshot_repo;

--- a/src/infrastructure/repositories/snapshot_repo.rs
+++ b/src/infrastructure/repositories/snapshot_repo.rs
@@ -1,0 +1,1616 @@
+//! The ClickHouse-backed store for the v2 snapshot tape (issue #56).
+//!
+//! Two tables — the metadata of a step and the flattened quotes of that step —
+//! written in a fixed order that makes a half-written snapshot invisible, and
+//! read with deduplication applied at query time so a retry can never surface
+//! twice.
+//!
+//! # The completion protocol
+//!
+//! A snapshot is persisted in two writes, in this order:
+//!
+//! 1. **Every quote row, as one batch.** One `INSERT`, never one per contract.
+//!    Either the server accepts the whole batch or the write fails and nothing
+//!    is marked.
+//! 2. **The completion marker**, carrying the number of quote rows the batch
+//!    contained.
+//!
+//! A reader therefore sees one of three states. No marker: the snapshot is
+//! absent, which is exactly how an unpersisted step reads, and deterministic
+//! replay can produce it. A marker whose `quote_count` matches the rows on
+//! disk: the snapshot is whole. A marker whose count does *not* match: the
+//! snapshot is reported absent and logged at `WARN`, because a snapshot missing
+//! strikes is worse than a snapshot missing entirely — a backtest would price
+//! against a chain with holes in it.
+//!
+//! # Why every read deduplicates
+//!
+//! `ReplacingMergeTree` collapses duplicate coordinates *eventually*, on a
+//! background merge. Idempotence has to hold immediately — the second write of
+//! a retried step is exactly when a duplicate would be read — so the row reads
+//! use `FINAL` and the count checks use `uniqExact` over the identity columns.
+//! Both are bounded by the `(simulation_id, simulation_generation)` prefix of the
+//! sorting key, so they never degenerate into a full scan.
+//!
+//! # When ClickHouse is down
+//!
+//! Every driver error becomes a [`ChainError`] here; no `clickhouse::error`
+//! type appears in a public signature, and neither the connection string nor
+//! the credentials are ever logged. The advance path treats a failed persist as
+//! non-fatal: the snapshot is deterministic, so the step can be written later
+//! by a replay without the client ever noticing.
+
+use crate::infrastructure::clickhouse::snapshots::interface::{
+    ContractSeriesQuery, SimulationSnapshotRepository,
+};
+use crate::infrastructure::clickhouse::snapshots::model::{
+    ContractReadRow, DECIMAL_SCALE, OptionQuoteRow, QUOTES_TABLE, QuoteReadRow, SNAPSHOTS_TABLE,
+    SnapshotMetaReadRow, SnapshotMetaRow, contract_quote_from_row, meta_row, quote_rows,
+    record_from_rows, to_storage_instant, to_storage_positive,
+};
+use crate::infrastructure::clickhouse::snapshots::record::{
+    ContractQuote, ContractSide, SnapshotRecord,
+};
+use crate::infrastructure::config::snapshot::SnapshotPersistenceConfig;
+use crate::infrastructure::{ClickHouseClient, ClickHouseConfig};
+use crate::utils::ChainError;
+use async_trait::async_trait;
+use chrono::Utc;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+/// The DDL of the metadata table, shipped with the crate.
+///
+/// Checked in under `src/infrastructure/clickhouse/schema/` rather than beside
+/// the compose files because it is compiled into the binary: the code that
+/// inserts these rows and the schema they must match travel together, and a
+/// deployment asset could drift from the row types without the compiler
+/// noticing.
+const SNAPSHOTS_DDL: &str = include_str!("../clickhouse/schema/simulation_snapshots.sql");
+
+/// The DDL of the quotes table. See [`SNAPSHOTS_DDL`].
+const QUOTES_DDL: &str = include_str!("../clickhouse/schema/simulation_option_quotes.sql");
+
+/// The placeholder the retention knob replaces in the DDL.
+const RETENTION_PLACEHOLDER: &str = "{{RETENTION_DAYS}}";
+
+/// Selects the metadata of every completed step in a range.
+///
+/// `FINAL` deduplicates a retried write immediately. `complete = true` is the
+/// marker; the `quote_count` it carries is verified against the rows actually
+/// read, in [`assemble`].
+const META_RANGE_QUERY: &str = "SELECT \
+        step, \
+        snapshot_id, \
+        toUnixTimestamp64Nano(simulated_at) AS simulated_at, \
+        symbol, \
+        underlying_price, \
+        base_volatility, \
+        quote_count \
+    FROM simulation_snapshots FINAL \
+    WHERE simulation_id = {simulation:String} \
+      AND simulation_generation = {generation:UInt64} \
+      AND step >= {from_step:UInt64} \
+      AND step <= {to_step:UInt64} \
+      AND complete = true \
+    ORDER BY step ASC";
+
+/// Selects the quotes of every step in a range, in storage order.
+///
+/// The ordering is the table's own sorting key, so this is a range read rather
+/// than a sort, and it is the order [`assemble`] relies on to group rows into
+/// expirations in one pass.
+const QUOTES_RANGE_QUERY: &str = "SELECT \
+        step, \
+        toUnixTimestamp64Nano(expires_at) AS expires_at, \
+        days_to_expiration, \
+        labels, \
+        strike, \
+        implied_volatility, \
+        call_bid, \
+        call_ask, \
+        call_mid, \
+        put_bid, \
+        put_ask, \
+        put_mid, \
+        delta_call, \
+        delta_put, \
+        gamma \
+    FROM simulation_option_quotes FINAL \
+    WHERE simulation_id = {simulation:String} \
+      AND simulation_generation = {generation:UInt64} \
+      AND step >= {from_step:UInt64} \
+      AND step <= {to_step:UInt64} \
+    ORDER BY step ASC, expires_at ASC, strike ASC";
+
+/// The steps in a range whose stored quotes match their marker's count.
+///
+/// The completeness check for a query that does not materialise a whole
+/// snapshot. `uniqExact` over the identity columns counts *deduplicated* rows
+/// without paying for `FINAL`, which is what makes this affordable inside a
+/// contract history.
+const COMPLETE_STEPS_SUBQUERY: &str = "SELECT marker.step \
+    FROM ( \
+        SELECT step, quote_count \
+        FROM simulation_snapshots FINAL \
+        WHERE simulation_id = {simulation:String} \
+          AND simulation_generation = {generation:UInt64} \
+          AND step >= {from_step:UInt64} \
+          AND step <= {to_step:UInt64} \
+          AND complete = true \
+    ) AS marker \
+    INNER JOIN ( \
+        SELECT step, uniqExact((expires_at, strike)) AS stored \
+        FROM simulation_option_quotes \
+        WHERE simulation_id = {simulation:String} \
+          AND simulation_generation = {generation:UInt64} \
+          AND step >= {from_step:UInt64} \
+          AND step <= {to_step:UInt64} \
+        GROUP BY step \
+    ) AS counted ON marker.step = counted.step \
+    WHERE marker.quote_count = counted.stored";
+
+/// Builds the contract-history query for one side.
+///
+/// The side chooses column names from a closed match on [`ContractSide`] —
+/// there is no path from a request value into this string, so the aliases are
+/// the only thing that varies and the query stays a constant in every other
+/// respect.
+#[must_use]
+fn contract_series_query(side: ContractSide, limit: usize) -> String {
+    let (bid, ask, mid, delta) = match side {
+        ContractSide::Call => ("call_bid", "call_ask", "call_mid", "delta_call"),
+        ContractSide::Put => ("put_bid", "put_ask", "put_mid", "delta_put"),
+    };
+
+    // `limit` is a validated `usize` from configuration, never a request value.
+    // It is interpolated rather than bound because the named parameters below
+    // must survive verbatim — `format!` would try to read `{simulation:String}`
+    // as a format specifier — and because a `LIMIT` placeholder is the one
+    // position where server-side parameters are least portable.
+    format!(
+        "SELECT \
+            quote.step AS step, \
+            toUnixTimestamp64Nano(quote.simulated_at) AS simulated_at, \
+            toUnixTimestamp64Nano(quote.expires_at) AS expires_at, \
+            quote.days_to_expiration AS days_to_expiration, \
+            quote.strike AS strike, \
+            quote.implied_volatility AS implied_volatility, \
+            quote.{bid} AS bid, \
+            quote.{ask} AS ask, \
+            quote.{mid} AS mid, \
+            quote.{delta} AS delta, \
+            quote.gamma AS gamma \
+        FROM simulation_option_quotes AS quote FINAL \
+        WHERE quote.simulation_id = {{simulation:String}} \
+          AND quote.simulation_generation = {{generation:UInt64}} \
+          AND quote.step >= {{from_step:UInt64}} \
+          AND quote.step <= {{to_step:UInt64}} \
+          AND quote.expires_at = fromUnixTimestamp64Nano({{expires_at:Int64}}) \
+          AND quote.strike = toDecimal128({{strike:String}}, {DECIMAL_SCALE}) \
+          AND quote.step IN ({COMPLETE_STEPS_SUBQUERY}) \
+        ORDER BY quote.simulated_at ASC, quote.step ASC \
+        LIMIT {limit}"
+    )
+}
+
+/// Appends a row bound to a range query.
+///
+/// Callers pass [`ClickHouseSnapshotRepository::probe_limit`], one more than a
+/// read may return, so a range that would exceed the bound comes back detectably
+/// long instead of quietly truncated.
+#[must_use]
+fn with_probe_limit(query: &str, limit: usize) -> String {
+    format!("{query} LIMIT {limit}")
+}
+
+/// Where a snapshot's rows are written.
+///
+/// A seam, not an abstraction for its own sake: it is what lets the write-order
+/// and one-batch rules be tested without a ClickHouse server, which is the only
+/// way they can be tested in the hermetic suite.
+#[async_trait]
+pub(crate) trait SnapshotWriter: Send + Sync {
+    /// Writes EVERY quote row of one snapshot in a single batch.
+    async fn write_quote_batch(&self, rows: &[OptionQuoteRow]) -> Result<(), ChainError>;
+
+    /// Writes the completion marker. Called only after the batch succeeded.
+    async fn write_completion_marker(&self, row: &SnapshotMetaRow) -> Result<(), ChainError>;
+}
+
+/// Runs the completion protocol: quotes first, as one batch, then the marker.
+///
+/// The ordering is the whole guarantee. If the batch fails, the marker is never
+/// written and the step reads as absent; if the marker fails, the orphan quote
+/// rows are invisible to every read path and a later retry overwrites them.
+///
+/// # Errors
+///
+/// Propagates whatever the writer reports.
+async fn run_completion_protocol<W>(
+    writer: &W,
+    quotes: &[OptionQuoteRow],
+    marker: &SnapshotMetaRow,
+) -> Result<(), ChainError>
+where
+    W: SnapshotWriter + ?Sized,
+{
+    // An empty snapshot is legal — a schedule can leave a step with nothing
+    // live — and an empty batch is a network round trip that writes nothing.
+    if !quotes.is_empty() {
+        writer.write_quote_batch(quotes).await?;
+    }
+    writer.write_completion_marker(marker).await
+}
+
+/// Persists and reads the v2 snapshot tape in ClickHouse.
+pub struct ClickHouseSnapshotRepository {
+    /// The shared ClickHouse client.
+    client: Arc<ClickHouseClient>,
+    /// The operator's limits: batch size, read bound, insert timeout,
+    /// retention.
+    config: SnapshotPersistenceConfig,
+}
+
+impl ClickHouseSnapshotRepository {
+    /// Creates a repository over an existing client.
+    ///
+    /// `config.enabled` is not consulted here: whether persistence happens at
+    /// all is decided when the service chooses to build a repository, in
+    /// [`ClickHouseSnapshotRepository::from_env`].
+    #[must_use]
+    pub fn new(client: Arc<ClickHouseClient>, config: SnapshotPersistenceConfig) -> Self {
+        Self { client, config }
+    }
+
+    /// Builds the repository the environment describes, or `None` when snapshot
+    /// persistence is switched off.
+    ///
+    /// This call itself performs no I/O — the ClickHouse client connects lazily
+    /// — but that does **not** make the warehouse optional once the knob is on:
+    /// the service calls [`ClickHouseSnapshotRepository::ensure_schema`] at
+    /// boot, so with `OCS_SNAPSHOT_PERSISTENCE_ENABLED=true` an unreachable
+    /// ClickHouse fails startup. Persistence off is the configuration that
+    /// tolerates its absence. Once running, a *later* outage is survivable:
+    /// the advance path treats a failed persist as non-fatal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when a knob is set but invalid, and
+    /// [`ChainError::ClickHouseError`] when the client cannot be built.
+    pub fn from_env() -> Result<Option<Self>, ChainError> {
+        let config = SnapshotPersistenceConfig::from_env()?;
+        if !config.enabled {
+            // Not logged here: the caller that decides what to do without a
+            // repository is the one that should say so, and saying it twice
+            // reads like two different facts.
+            return Ok(None);
+        }
+
+        let client = ClickHouseClient::new(ClickHouseConfig::default())?;
+        Ok(Some(Self::new(Arc::new(client), config)))
+    }
+
+    /// The limits this repository enforces.
+    #[must_use]
+    pub fn config(&self) -> &SnapshotPersistenceConfig {
+        &self.config
+    }
+
+    /// Creates the two tables if they are absent.
+    ///
+    /// Idempotent, and safe to call at every startup. It will **not** alter a
+    /// table that already exists, so changing `OCS_SNAPSHOT_RETENTION_DAYS`
+    /// against a live deployment needs an explicit
+    /// `ALTER TABLE ... MODIFY TTL`; the DDL documents that.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::ClickHouseError`] when the warehouse rejects the
+    /// DDL or is unreachable.
+    #[instrument(skip(self), level = "debug")]
+    pub async fn ensure_schema(&self) -> Result<(), ChainError> {
+        for ddl in [SNAPSHOTS_DDL, QUOTES_DDL] {
+            // The only substitution is a `u32` that
+            // `SnapshotPersistenceConfig::from_env` has already bounded, so no
+            // external text can reach this statement.
+            let statement = ddl.replace(
+                RETENTION_PLACEHOLDER,
+                &self.config.retention_days.to_string(),
+            );
+            self.client.client.query(&statement).execute().await?;
+        }
+
+        info!(
+            retention_days = self.config.retention_days,
+            "Ensured the v2 snapshot schema"
+        );
+        Ok(())
+    }
+
+    /// Reads the metadata of every completed step in an inclusive range.
+    async fn fetch_meta_rows(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        from_step: u64,
+        to_step: u64,
+    ) -> Result<Vec<SnapshotMetaReadRow>, ChainError> {
+        let sql = with_probe_limit(META_RANGE_QUERY, self.probe_limit()?);
+        let rows = self
+            .client
+            .client
+            .query(&sql)
+            .param("simulation", simulation.to_string())
+            .param("generation", generation)
+            .param("from_step", from_step)
+            .param("to_step", to_step)
+            .fetch_all::<SnapshotMetaReadRow>()
+            .await?;
+
+        self.reject_if_over_budget(rows.len(), "snapshots")?;
+        Ok(rows)
+    }
+
+    /// Reads the quotes of every step in an inclusive range, in storage order.
+    async fn fetch_quote_rows(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        from_step: u64,
+        to_step: u64,
+    ) -> Result<Vec<QuoteReadRow>, ChainError> {
+        let sql = with_probe_limit(QUOTES_RANGE_QUERY, self.probe_limit()?);
+        let rows = self
+            .client
+            .client
+            .query(&sql)
+            .param("simulation", simulation.to_string())
+            .param("generation", generation)
+            .param("from_step", from_step)
+            .param("to_step", to_step)
+            .fetch_all::<QuoteReadRow>()
+            .await?;
+
+        self.reject_if_over_budget(rows.len(), "quotes")?;
+        Ok(rows)
+    }
+
+    /// One more row than a read may return, so an over-long answer is
+    /// detectable rather than silently truncated.
+    fn probe_limit(&self) -> Result<usize, ChainError> {
+        self.config
+            .max_read_rows
+            .checked_add(1)
+            .ok_or_else(|| ChainError::Validation {
+                field: "OCS_SNAPSHOT_MAX_READ_ROWS".to_string(),
+                reason: "is too large to probe for truncation".to_string(),
+            })
+    }
+
+    /// Fails when a read came back at the probe limit, which means the answer
+    /// was cut off.
+    fn reject_if_over_budget(&self, returned: usize, what: &str) -> Result<(), ChainError> {
+        if returned > self.config.max_read_rows {
+            return Err(ChainError::Validation {
+                field: "OCS_SNAPSHOT_MAX_READ_ROWS".to_string(),
+                reason: format!(
+                    "the requested range holds more {what} than the configured bound of {}; \
+                     request a smaller step range",
+                    self.config.max_read_rows
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Rebuilds the snapshots a range read returned, verifying each against its
+/// marker.
+///
+/// Pure, so the completion check — the rule that decides whether a step is
+/// visible at all — is testable without a server.
+///
+/// `quotes` must arrive in the storage order the range query asks for; rows are
+/// grouped by step, and within a step by expiration, in a single pass.
+///
+/// # Errors
+///
+/// Returns [`ChainError::ClickHouseError`] when a stored value is unreadable or
+/// carries a foreign identity.
+fn assemble(
+    simulation: Uuid,
+    generation: u64,
+    metas: &[SnapshotMetaReadRow],
+    quotes: Vec<QuoteReadRow>,
+) -> Result<Vec<SnapshotRecord>, ChainError> {
+    let mut by_step: BTreeMap<u64, Vec<QuoteReadRow>> = BTreeMap::new();
+    for row in quotes {
+        by_step.entry(row.step).or_default().push(row);
+    }
+
+    let mut records = Vec::with_capacity(metas.len());
+    for meta in metas {
+        let rows = by_step.remove(&meta.step).unwrap_or_default();
+
+        // The completion check. A marker promising more rows than the table
+        // holds means the batch never fully landed, or that retention has
+        // started eating the snapshot; either way it is not a snapshot anyone
+        // should price against.
+        //
+        // The saturating fallback cannot fire on any target this builds for —
+        // `usize` is at most 64 bits — and a hypothetical wider one would
+        // saturate to a count that disagrees with any marker, which fails
+        // closed: the snapshot is skipped rather than served short.
+        let stored = u64::try_from(rows.len()).unwrap_or(u64::MAX);
+        if stored != meta.quote_count {
+            warn!(
+                simulation = %simulation,
+                generation,
+                step = meta.step,
+                expected = meta.quote_count,
+                stored,
+                "Skipping an incomplete persisted snapshot"
+            );
+            continue;
+        }
+
+        records.push(record_from_rows(simulation, generation, meta, &rows)?);
+    }
+
+    Ok(records)
+}
+
+/// Validates an inclusive step range.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the range is reversed or a bound
+/// does not fit its column.
+fn step_bounds(from_step: usize, to_step: usize) -> Result<(u64, u64), ChainError> {
+    if from_step > to_step {
+        return Err(ChainError::Validation {
+            field: "from_step".to_string(),
+            reason: format!("must not exceed to_step, got {from_step} > {to_step}"),
+        });
+    }
+
+    let from = u64::try_from(from_step).map_err(|_| ChainError::Validation {
+        field: "from_step".to_string(),
+        reason: format!("{from_step} does not fit a UInt64 column"),
+    })?;
+    let to = u64::try_from(to_step).map_err(|_| ChainError::Validation {
+        field: "to_step".to_string(),
+        reason: format!("{to_step} does not fit a UInt64 column"),
+    })?;
+
+    Ok((from, to))
+}
+
+/// The current ingestion timestamp, in unix milliseconds.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when the host clock is before 1970, which
+/// would make the `ReplacingMergeTree` version meaningless.
+fn ingestion_timestamp_ms() -> Result<u64, ChainError> {
+    u64::try_from(Utc::now().timestamp_millis())
+        .map_err(|_| ChainError::Internal("the host clock is before 1970".to_string()))
+}
+
+#[async_trait]
+impl SnapshotWriter for ClickHouseSnapshotRepository {
+    /// Writes the batch as ONE `INSERT`.
+    ///
+    /// `Insert::write` buffers and flushes in chunks over a single request, so
+    /// the loop is one network conversation regardless of how many rows it
+    /// carries — the opposite of an insert per contract, which is what the
+    /// issue rules out.
+    async fn write_quote_batch(&self, rows: &[OptionQuoteRow]) -> Result<(), ChainError> {
+        let timeout = Some(self.config.insert_timeout);
+        let mut insert = self
+            .client
+            .client
+            .insert::<OptionQuoteRow>(QUOTES_TABLE)
+            .await?
+            .with_timeouts(timeout, timeout);
+
+        for row in rows {
+            insert.write(row).await?;
+        }
+        insert.end().await?;
+
+        Ok(())
+    }
+
+    async fn write_completion_marker(&self, row: &SnapshotMetaRow) -> Result<(), ChainError> {
+        let timeout = Some(self.config.insert_timeout);
+        let mut insert = self
+            .client
+            .client
+            .insert::<SnapshotMetaRow>(SNAPSHOTS_TABLE)
+            .await?
+            .with_timeouts(timeout, timeout);
+
+        insert.write(row).await?;
+        insert.end().await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimulationSnapshotRepository for ClickHouseSnapshotRepository {
+    #[instrument(
+        skip(self, record),
+        fields(
+            simulation = %record.simulation,
+            generation = record.generation,
+            step = record.step,
+        ),
+        level = "debug"
+    )]
+    async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
+        record.validate()?;
+
+        let quote_count = record.quote_count();
+        if quote_count > self.config.batch_rows {
+            return Err(ChainError::Validation {
+                field: "OCS_SNAPSHOT_BATCH_ROWS".to_string(),
+                reason: format!(
+                    "the snapshot holds {quote_count} quote rows, above the configured bound of {}",
+                    self.config.batch_rows
+                ),
+            });
+        }
+
+        let inserted_at_ms = ingestion_timestamp_ms()?;
+        let quotes = quote_rows(&record, inserted_at_ms)?;
+        let marker = meta_row(&record, inserted_at_ms)?;
+
+        run_completion_protocol(self, &quotes, &marker).await?;
+
+        debug!(rows = quotes.len(), "Persisted a v2 snapshot");
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn get(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        step: usize,
+    ) -> Result<Option<SnapshotRecord>, ChainError> {
+        let (from, to) = step_bounds(step, step)?;
+
+        let metas = self
+            .fetch_meta_rows(simulation, generation, from, to)
+            .await?;
+        let Some(meta) = metas.first() else {
+            return Ok(None);
+        };
+
+        // Checked before reading the rows: a snapshot too large to return is a
+        // configuration answer, not a silently empty one.
+        let expected = usize::try_from(meta.quote_count).unwrap_or(usize::MAX);
+        self.reject_if_over_budget(expected, "quotes")?;
+
+        let quotes = self
+            .fetch_quote_rows(simulation, generation, from, to)
+            .await?;
+        let mut records = assemble(simulation, generation, std::slice::from_ref(meta), quotes)?;
+
+        Ok(records.pop())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn read_range(
+        &self,
+        simulation: Uuid,
+        generation: u64,
+        from_step: usize,
+        to_step: usize,
+    ) -> Result<Vec<SnapshotRecord>, ChainError> {
+        let (from, to) = step_bounds(from_step, to_step)?;
+
+        let metas = self
+            .fetch_meta_rows(simulation, generation, from, to)
+            .await?;
+        let quotes = self
+            .fetch_quote_rows(simulation, generation, from, to)
+            .await?;
+
+        let records = assemble(simulation, generation, &metas, quotes)?;
+        debug!(steps = records.len(), "Read a range of persisted snapshots");
+
+        Ok(records)
+    }
+
+    #[instrument(
+        skip(self, query),
+        fields(simulation = %query.simulation, side = %query.side),
+        level = "debug"
+    )]
+    async fn contract_series(
+        &self,
+        query: ContractSeriesQuery,
+    ) -> Result<Vec<ContractQuote>, ChainError> {
+        let (from, to) = step_bounds(query.from_step, query.to_step)?;
+        let expires_at = to_storage_instant(query.expires_at, "expires_at")?;
+        // The strike is matched as a decimal literal, not as a scaled integer:
+        // the column is `Decimal(38, 28)` and `toDecimal128` parses the same
+        // text `Positive` renders, so equality is exact.
+        let strike_text = query.strike.to_dec().to_string();
+        // Rendered once here purely to fail early on an unrepresentable strike;
+        // the comparison itself uses the text above.
+        to_storage_positive(query.strike, "strike")?;
+
+        let sql = contract_series_query(query.side, self.probe_limit()?);
+        let rows = self
+            .client
+            .client
+            .query(&sql)
+            .param("simulation", query.simulation.to_string())
+            .param("generation", query.generation)
+            .param("from_step", from)
+            .param("to_step", to)
+            .param("expires_at", expires_at)
+            .param("strike", strike_text)
+            .fetch_all::<ContractReadRow>()
+            .await?;
+
+        self.reject_if_over_budget(rows.len(), "quotes")?;
+
+        let mut series = Vec::with_capacity(rows.len());
+        for row in &rows {
+            series.push(contract_quote_from_row(row, query.side)?);
+        }
+
+        debug!(points = series.len(), "Read a contract history");
+        Ok(series)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::clickhouse::snapshots::model::{DECIMAL_SCALE, to_storage_decimal};
+    use crate::infrastructure::clickhouse::snapshots::record::{ExpirationRecord, QuoteRow};
+    use chrono::{DateTime, TimeZone};
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+    use std::str::FromStr;
+    use std::sync::Mutex;
+
+    fn instant(day: u32) -> DateTime<Utc> {
+        match Utc.with_ymd_and_hms(2026, 1, day, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        }
+    }
+
+    /// A quote whose call bid carries the full 29 significant digits a
+    /// `Decimal` can hold.
+    ///
+    /// Upstream's Black-Scholes kernels produce premiums like this, and they
+    /// are exactly the values a `Float64` column would quietly round — so the
+    /// fixture keeps one, and every round-trip assertion below is really an
+    /// assertion about precision.
+    fn full_precision_premium() -> Positive {
+        let value = match Decimal::from_str("1.234567890123456789012345678") {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture decimal must parse: {error}"),
+        };
+        match Positive::new_decimal(value) {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture premium must be positive: {error}"),
+        }
+    }
+
+    fn quote(strike: f64) -> QuoteRow {
+        QuoteRow::new(pos_or_panic!(strike), pos_or_panic!(0.185))
+            .with_call(
+                Some(full_precision_premium()),
+                Some(pos_or_panic!(1.35)),
+                Some(pos_or_panic!(1.2)),
+                Some(dec!(0.5123)),
+            )
+            .with_put(
+                Some(pos_or_panic!(0.95)),
+                Some(pos_or_panic!(1.15)),
+                None,
+                Some(dec!(-0.4877)),
+            )
+            .with_gamma(Some(dec!(0.00312345)))
+    }
+
+    fn record(simulation: Uuid, step: usize) -> SnapshotRecord {
+        SnapshotRecord::new(
+            simulation,
+            2,
+            step,
+            instant(5),
+            "SPX".to_string(),
+            pos_or_panic!(5000.25),
+            pos_or_panic!(0.18),
+            vec![
+                ExpirationRecord::new(
+                    instant(6),
+                    pos_or_panic!(1.5),
+                    vec!["weeklies".to_string(), "zero_dte".to_string()],
+                    vec![quote(4975.0), quote(5000.0), quote(5025.0)],
+                ),
+                ExpirationRecord::new(
+                    instant(9),
+                    pos_or_panic!(4.5),
+                    vec!["weeklies".to_string()],
+                    vec![quote(4975.0), quote(5000.0)],
+                ),
+            ],
+        )
+    }
+
+    /// What a writer was asked to do, in order.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum WriteOp {
+        /// A quote batch of the given size.
+        Batch(usize),
+        /// The completion marker, promising the given row count.
+        Marker(u64),
+    }
+
+    /// A writer that records the protocol instead of performing it.
+    #[derive(Default)]
+    struct RecordingWriter {
+        operations: Mutex<Vec<WriteOp>>,
+        fail_batch: bool,
+    }
+
+    impl RecordingWriter {
+        fn failing() -> Self {
+            Self {
+                operations: Mutex::new(Vec::new()),
+                fail_batch: true,
+            }
+        }
+
+        fn operations(&self) -> Vec<WriteOp> {
+            match self.operations.lock() {
+                Ok(operations) => operations.clone(),
+                Err(error) => panic!("the recorder must not be poisoned: {error}"),
+            }
+        }
+
+        fn push(&self, operation: WriteOp) {
+            match self.operations.lock() {
+                Ok(mut operations) => operations.push(operation),
+                Err(error) => panic!("the recorder must not be poisoned: {error}"),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SnapshotWriter for RecordingWriter {
+        async fn write_quote_batch(&self, rows: &[OptionQuoteRow]) -> Result<(), ChainError> {
+            self.push(WriteOp::Batch(rows.len()));
+            if self.fail_batch {
+                return Err(ChainError::ClickHouseError(
+                    "the warehouse is down".to_string(),
+                ));
+            }
+            Ok(())
+        }
+
+        async fn write_completion_marker(&self, row: &SnapshotMetaRow) -> Result<(), ChainError> {
+            self.push(WriteOp::Marker(row.quote_count));
+            Ok(())
+        }
+    }
+
+    fn rows_for(record: &SnapshotRecord) -> (Vec<OptionQuoteRow>, SnapshotMetaRow) {
+        let quotes = match quote_rows(record, 1) {
+            Ok(rows) => rows,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+        let marker = match meta_row(record, 1) {
+            Ok(row) => row,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+        (quotes, marker)
+    }
+
+    /// The read rows a range query would return for a record.
+    fn read_rows(record: &SnapshotRecord) -> (SnapshotMetaReadRow, Vec<QuoteReadRow>) {
+        let (quotes, marker) = rows_for(record);
+
+        let meta = SnapshotMetaReadRow {
+            step: marker.step,
+            snapshot_id: marker.snapshot_id,
+            simulated_at: marker.simulated_at,
+            symbol: marker.symbol,
+            underlying_price: marker.underlying_price,
+            base_volatility: marker.base_volatility,
+            quote_count: marker.quote_count,
+        };
+        let quotes = quotes
+            .into_iter()
+            .map(|row| QuoteReadRow {
+                step: row.step,
+                expires_at: row.expires_at,
+                days_to_expiration: row.days_to_expiration,
+                labels: row.labels,
+                strike: row.strike,
+                implied_volatility: row.implied_volatility,
+                call_bid: row.call_bid,
+                call_ask: row.call_ask,
+                call_mid: row.call_mid,
+                put_bid: row.put_bid,
+                put_ask: row.put_ask,
+                put_mid: row.put_mid,
+                delta_call: row.delta_call,
+                delta_put: row.delta_put,
+                gamma: row.gamma,
+            })
+            .collect();
+
+        (meta, quotes)
+    }
+
+    // ---- the write protocol ------------------------------------------------
+
+    /// Every quote row of a snapshot goes out in ONE batch.
+    ///
+    /// The acceptance criterion that rules out an insert per contract: a
+    /// five-row snapshot must produce exactly one batch carrying five rows, not
+    /// five batches of one.
+    #[tokio::test]
+    async fn test_a_snapshot_writes_its_quotes_in_one_batch() {
+        let writer = RecordingWriter::default();
+        let (quotes, marker) = rows_for(&record(Uuid::from_u128(1), 0));
+
+        match run_completion_protocol(&writer, &quotes, &marker).await {
+            Ok(()) => {}
+            Err(error) => panic!("the protocol must complete: {error}"),
+        }
+
+        let operations = writer.operations();
+        let batches: Vec<&WriteOp> = operations
+            .iter()
+            .filter(|operation| matches!(operation, WriteOp::Batch(_)))
+            .collect();
+        assert_eq!(batches.len(), 1, "one snapshot must be one insert");
+        assert_eq!(batches.first(), Some(&&WriteOp::Batch(5)));
+    }
+
+    /// The marker is written last, so a reader never meets it before the rows
+    /// it promises.
+    #[tokio::test]
+    async fn test_the_marker_is_written_after_the_quotes() {
+        let writer = RecordingWriter::default();
+        let (quotes, marker) = rows_for(&record(Uuid::from_u128(1), 0));
+
+        match run_completion_protocol(&writer, &quotes, &marker).await {
+            Ok(()) => {}
+            Err(error) => panic!("the protocol must complete: {error}"),
+        }
+
+        assert_eq!(
+            writer.operations(),
+            vec![WriteOp::Batch(5), WriteOp::Marker(5)]
+        );
+    }
+
+    /// A failed batch never leaves a marker behind, which is what makes a
+    /// half-written snapshot invisible instead of corrupt.
+    #[tokio::test]
+    async fn test_a_failed_batch_writes_no_marker() {
+        let writer = RecordingWriter::failing();
+        let (quotes, marker) = rows_for(&record(Uuid::from_u128(1), 0));
+
+        match run_completion_protocol(&writer, &quotes, &marker).await {
+            Err(ChainError::ClickHouseError(_)) => {}
+            other => panic!("expected the batch failure to propagate, got {other:?}"),
+        }
+
+        assert_eq!(writer.operations(), vec![WriteOp::Batch(5)]);
+    }
+
+    /// An empty snapshot writes its marker and no batch at all: an empty insert
+    /// is a round trip that stores nothing.
+    #[tokio::test]
+    async fn test_an_empty_snapshot_writes_only_its_marker() {
+        let writer = RecordingWriter::default();
+        let mut empty = record(Uuid::from_u128(1), 0);
+        empty.expirations.clear();
+        let (quotes, marker) = rows_for(&empty);
+
+        match run_completion_protocol(&writer, &quotes, &marker).await {
+            Ok(()) => {}
+            Err(error) => panic!("the protocol must complete: {error}"),
+        }
+
+        assert_eq!(writer.operations(), vec![WriteOp::Marker(0)]);
+    }
+
+    // ---- the completion check ---------------------------------------------
+
+    /// A snapshot whose rows match its marker reconstructs exactly.
+    #[test]
+    fn test_a_complete_snapshot_reconstructs() {
+        let original = record(Uuid::from_u128(3), 4);
+        let (meta, quotes) = read_rows(&original);
+
+        match assemble(original.simulation, original.generation, &[meta], quotes) {
+            Ok(records) => assert_eq!(records, vec![original]),
+            Err(error) => panic!("the snapshot must reconstruct: {error}"),
+        }
+    }
+
+    /// A marker promising more rows than the table holds is treated as absent.
+    ///
+    /// This is the case a torn write leaves behind, and the reason the count
+    /// travels with the marker.
+    #[test]
+    fn test_a_marker_missing_quotes_reads_as_absent() {
+        let original = record(Uuid::from_u128(3), 4);
+        let (meta, mut quotes) = read_rows(&original);
+        quotes.pop();
+
+        match assemble(original.simulation, original.generation, &[meta], quotes) {
+            Ok(records) => assert!(
+                records.is_empty(),
+                "an incomplete snapshot must not surface"
+            ),
+            Err(error) => panic!("an incomplete snapshot is not an error: {error}"),
+        }
+    }
+
+    /// A marker with no rows at all is treated as absent too — the state a
+    /// failed batch would leave if the marker had somehow been written.
+    #[test]
+    fn test_a_marker_with_no_quotes_reads_as_absent() {
+        let original = record(Uuid::from_u128(3), 4);
+        let (meta, _) = read_rows(&original);
+
+        match assemble(
+            original.simulation,
+            original.generation,
+            &[meta],
+            Vec::new(),
+        ) {
+            Ok(records) => assert!(records.is_empty()),
+            Err(error) => panic!("an incomplete snapshot is not an error: {error}"),
+        }
+    }
+
+    /// A range keeps the complete steps and drops the incomplete ones, rather
+    /// than failing the whole read: the caller can replay what is missing.
+    #[test]
+    fn test_a_range_skips_only_the_incomplete_steps() {
+        let simulation = Uuid::from_u128(3);
+        let (first_meta, first_quotes) = read_rows(&record(simulation, 0));
+        let (second_meta, mut second_quotes) = read_rows(&record(simulation, 1));
+        let (third_meta, third_quotes) = read_rows(&record(simulation, 2));
+        second_quotes.truncate(1);
+
+        let mut quotes = first_quotes;
+        quotes.extend(second_quotes);
+        quotes.extend(third_quotes);
+
+        match assemble(
+            simulation,
+            2,
+            &[first_meta, second_meta, third_meta],
+            quotes,
+        ) {
+            Ok(records) => {
+                let steps: Vec<usize> = records.iter().map(|record| record.step).collect();
+                assert_eq!(steps, vec![0, 2]);
+            }
+            Err(error) => panic!("the range must read: {error}"),
+        }
+    }
+
+    /// A range comes back ascending by step, which is what an export streams.
+    #[test]
+    fn test_a_range_reconstructs_in_step_order() {
+        let simulation = Uuid::from_u128(3);
+        let mut metas = Vec::new();
+        let mut quotes = Vec::new();
+        for step in 0..3 {
+            let (meta, rows) = read_rows(&record(simulation, step));
+            metas.push(meta);
+            quotes.extend(rows);
+        }
+
+        match assemble(simulation, 2, &metas, quotes) {
+            Ok(records) => {
+                let steps: Vec<usize> = records.iter().map(|record| record.step).collect();
+                assert_eq!(steps, vec![0, 1, 2]);
+            }
+            Err(error) => panic!("the range must read: {error}"),
+        }
+    }
+
+    // ---- query construction ------------------------------------------------
+
+    /// Every read deduplicates, immediately rather than eventually.
+    #[test]
+    fn test_every_row_read_uses_final() {
+        assert!(META_RANGE_QUERY.contains("simulation_snapshots FINAL"));
+        assert!(QUOTES_RANGE_QUERY.contains("simulation_option_quotes FINAL"));
+        assert!(contract_series_query(ContractSide::Call, 10).contains("AS quote FINAL"));
+    }
+
+    /// The completeness subquery counts deduplicated rows without paying for
+    /// `FINAL`, and compares them against the marker.
+    #[test]
+    fn test_the_completeness_subquery_deduplicates_its_count() {
+        assert!(COMPLETE_STEPS_SUBQUERY.contains("uniqExact((expires_at, strike))"));
+        assert!(COMPLETE_STEPS_SUBQUERY.contains("marker.quote_count = counted.stored"));
+        assert!(COMPLETE_STEPS_SUBQUERY.contains("complete = true"));
+    }
+
+    /// A contract history only ever reads complete steps.
+    #[test]
+    fn test_a_contract_history_filters_on_complete_steps() {
+        let sql = contract_series_query(ContractSide::Put, 100);
+
+        assert!(sql.contains("quote.step IN (SELECT marker.step"));
+        assert!(sql.contains("uniqExact"));
+    }
+
+    /// The side selects columns, and nothing else about the query changes.
+    #[test]
+    fn test_the_side_only_changes_the_projected_columns() {
+        let call = contract_series_query(ContractSide::Call, 100);
+        let put = contract_series_query(ContractSide::Put, 100);
+
+        assert!(call.contains("quote.call_bid AS bid"));
+        assert!(call.contains("quote.delta_call AS delta"));
+        assert!(!call.contains("put_bid AS bid"));
+        assert!(put.contains("quote.put_bid AS bid"));
+        assert!(put.contains("quote.delta_put AS delta"));
+        assert!(!put.contains("call_bid AS bid"));
+
+        // The gamma is shared by both sides, so both project the same column.
+        assert!(call.contains("quote.gamma AS gamma"));
+        assert!(put.contains("quote.gamma AS gamma"));
+    }
+
+    /// Every value a caller controls is a named server-side parameter; none of
+    /// them is ever interpolated into the SQL text.
+    #[test]
+    fn test_caller_values_are_bound_as_named_parameters() {
+        let queries = [
+            META_RANGE_QUERY.to_string(),
+            QUOTES_RANGE_QUERY.to_string(),
+            contract_series_query(ContractSide::Call, 100),
+        ];
+
+        for sql in &queries {
+            assert!(sql.contains("{simulation:String}"), "{sql}");
+            assert!(sql.contains("{generation:UInt64}"), "{sql}");
+            // No quoting means no place for an injected literal to hide.
+            assert!(!sql.contains('\''), "{sql}");
+        }
+
+        let series = contract_series_query(ContractSide::Call, 100);
+        assert!(series.contains("fromUnixTimestamp64Nano({expires_at:Int64})"));
+        assert!(series.contains("toDecimal128({strike:String}, 28)"));
+    }
+
+    /// The strike is compared at the scale the column stores, so an exact
+    /// strike matches exactly.
+    #[test]
+    fn test_the_strike_comparison_uses_the_storage_scale() {
+        let sql = contract_series_query(ContractSide::Call, 10);
+
+        assert!(sql.contains(&format!("toDecimal128({{strike:String}}, {DECIMAL_SCALE})")));
+    }
+
+    /// A range query carries the configured bound, plus one so truncation is
+    /// detectable.
+    #[test]
+    fn test_a_range_query_carries_its_probe_limit() {
+        assert!(with_probe_limit(META_RANGE_QUERY, 501).ends_with("LIMIT 501"));
+        assert!(contract_series_query(ContractSide::Put, 77).ends_with("LIMIT 77"));
+    }
+
+    /// A read at the probe limit is an error naming the knob, never a quietly
+    /// short answer.
+    #[test]
+    fn test_an_over_long_read_names_the_knob() {
+        let repository = ClickHouseSnapshotRepository::new(
+            match ClickHouseClient::new(ClickHouseConfig::default()) {
+                Ok(client) => Arc::new(client),
+                Err(error) => panic!("the client must build: {error}"),
+            },
+            SnapshotPersistenceConfig {
+                max_read_rows: 10,
+                ..SnapshotPersistenceConfig::default()
+            },
+        );
+
+        match repository.probe_limit() {
+            Ok(limit) => assert_eq!(limit, 11),
+            Err(error) => panic!("the probe limit must be computable: {error}"),
+        }
+        match repository.reject_if_over_budget(11, "quotes") {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_MAX_READ_ROWS");
+                assert!(reason.contains("smaller step range"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+        assert!(repository.reject_if_over_budget(10, "quotes").is_ok());
+    }
+
+    // ---- schema ------------------------------------------------------------
+
+    /// The DDL is complete after substitution: no placeholder survives, and the
+    /// retention lands in the TTL.
+    #[test]
+    fn test_the_ddl_substitutes_its_retention() {
+        let statement = SNAPSHOTS_DDL.replace(RETENTION_PLACEHOLDER, "45");
+
+        assert!(!statement.contains(RETENTION_PLACEHOLDER));
+        assert!(statement.contains("INTERVAL 45 DAY DELETE"));
+    }
+
+    /// The engine, ordering and partitioning are the ones the query patterns
+    /// were designed against — a change to any of them breaks either
+    /// deduplication or the access path, so it must be deliberate.
+    #[test]
+    fn test_the_schema_keeps_its_engine_and_keys() {
+        assert!(SNAPSHOTS_DDL.contains("ENGINE = ReplacingMergeTree(inserted_at_ms)"));
+        assert!(SNAPSHOTS_DDL.contains("ORDER BY (simulation_id, simulation_generation, step)"));
+        assert!(SNAPSHOTS_DDL.contains("PARTITION BY toYYYYMM(simulated_at)"));
+
+        assert!(QUOTES_DDL.contains("ENGINE = ReplacingMergeTree(inserted_at_ms)"));
+        assert!(
+            QUOTES_DDL.contains(
+                "ORDER BY (simulation_id, simulation_generation, step, expires_at, strike)"
+            )
+        );
+        assert!(QUOTES_DDL.contains("PARTITION BY toYYYYMM(simulated_at)"));
+        assert!(QUOTES_DDL.contains("INDEX idx_contract (expires_at, strike) TYPE minmax"));
+    }
+
+    /// The partition key is derived from the row's own content, not from when
+    /// it was written.
+    ///
+    /// The subtle one: `ReplacingMergeTree` only deduplicates inside a
+    /// partition, so partitioning on the ingestion time would let a backfill
+    /// survive as a duplicate of the row it was meant to replace.
+    #[test]
+    fn test_the_partition_key_is_deterministic() {
+        for ddl in [SNAPSHOTS_DDL, QUOTES_DDL] {
+            assert!(ddl.contains("PARTITION BY toYYYYMM(simulated_at)"));
+            assert!(
+                !ddl.contains("PARTITION BY toYYYYMM(inserted"),
+                "partitioning on the ingestion time would break deduplication"
+            );
+        }
+    }
+
+    /// Retention is anchored to ingestion time, because simulated time may sit
+    /// years in the future.
+    #[test]
+    fn test_retention_is_anchored_to_ingestion_time() {
+        for ddl in [SNAPSHOTS_DDL, QUOTES_DDL] {
+            assert!(ddl.contains("TTL toDateTime(intDiv(inserted_at_ms, 1000))"));
+        }
+    }
+
+    /// Every decimal column stores at the scale that never rounds a
+    /// `rust_decimal`.
+    #[test]
+    fn test_the_decimal_columns_match_the_storage_scale() {
+        let column = format!("Decimal(38, {DECIMAL_SCALE})");
+
+        assert!(SNAPSHOTS_DDL.contains(&column));
+        assert!(QUOTES_DDL.contains(&column));
+        // A quote upstream never priced must survive as absent rather than as
+        // a zero, so every optional column is nullable: six quotes, two deltas
+        // and gamma.
+        assert_eq!(
+            QUOTES_DDL.matches(&format!("Nullable({column})")).count(),
+            9
+        );
+    }
+
+    // ---- bounds ------------------------------------------------------------
+
+    /// A reversed range is refused before it reaches the warehouse.
+    #[test]
+    fn test_a_reversed_range_is_refused() {
+        match step_bounds(9, 4) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "from_step");
+                assert!(reason.contains("must not exceed to_step"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A single step is a legal range.
+    #[test]
+    fn test_a_single_step_range_is_accepted() {
+        match step_bounds(7, 7) {
+            Ok(bounds) => assert_eq!(bounds, (7, 7)),
+            Err(error) => panic!("a single-step range must be accepted: {error}"),
+        }
+    }
+
+    /// A snapshot above the batch bound never reaches the warehouse.
+    #[tokio::test]
+    async fn test_an_oversized_snapshot_is_refused() {
+        let repository = ClickHouseSnapshotRepository::new(
+            match ClickHouseClient::new(ClickHouseConfig::default()) {
+                Ok(client) => Arc::new(client),
+                Err(error) => panic!("the client must build: {error}"),
+            },
+            SnapshotPersistenceConfig {
+                batch_rows: 2,
+                ..SnapshotPersistenceConfig::default()
+            },
+        );
+
+        // Five rows against a bound of two: refused before any I/O, which is
+        // why this test needs no server.
+        match repository.persist(record(Uuid::from_u128(1), 0)).await {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "OCS_SNAPSHOT_BATCH_ROWS");
+                assert!(reason.contains("above the configured bound"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A malformed record is refused before any I/O too.
+    #[tokio::test]
+    async fn test_a_malformed_record_is_refused() {
+        let repository = ClickHouseSnapshotRepository::new(
+            match ClickHouseClient::new(ClickHouseConfig::default()) {
+                Ok(client) => Arc::new(client),
+                Err(error) => panic!("the client must build: {error}"),
+            },
+            SnapshotPersistenceConfig::default(),
+        );
+        let mut unordered = record(Uuid::from_u128(1), 0);
+        unordered.expirations.reverse();
+
+        match repository.persist(unordered).await {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "expirations"),
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The repository reports the limits it was built with.
+    #[test]
+    fn test_the_repository_exposes_its_configuration() {
+        let config = SnapshotPersistenceConfig {
+            batch_rows: 7,
+            ..SnapshotPersistenceConfig::default()
+        };
+        let repository = ClickHouseSnapshotRepository::new(
+            match ClickHouseClient::new(ClickHouseConfig::default()) {
+                Ok(client) => Arc::new(client),
+                Err(error) => panic!("the client must build: {error}"),
+            },
+            config,
+        );
+
+        assert_eq!(repository.config().batch_rows, 7);
+    }
+
+    /// Persistence off means no repository at all, so a deployment without a
+    /// warehouse never attempts a write.
+    #[test]
+    fn test_a_disabled_configuration_builds_no_repository() {
+        // The ambient environment leaves the knob unset, and the default is
+        // off — the state every existing deployment is in.
+        match ClickHouseSnapshotRepository::from_env() {
+            Ok(None) => {}
+            Ok(Some(_)) => {
+                // Only reachable when an operator enabled it in this shell.
+                assert!(
+                    std::env::var("OCS_SNAPSHOT_PERSISTENCE_ENABLED").is_ok(),
+                    "persistence must not switch itself on"
+                );
+            }
+            Err(error) => panic!("the ambient environment must load: {error}"),
+        }
+    }
+
+    /// The scaled form of a strike agrees with the text the query compares
+    /// against, so a match is exact rather than approximate.
+    #[test]
+    fn test_the_strike_text_and_its_storage_form_agree() {
+        let strike = pos_or_panic!(5000.25);
+        let text = strike.to_dec().to_string();
+
+        assert_eq!(text, "5000.25");
+        match to_storage_decimal(dec!(5000.25), "strike") {
+            Ok(scaled) => assert_eq!(scaled, 50_002_500_000_000_000_000_000_000_000_000_i128),
+            Err(error) => panic!("the strike must scale: {error}"),
+        }
+    }
+
+    // ---- live ClickHouse ---------------------------------------------------
+
+    /// Builds a repository against the ambient `CLICKHOUSE_*` configuration.
+    fn live_repository() -> ClickHouseSnapshotRepository {
+        let client = match ClickHouseClient::new(ClickHouseConfig::default()) {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("the client must build: {error}"),
+        };
+        ClickHouseSnapshotRepository::new(client, SnapshotPersistenceConfig::default())
+    }
+
+    /// Removes a test simulation's rows, best effort.
+    async fn cleanup(repository: &ClickHouseSnapshotRepository, simulation: Uuid) {
+        for table in [SNAPSHOTS_TABLE, QUOTES_TABLE] {
+            let _ = repository
+                .client
+                .client
+                .query(&format!(
+                    "DELETE FROM {table} WHERE simulation_id = {{simulation:String}}"
+                ))
+                .param("simulation", simulation.to_string())
+                .execute()
+                .await;
+        }
+    }
+
+    /// The acceptance criterion, end to end: a snapshot written to a real
+    /// ClickHouse reconstructs into exactly the record that was written.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_a_snapshot_round_trips_through_live_clickhouse() {
+        let repository = live_repository();
+        let simulation = Uuid::new_v4();
+
+        match repository.ensure_schema().await {
+            Ok(()) => {}
+            Err(error) => panic!("the schema must be creatable: {error}"),
+        }
+
+        let original = record(simulation, 0);
+        match repository.persist(original.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("the snapshot must persist: {error}"),
+        }
+
+        let read = repository.get(simulation, original.generation, 0).await;
+        cleanup(&repository, simulation).await;
+
+        match read {
+            Ok(Some(reconstructed)) => assert_eq!(reconstructed, original),
+            other => panic!("the snapshot must reconstruct, got {other:?}"),
+        }
+    }
+
+    /// Persisting the same snapshot twice is idempotent from every read path,
+    /// immediately — before any background merge has had a chance to run.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_persisting_twice_is_idempotent_against_live_clickhouse() {
+        let repository = live_repository();
+        let simulation = Uuid::new_v4();
+
+        match repository.ensure_schema().await {
+            Ok(()) => {}
+            Err(error) => panic!("the schema must be creatable: {error}"),
+        }
+
+        let original = record(simulation, 0);
+        for _ in 0..2 {
+            match repository.persist(original.clone()).await {
+                Ok(()) => {}
+                Err(error) => panic!("the snapshot must persist: {error}"),
+            }
+        }
+
+        let single = repository.get(simulation, original.generation, 0).await;
+        let range = repository
+            .read_range(simulation, original.generation, 0, 0)
+            .await;
+        let series = repository
+            .contract_series(ContractSeriesQuery::new(
+                simulation,
+                original.generation,
+                instant(6),
+                pos_or_panic!(5000.0),
+                ContractSide::Call,
+                0,
+                0,
+            ))
+            .await;
+        cleanup(&repository, simulation).await;
+
+        match single {
+            Ok(Some(reconstructed)) => assert_eq!(reconstructed, original),
+            other => panic!("the snapshot must reconstruct, got {other:?}"),
+        }
+        match range {
+            Ok(records) => assert_eq!(records, vec![original]),
+            other => panic!("the range must hold one snapshot, got {other:?}"),
+        }
+        match series {
+            Ok(points) => assert_eq!(points.len(), 1, "a retry must not duplicate a quote"),
+            other => panic!("the series must read, got {other:?}"),
+        }
+    }
+
+    /// A marker whose quotes never landed reads as absent rather than as a
+    /// snapshot with holes in it.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_a_torn_write_reads_as_absent_against_live_clickhouse() {
+        let repository = live_repository();
+        let simulation = Uuid::new_v4();
+
+        match repository.ensure_schema().await {
+            Ok(()) => {}
+            Err(error) => panic!("the schema must be creatable: {error}"),
+        }
+
+        // The state a crash between the two writes would leave: a marker
+        // promising five rows, with none of them on disk.
+        let original = record(simulation, 0);
+        let marker = match meta_row(&original, 1) {
+            Ok(row) => row,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+        match repository.write_completion_marker(&marker).await {
+            Ok(()) => {}
+            Err(error) => panic!("the marker must write: {error}"),
+        }
+
+        let read = repository.get(simulation, original.generation, 0).await;
+        let range = repository
+            .read_range(simulation, original.generation, 0, 0)
+            .await;
+        cleanup(&repository, simulation).await;
+
+        match read {
+            Ok(None) => {}
+            other => panic!("a torn write must read as absent, got {other:?}"),
+        }
+        match range {
+            Ok(records) => assert!(records.is_empty()),
+            other => panic!("a torn write must not appear in a range, got {other:?}"),
+        }
+    }
+
+    /// A snapshot whose marker promises more rows than the table holds is
+    /// invisible from every read path, including the contract history.
+    ///
+    /// The state a batch that landed short would leave. It also exercises the
+    /// marker's own deduplication: two markers exist for the coordinate, and
+    /// `FINAL` must resolve to the newer one.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_a_short_batch_hides_the_snapshot_against_live_clickhouse() {
+        let repository = live_repository();
+        let simulation = Uuid::new_v4();
+
+        match repository.ensure_schema().await {
+            Ok(()) => {}
+            Err(error) => panic!("the schema must be creatable: {error}"),
+        }
+
+        let original = record(simulation, 0);
+        match repository.persist(original.clone()).await {
+            Ok(()) => {}
+            Err(error) => panic!("the snapshot must persist: {error}"),
+        }
+
+        // A later marker claiming one row more than the batch wrote. Later, so
+        // ReplacingMergeTree prefers it over the honest one.
+        let later = match ingestion_timestamp_ms() {
+            Ok(now) => now + 1_000,
+            Err(error) => panic!("the clock must be readable: {error}"),
+        };
+        let mut inflated = match meta_row(&original, later) {
+            Ok(row) => row,
+            Err(error) => panic!("the record must convert: {error}"),
+        };
+        inflated.quote_count += 1;
+        match repository.write_completion_marker(&inflated).await {
+            Ok(()) => {}
+            Err(error) => panic!("the marker must write: {error}"),
+        }
+
+        let read = repository.get(simulation, original.generation, 0).await;
+        let range = repository
+            .read_range(simulation, original.generation, 0, 0)
+            .await;
+        let series = repository
+            .contract_series(ContractSeriesQuery::new(
+                simulation,
+                original.generation,
+                instant(6),
+                pos_or_panic!(5000.0),
+                ContractSide::Call,
+                0,
+                0,
+            ))
+            .await;
+        cleanup(&repository, simulation).await;
+
+        match read {
+            Ok(None) => {}
+            other => panic!("a short batch must read as absent, got {other:?}"),
+        }
+        match range {
+            Ok(records) => assert!(records.is_empty()),
+            other => panic!("a short batch must not appear in a range, got {other:?}"),
+        }
+        match series {
+            Ok(points) => assert!(
+                points.is_empty(),
+                "a contract history must not read from an incomplete step"
+            ),
+            other => panic!("the series must read, got {other:?}"),
+        }
+    }
+
+    /// A contract history comes back in simulated-time order, carrying the
+    /// selected side's quotes.
+    #[tokio::test]
+    #[ignore = "requires live ClickHouse on localhost:8123 (override via CLICKHOUSE_* env)"]
+    async fn test_a_contract_history_reads_from_live_clickhouse() {
+        let repository = live_repository();
+        let simulation = Uuid::new_v4();
+
+        match repository.ensure_schema().await {
+            Ok(()) => {}
+            Err(error) => panic!("the schema must be creatable: {error}"),
+        }
+
+        for (step, hours) in [(0_usize, 0_i64), (1, 1), (2, 2)] {
+            let mut snapshot = record(simulation, step);
+            // Distinct simulated instants, so the ordering is observable.
+            snapshot.simulated_at = instant(5) + chrono::Duration::hours(hours);
+            match repository.persist(snapshot).await {
+                Ok(()) => {}
+                Err(error) => panic!("the snapshot must persist: {error}"),
+            }
+        }
+
+        let series = repository
+            .contract_series(ContractSeriesQuery::new(
+                simulation,
+                2,
+                instant(9),
+                pos_or_panic!(5000.0),
+                ContractSide::Put,
+                0,
+                2,
+            ))
+            .await;
+        cleanup(&repository, simulation).await;
+
+        match series {
+            Ok(points) => {
+                let steps: Vec<usize> = points.iter().map(|point| point.step).collect();
+                assert_eq!(steps, vec![0, 1, 2]);
+                for point in &points {
+                    assert_eq!(point.side, ContractSide::Put);
+                    assert_eq!(point.strike, pos_or_panic!(5000.0));
+                    // The put mid is deliberately absent in the fixture, and a
+                    // missing quote must survive as missing.
+                    assert_eq!(point.mid, None);
+                    assert_eq!(point.delta, Some(dec!(-0.4877)));
+                }
+            }
+            other => panic!("the series must read, got {other:?}"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,23 @@
 //! same price path and different premiums. It is a stated difference, tracked
 //! in issue #63 and asked for upstream in optionstratlib#423.
 //!
+//! **Advanced steps can be filed in ClickHouse.** With
+//! `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is
+//! written as one metadata row plus one flattened row per expiration and
+//! strike, so a client can query one contract across time instead of unwinding
+//! whole documents. A peek and an export replay and persist nothing — only the
+//! advance, which is the call that moves the cursor, files anything.
+//!
+//! Filing happens **after** the cursor commits and off the request's clock, so
+//! a degraded warehouse can neither fail a response nor delay one. Row identity
+//! is derived from `(simulation, tape generation, step)`, which makes a retry
+//! replace a row rather than duplicate it, and a reader never sees a snapshot
+//! whose quote rows are missing — the metadata row carries the expected count
+//! and a mismatch reads as absent. Turning the knob on makes ClickHouse a hard
+//! startup dependency: the tables are created at boot, so a schema or
+//! connectivity problem fails the boot rather than surfacing later. MongoDB
+//! stays event and audit only.
+//!
 //! **Replay.** The creation response echoes the effective seed, effective
 //! start, step interval, time frame, timezone, calendar version, IANA tzdb
 //! release and normalised schedules — everything needed to reproduce the run
@@ -154,8 +171,8 @@
 //! - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
 //!   `OCS_V2_CLEANUP_INTERVAL_SECS`, `OCS_MAX_CACHED_TAPES`,
 //!   `OCS_MAX_CACHED_SNAPSHOTS`, `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS`,
-//!   `OCS_MAX_EXPORT_ROWS` — are **validated at startup** and fail the
-//!   process with a message naming the variable. Silently reverting a
+//!   `OCS_MAX_EXPORT_ROWS`, `OCS_SNAPSHOT_*` — are **validated at startup** and
+//!   fail the process with a message naming the variable. Silently reverting a
 //!   retention window would expire simulations a client is still walking, and
 //!   silently reverting a cache bound would change the service's memory
 //!   profile with nothing to show for it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,8 @@
 
 use optionchain_simulator::api::{ListenOn, start_server};
 use optionchain_simulator::infrastructure::{
-    MetricsCollector, RedisClient, RedisConfig, SimulationV2Config, init_mongodb,
+    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, SimulationV2Config,
+    init_mongodb,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
@@ -147,7 +148,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None, // the documented v2 prefix
         Some(v2_config.retention_secs()),
     ));
-    let simulation_manager = Arc::new(SimulationManager::new(simulation_store, v2_config));
+    // Snapshot persistence is opt-in (`OCS_SNAPSHOT_PERSISTENCE_ENABLED`). When
+    // it is off the manager never learns the feature exists; when it is on, the
+    // tables are created here rather than on the first advance, so a schema
+    // problem is a startup failure with a message rather than a warning buried
+    // in the serving path.
+    let mut simulation_manager = SimulationManager::new(simulation_store, v2_config);
+    match ClickHouseSnapshotRepository::from_env()? {
+        Some(warehouse) => {
+            warehouse.ensure_schema().await?;
+            info!("v2 snapshot persistence is enabled");
+            simulation_manager = simulation_manager.with_warehouse(Arc::new(warehouse));
+        }
+        None => {
+            info!("v2 snapshot persistence is disabled; snapshots are served from replay only");
+        }
+    }
+    let simulation_manager = Arc::new(simulation_manager);
 
     // Reap idle simulations and evict what they left cached. Detached, because
     // the sweep is independent of any request; it stops when the process does.

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tables are created here rather than on the first advance, so a schema
     // problem is a startup failure with a message rather than a warning buried
     // in the serving path.
+    //
+    // The manager owns the one repository: it writes through it, and the v2
+    // export reads back through the same handle — the routes take it off the
+    // manager rather than being passed a second one, because two handles could
+    // be configured differently and there is only ever one warehouse.
     let mut simulation_manager = SimulationManager::new(simulation_store, v2_config);
     match ClickHouseSnapshotRepository::from_env()? {
         Some(warehouse) => {

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -26,11 +26,12 @@ use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
 use crate::infrastructure::{SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord};
 use crate::session::model::SessionState;
-use crate::session::snapshot_record::snapshot_record;
+use crate::session::snapshot_record::{snapshot_quote_count, snapshot_record};
 use crate::session::store::SimulationStore;
 use crate::session::{SessionV2, SimulationParametersV2};
 use crate::utils::ChainError;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc;
@@ -53,21 +54,41 @@ pub struct SimulationManager {
     /// persistence on. `None` is the default and the whole feature is then
     /// absent from the serving path — no connection, no latency, no failure
     /// mode.
-    warehouse: Option<mpsc::Sender<SnapshotRecord>>,
+    warehouse: Option<Warehouse>,
 }
 
-/// How many snapshots may be waiting to be filed before the oldest is dropped.
+/// The queue in front of the warehouse, and what is currently in it.
+struct Warehouse {
+    /// The repository itself, so a reader — the export — can consult the same
+    /// warehouse the writer fills without being handed a second handle to it.
+    repository: Arc<dyn SimulationSnapshotRepository>,
+    sender: mpsc::Sender<SnapshotRecord>,
+    /// Quote rows queued but not yet written. Incremented before a send and
+    /// decremented by the writer once the record leaves the queue, so it
+    /// measures what is resident rather than what has been served.
+    queued_contracts: Arc<AtomicUsize>,
+}
+
+/// How many snapshots may be waiting to be filed.
 ///
 /// The queue is what keeps a degraded warehouse from becoming a memory leak. An
 /// unbounded spawn-per-advance cannot delay a response, but at a sustained
 /// advance rate against a warehouse that is timing out it accumulates records
 /// until the process dies — which fails every request, not just the write.
-///
-/// The depth is generous relative to the reference configuration (a record is
-/// on the order of a few hundred quotes) and deliberately not a knob: a
-/// deployment that needs to tune it is a deployment whose warehouse cannot keep
-/// up, and the answer there is the warehouse, not a bigger buffer.
 const SNAPSHOT_QUEUE_DEPTH: usize = 1_024;
+
+/// How many quote rows may be waiting to be filed, across every queued record.
+///
+/// A depth in *records* is the wrong unit for the same reason an entry count
+/// was the wrong unit for the snapshot cache: a record is a few hundred quotes
+/// in the reference configuration and up to the per-snapshot cap in a large
+/// one, so 1 024 of them is anywhere from a hundred thousand to two hundred
+/// million rows. This bounds what is actually resident.
+///
+/// Neither bound is a knob. A deployment that needs to tune them is one whose
+/// warehouse cannot keep up with its advance rate, and the answer there is the
+/// warehouse, not a deeper buffer in front of it.
+const SNAPSHOT_QUEUE_CONTRACTS: usize = 4_000_000;
 
 impl SimulationManager {
     /// Creates a manager over a simulation store.
@@ -96,8 +117,11 @@ impl SimulationManager {
     /// have to name the feature to not use it, and the serving path should not
     /// branch on a config flag it can express as a missing dependency.
     #[must_use]
-    pub fn with_warehouse(mut self, warehouse: Arc<dyn SimulationSnapshotRepository>) -> Self {
+    pub fn with_warehouse(mut self, repository: Arc<dyn SimulationSnapshotRepository>) -> Self {
         let (sender, mut receiver) = mpsc::channel::<SnapshotRecord>(SNAPSHOT_QUEUE_DEPTH);
+        let queued_contracts = Arc::new(AtomicUsize::new(0));
+        let writer_contracts = Arc::clone(&queued_contracts);
+        let warehouse = Arc::clone(&repository);
 
         // One writer, not one task per advance: the queue bounds what a slow
         // warehouse can accumulate, and serialising the writes means two steps
@@ -106,7 +130,12 @@ impl SimulationManager {
             while let Some(record) = receiver.recv().await {
                 let simulation = record.simulation;
                 let step = record.step;
-                if let Err(error) = warehouse.persist(record).await {
+                let contracts = record.quote_count();
+
+                let result = warehouse.persist(record).await;
+                writer_contracts.fetch_sub(contracts, Ordering::SeqCst);
+
+                if let Err(error) = result {
                     warn!(
                         simulation_id = %simulation,
                         step,
@@ -117,8 +146,25 @@ impl SimulationManager {
             }
         });
 
-        self.warehouse = Some(sender);
+        self.warehouse = Some(Warehouse {
+            repository,
+            sender,
+            queued_contracts,
+        });
         self
+    }
+
+    /// The warehouse this manager files into, if any.
+    ///
+    /// Exists so the export can prefer persisted snapshots over replay without
+    /// the binary threading a second handle through the server: the manager
+    /// already owns the one the writer uses, and two handles could drift to two
+    /// different configurations.
+    #[must_use]
+    pub fn warehouse(&self) -> Option<Arc<dyn SimulationSnapshotRepository>> {
+        self.warehouse
+            .as_ref()
+            .map(|warehouse| Arc::clone(&warehouse.repository))
     }
 
     /// The operational configuration this manager applies.
@@ -272,8 +318,34 @@ impl SimulationManager {
             return;
         };
 
+        // Decide before building anything. Materialising a record clones every
+        // quote, so doing it and *then* discovering the queue is full would put
+        // the cost of a degraded warehouse back on the advance — which is the
+        // one thing this path exists to avoid.
+        let incoming = snapshot_quote_count(snapshot);
+        let queued = warehouse.queued_contracts.load(Ordering::SeqCst);
+        if warehouse.sender.capacity() == 0
+            || queued.saturating_add(incoming) > SNAPSHOT_QUEUE_CONTRACTS
+        {
+            warn!(
+                simulation_id = %simulation.id,
+                step = snapshot.step,
+                queued,
+                "The snapshot queue is full; the step was not filed and can be replayed"
+            );
+            return;
+        }
+
         let record = snapshot_record(simulation.id, &simulation.parameters.symbol, snapshot);
-        if let Err(error) = warehouse.try_send(record) {
+        warehouse
+            .queued_contracts
+            .fetch_add(incoming, Ordering::SeqCst);
+
+        if let Err(error) = warehouse.sender.try_send(record) {
+            // Lost the race with another advance; undo the reservation.
+            warehouse
+                .queued_contracts
+                .fetch_sub(incoming, Ordering::SeqCst);
             warn!(
                 simulation_id = %simulation.id,
                 step = snapshot.step,
@@ -610,6 +682,54 @@ mod tests {
         }
     }
 
+    /// A warehouse whose first write never completes — the shape a degraded
+    /// deployment has, and the one an unbounded queue cannot survive.
+    #[derive(Default)]
+    struct StallingWarehouse {
+        started: AtomicUsize,
+    }
+
+    impl StallingWarehouse {
+        fn started(&self) -> usize {
+            self.started.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SimulationSnapshotRepository for StallingWarehouse {
+        async fn persist(&self, _record: SnapshotRecord) -> Result<(), ChainError> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Ok(None)
+        }
+
+        async fn read_range(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _from_step: usize,
+            _to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn contract_series(
+            &self,
+            _query: ContractSeriesQuery,
+        ) -> Result<Vec<ContractQuote>, ChainError> {
+            Ok(Vec::new())
+        }
+    }
+
     /// Filing is detached, so a test has to let the spawned write run before it
     /// can observe it. One yield is enough on the current-thread runtime the
     /// tests use; the loop keeps it from being a race on a busier one.
@@ -677,6 +797,40 @@ mod tests {
             warehouse.filed(),
             vec![(simulation.id, 0)],
             "the step the advance served is the step that is filed"
+        );
+    }
+
+    /// A warehouse that never drains stops receiving, rather than accumulating
+    /// records until the process dies.
+    ///
+    /// The bound that matters is rows, not records: a record is a few hundred
+    /// quotes in this fixture and up to the per-snapshot cap in a large
+    /// configuration, so a depth in records says nothing about what is
+    /// resident.
+    #[tokio::test]
+    async fn test_a_stalled_warehouse_stops_being_queued() {
+        let warehouse = Arc::new(StallingWarehouse::default());
+        let manager = SimulationManager::new(
+            Arc::new(InMemorySimulationStore::new()),
+            SimulationV2Config::default(),
+        )
+        .with_warehouse(Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>);
+
+        // More advances than the queue can hold, against a warehouse whose
+        // first write never returns.
+        for _ in 0..(SNAPSHOT_QUEUE_DEPTH + 8) {
+            let simulation = created(&manager, 2).await;
+            match manager.advance(simulation.id).await {
+                Ok(_) => {}
+                Err(error) => panic!("the advance must serve regardless: {error}"),
+            }
+        }
+        settle().await;
+
+        assert!(
+            warehouse.started() <= SNAPSHOT_QUEUE_DEPTH + 1,
+            "a stalled warehouse must stop receiving, got {} starts",
+            warehouse.started()
         );
     }
 

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -24,30 +24,18 @@
 
 use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
-use crate::infrastructure::SimulationV2Config;
-use crate::session::manager::DEFAULT_NAMESPACE;
+use crate::infrastructure::{SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord};
 use crate::session::model::SessionState;
+use crate::session::snapshot_record::snapshot_record;
 use crate::session::store::SimulationStore;
 use crate::session::{SessionV2, SimulationParametersV2};
-use crate::utils::{ChainError, UuidGenerator};
+use crate::utils::ChainError;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tracing::{debug, info, instrument};
+use tokio::sync::mpsc;
+use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
-
-/// The UUID v5 namespace simulations are generated under.
-///
-/// The same namespace v1 uses, parsed once. It is a compile-time constant that
-/// has been valid since the crate's first release; a parse failure here would
-/// mean the constant itself was edited to something malformed, so falling back
-/// to the nil namespace keeps the service up rather than aborting a request
-/// path — ids stay unique either way, since the generator counts within the
-/// namespace.
-#[must_use]
-fn default_namespace() -> Uuid {
-    Uuid::parse_str(DEFAULT_NAMESPACE).unwrap_or(Uuid::nil())
-}
 
 /// One cached factor tape and the last time it was used.
 struct TapeEntry {
@@ -58,11 +46,28 @@ struct TapeEntry {
 /// Owns the lifecycle of v2 rolling simulations.
 pub struct SimulationManager {
     store: Arc<dyn SimulationStore>,
-    uuid_generator: UuidGenerator,
     config: SimulationV2Config,
     tapes: Mutex<HashMap<Uuid, TapeEntry>>,
     snapshots: Mutex<SnapshotCache>,
+    /// Where served snapshots are queued for filing, when the operator turned
+    /// persistence on. `None` is the default and the whole feature is then
+    /// absent from the serving path — no connection, no latency, no failure
+    /// mode.
+    warehouse: Option<mpsc::Sender<SnapshotRecord>>,
 }
+
+/// How many snapshots may be waiting to be filed before the oldest is dropped.
+///
+/// The queue is what keeps a degraded warehouse from becoming a memory leak. An
+/// unbounded spawn-per-advance cannot delay a response, but at a sustained
+/// advance rate against a warehouse that is timing out it accumulates records
+/// until the process dies — which fails every request, not just the write.
+///
+/// The depth is generous relative to the reference configuration (a record is
+/// on the order of a few hundred quotes) and deliberately not a knob: a
+/// deployment that needs to tune it is a deployment whose warehouse cannot keep
+/// up, and the answer there is the warehouse, not a bigger buffer.
+const SNAPSHOT_QUEUE_DEPTH: usize = 1_024;
 
 impl SimulationManager {
     /// Creates a manager over a simulation store.
@@ -74,14 +79,46 @@ impl SimulationManager {
     pub fn new(store: Arc<dyn SimulationStore>, config: SimulationV2Config) -> Self {
         Self {
             store,
-            uuid_generator: UuidGenerator::new(default_namespace()),
             config,
             tapes: Mutex::new(HashMap::new()),
             snapshots: Mutex::new(SnapshotCache::with_bounds(
                 config.max_cached_snapshots,
                 config.max_cached_snapshot_contracts,
             )),
+            warehouse: None,
         }
+    }
+
+    /// Files every served snapshot in `warehouse`.
+    ///
+    /// Opt-in, and deliberately a separate constructor rather than an argument
+    /// to [`SimulationManager::new`]: a deployment without ClickHouse should not
+    /// have to name the feature to not use it, and the serving path should not
+    /// branch on a config flag it can express as a missing dependency.
+    #[must_use]
+    pub fn with_warehouse(mut self, warehouse: Arc<dyn SimulationSnapshotRepository>) -> Self {
+        let (sender, mut receiver) = mpsc::channel::<SnapshotRecord>(SNAPSHOT_QUEUE_DEPTH);
+
+        // One writer, not one task per advance: the queue bounds what a slow
+        // warehouse can accumulate, and serialising the writes means two steps
+        // of one simulation reach the warehouse in the order they were served.
+        tokio::spawn(async move {
+            while let Some(record) = receiver.recv().await {
+                let simulation = record.simulation;
+                let step = record.step;
+                if let Err(error) = warehouse.persist(record).await {
+                    warn!(
+                        simulation_id = %simulation,
+                        step,
+                        error = %error,
+                        "Could not file the snapshot; the step can be replayed and rewritten"
+                    );
+                }
+            }
+        });
+
+        self.warehouse = Some(sender);
+        self
     }
 
     /// The operational configuration this manager applies.
@@ -105,7 +142,7 @@ impl SimulationManager {
         &self,
         parameters: SimulationParametersV2,
     ) -> Result<SessionV2, ChainError> {
-        let simulation = SessionV2::new(parameters, &self.uuid_generator);
+        let simulation = SessionV2::new(parameters);
         self.store.create(simulation.clone()).await?;
 
         info!(
@@ -192,12 +229,58 @@ impl SimulationManager {
             .save_cas(simulation.clone(), expected_version)
             .await?;
 
+        // After the commit, never before: a snapshot is only real once the
+        // cursor that served it is durable, and persisting first would leave a
+        // row for a step a losing writer never served.
+        self.file_snapshot(&simulation, &snapshot);
+
         if simulation.state == SessionState::Completed {
             self.evict(id);
             debug!(simulation_id = %id, "Simulation completed; cached state evicted");
         }
 
         Ok((simulation, snapshot))
+    }
+
+    /// Queues a served snapshot for filing, if a warehouse is configured.
+    ///
+    /// **Off the request's clock.** A failure cannot fail the advance — the
+    /// cursor has already committed and the client already has its snapshot —
+    /// and neither can a slow one delay it: the record goes into a bounded
+    /// queue that one writer task drains.
+    ///
+    /// A full queue **drops** the record with a `WARN` naming the step. That is
+    /// the same trade as a failed write, made explicit: the step stays
+    /// reproducible, replay rebuilds it, and a retry writes the same rows. What
+    /// it costs is a gap, and the honest way to find one is to compare a
+    /// simulation's cursor against what `read_range` returns — a log line can be
+    /// lost with the process, a missing row cannot.
+    ///
+    /// Filing is idempotent because both tables sort on
+    /// `(simulation, generation, step, …)` and their `ReplacingMergeTree` engine
+    /// collapses on that sorting key, so a retry of a step that did land
+    /// replaces its rows rather than adding a second copy. The derived
+    /// `snapshot_id` rides along as a payload column and is verified on read; it
+    /// is not what does the replacing.
+    ///
+    /// The trade this accepts: a snapshot filed after the response means a
+    /// client that advances and immediately queries the warehouse may not find
+    /// the step yet. Deterministic replay is the read path that is always
+    /// current; the warehouse is the one that is durable.
+    fn file_snapshot(&self, simulation: &SessionV2, snapshot: &SeriesSnapshot) {
+        let Some(warehouse) = &self.warehouse else {
+            return;
+        };
+
+        let record = snapshot_record(simulation.id, &simulation.parameters.symbol, snapshot);
+        if let Err(error) = warehouse.try_send(record) {
+            warn!(
+                simulation_id = %simulation.id,
+                step = snapshot.step,
+                error = %error,
+                "The snapshot queue is full; the step was not filed and can be replayed"
+            );
+        }
     }
 
     /// Deletes a simulation and everything cached for it.
@@ -396,6 +479,7 @@ mod tests {
     use super::*;
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::infrastructure::{ContractQuote, ContractSeriesQuery, SnapshotRecord};
     use crate::session::store::InMemorySimulationStore;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use chrono::{TimeZone, Utc, Weekday};
@@ -460,6 +544,197 @@ mod tests {
             Arc::new(InMemorySimulationStore::new()),
             SimulationV2Config::default(),
         )
+    }
+
+    /// A warehouse that records what it was asked to file, and can be told to
+    /// fail — the two behaviours the wiring promises something about.
+    #[derive(Default)]
+    struct RecordingWarehouse {
+        filed: Mutex<Vec<(Uuid, usize)>>,
+        fail: bool,
+    }
+
+    impl RecordingWarehouse {
+        fn failing() -> Self {
+            Self {
+                filed: Mutex::new(Vec::new()),
+                fail: true,
+            }
+        }
+
+        fn filed(&self) -> Vec<(Uuid, usize)> {
+            match self.filed.lock() {
+                Ok(filed) => filed.clone(),
+                Err(poisoned) => poisoned.into_inner().clone(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SimulationSnapshotRepository for RecordingWarehouse {
+        async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
+            if self.fail {
+                return Err(ChainError::Internal("the warehouse is down".to_string()));
+            }
+            match self.filed.lock() {
+                Ok(mut filed) => filed.push((record.simulation, record.step)),
+                Err(poisoned) => poisoned.into_inner().push((record.simulation, record.step)),
+            }
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Ok(None)
+        }
+
+        async fn read_range(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _from_step: usize,
+            _to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn contract_series(
+            &self,
+            _query: ContractSeriesQuery,
+        ) -> Result<Vec<ContractQuote>, ChainError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Filing is detached, so a test has to let the spawned write run before it
+    /// can observe it. One yield is enough on the current-thread runtime the
+    /// tests use; the loop keeps it from being a race on a busier one.
+    async fn settle() {
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// The simulation id is not an input to anything seeded.
+    ///
+    /// This is what the switch to random ids rests on. Two simulations built
+    /// from one set of parameters have different ids and must still produce the
+    /// same snapshots, strike for strike — `SeriesSnapshot`'s equality compares
+    /// premiums, Greeks and the underlying price, not lengths. If the id ever
+    /// leaked into the tape, the planner or the chain build, this fails.
+    #[tokio::test]
+    async fn test_the_simulation_id_does_not_reach_the_tape() {
+        let manager = manager();
+
+        let first = created(&manager, 3).await;
+        let second = created(&manager, 3).await;
+        assert_ne!(first.id, second.id, "ids are random, so two differ");
+        assert_eq!(
+            first.parameters.seed, second.parameters.seed,
+            "the fixture must pin the seed, or this proves nothing"
+        );
+
+        for _ in 0..3 {
+            let left = match manager.advance(first.id).await {
+                Ok((_, snapshot)) => snapshot,
+                Err(error) => panic!("the first simulation must advance: {error}"),
+            };
+            let right = match manager.advance(second.id).await {
+                Ok((_, snapshot)) => snapshot,
+                Err(error) => panic!("the second simulation must advance: {error}"),
+            };
+
+            assert_eq!(
+                left, right,
+                "step {} differs between two simulations that share every parameter",
+                left.step
+            );
+        }
+    }
+
+    /// An advance files exactly the step it served.
+    #[tokio::test]
+    async fn test_an_advance_files_the_step_it_served() {
+        let warehouse = Arc::new(RecordingWarehouse::default());
+        let manager = SimulationManager::new(
+            Arc::new(InMemorySimulationStore::new()),
+            SimulationV2Config::default(),
+        )
+        .with_warehouse(Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>);
+
+        let simulation = created(&manager, 3).await;
+        match manager.advance(simulation.id).await {
+            Ok(_) => {}
+            Err(error) => panic!("the advance must serve: {error}"),
+        }
+        settle().await;
+
+        assert_eq!(
+            warehouse.filed(),
+            vec![(simulation.id, 0)],
+            "the step the advance served is the step that is filed"
+        );
+    }
+
+    /// A warehouse that is down does not fail the advance. This is the whole
+    /// point of filing after the commit and off the request's clock.
+    #[tokio::test]
+    async fn test_a_failing_warehouse_does_not_fail_the_advance() {
+        let warehouse = Arc::new(RecordingWarehouse::failing());
+        let manager = SimulationManager::new(
+            Arc::new(InMemorySimulationStore::new()),
+            SimulationV2Config::default(),
+        )
+        .with_warehouse(warehouse as Arc<dyn SimulationSnapshotRepository>);
+
+        let simulation = created(&manager, 3).await;
+
+        match manager.advance(simulation.id).await {
+            Ok((advanced, _)) => assert_eq!(advanced.current_step, 1, "the cursor still moved"),
+            Err(error) => panic!("a warehouse failure must not fail the advance: {error}"),
+        }
+        settle().await;
+    }
+
+    /// A peek serves a snapshot and files nothing: it moves no cursor, so there
+    /// is no step to file.
+    #[tokio::test]
+    async fn test_a_peek_files_nothing() {
+        let warehouse = Arc::new(RecordingWarehouse::default());
+        let manager = SimulationManager::new(
+            Arc::new(InMemorySimulationStore::new()),
+            SimulationV2Config::default(),
+        )
+        .with_warehouse(Arc::clone(&warehouse) as Arc<dyn SimulationSnapshotRepository>);
+
+        let simulation = created(&manager, 3).await;
+        match manager.peek(simulation.id).await {
+            Ok(_) => {}
+            Err(error) => panic!("the peek must serve: {error}"),
+        }
+        settle().await;
+
+        assert!(warehouse.filed().is_empty(), "a peek persists nothing");
+    }
+
+    /// Without a warehouse the serving path is unchanged — there is nothing to
+    /// call and nothing to fail.
+    #[tokio::test]
+    async fn test_a_manager_without_a_warehouse_serves_normally() {
+        let manager = manager();
+        let simulation = created(&manager, 2).await;
+
+        match manager.advance(simulation.id).await {
+            Ok((advanced, snapshot)) => {
+                assert_eq!(advanced.current_step, 1);
+                assert_eq!(snapshot.step, 0);
+            }
+            Err(error) => panic!("the advance must serve: {error}"),
+        }
     }
 
     async fn created(manager: &SimulationManager, steps: usize) -> SessionV2 {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -38,6 +38,9 @@ mod model;
 /// conversion from the v2 request DTO. Kept apart from `model` because
 /// `/api/v1/chain` and its stored shape are frozen (ADR 0001 section 12).
 mod model_v2;
+/// The domain snapshot in the shape the ClickHouse warehouse stores, and the
+/// tape generation it is filed under.
+mod snapshot_record;
 ///
 /// The `state_handler` module is responsible for managing and encapsulating all
 /// logic related to the application state. It defines functionality to manipulate,

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -28,7 +28,7 @@ use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
 use crate::infrastructure::max_snapshot_contracts;
 use crate::session::model::{SessionState, SimulationMethod};
-use crate::utils::{ChainError, UuidGenerator};
+use crate::utils::ChainError;
 use chrono::{DateTime, NaiveTime, TimeDelta, Timelike, Utc};
 use chrono_tz::Tz;
 use optionstratlib::utils::TimeFrame;
@@ -724,11 +724,24 @@ fn default_schema_version() -> u32 {
 
 impl SessionV2 {
     /// Creates a simulation from resolved parameters.
+    ///
+    /// The id is **random** (`Uuid::new_v4`), for the reason v1 already
+    /// documents: [`UuidGenerator`] derives from a process-local counter that
+    /// starts at zero, so a restarted service or a second replica would reissue
+    /// the same id sequence. That was survivable while an id only had to be
+    /// unique among live sessions; it is not now that persisted snapshots are
+    /// filed under `(simulation, generation, step)` for as long as the retention
+    /// window, where a repeated id means one run's tape silently replacing
+    /// another's.
+    ///
+    /// The id is not an input to anything seeded — the tape and the snapshots
+    /// are functions of the parameters alone — so randomising it leaves the
+    /// reproducibility contract exactly where it was.
     #[must_use]
-    pub fn new(parameters: SimulationParametersV2, uuid_generator: &UuidGenerator) -> Self {
+    pub fn new(parameters: SimulationParametersV2) -> Self {
         let now = SystemTime::now();
         Self {
-            id: uuid_generator.next(),
+            id: Uuid::new_v4(),
             schema_version: SESSION_V2_SCHEMA_VERSION,
             created_at: now,
             updated_at: now,
@@ -959,13 +972,6 @@ mod tests {
         match SimulationParametersV2::try_from(request) {
             Ok(parameters) => parameters,
             Err(error) => panic!("the request must convert: {error}"),
-        }
-    }
-
-    fn generator() -> UuidGenerator {
-        match Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE) {
-            Ok(namespace) => UuidGenerator::new(namespace),
-            Err(error) => panic!("the default namespace must parse: {error}"),
         }
     }
 
@@ -1303,7 +1309,7 @@ mod tests {
     /// revision.
     #[test]
     fn test_simulation_round_trips_through_serde() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
 
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
@@ -1322,7 +1328,7 @@ mod tests {
     /// migration can tell documents apart without inferring from their shape.
     #[test]
     fn test_stored_document_carries_an_explicit_schema_version() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
 
         let value = match serde_json::to_value(&simulation) {
             Ok(value) => value,
@@ -1518,7 +1524,7 @@ mod tests {
     /// downgraded.
     #[test]
     fn test_stored_simulation_rejects_a_future_schema_version() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1538,7 +1544,7 @@ mod tests {
     /// A stored simulation in a state the v2 lifecycle cannot reach is refused.
     #[test]
     fn test_stored_simulation_rejects_an_unreachable_state() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1566,7 +1572,7 @@ mod tests {
     fn test_stored_simulation_rejects_a_state_the_cursor_contradicts() {
         let mut request = reference_request();
         request.steps = 4;
-        let simulation = SessionV2::new(parameters(request), &generator());
+        let simulation = SessionV2::new(parameters(request));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1615,7 +1621,7 @@ mod tests {
     fn test_stored_simulation_rejects_a_cursor_past_the_horizon() {
         let mut request = reference_request();
         request.steps = 2;
-        let simulation = SessionV2::new(parameters(request), &generator());
+        let simulation = SessionV2::new(parameters(request));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1632,7 +1638,7 @@ mod tests {
     /// A `total_steps` that disagrees with the parameters is refused.
     #[test]
     fn test_stored_simulation_rejects_a_mismatched_total_steps() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1650,7 +1656,7 @@ mod tests {
     /// what it should accept.
     #[test]
     fn test_a_valid_stored_simulation_still_loads() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
         let json = match serde_json::to_string(&simulation) {
             Ok(json) => json,
             Err(error) => panic!("must serialize: {error}"),
@@ -1667,7 +1673,7 @@ mod tests {
     /// A new simulation starts at cursor zero, revision zero, Initialized.
     #[test]
     fn test_new_simulation_starts_initialized_at_cursor_zero() {
-        let simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let simulation = SessionV2::new(parameters(reference_request()));
 
         assert_eq!(simulation.current_step, 0);
         assert_eq!(simulation.total_steps, 500);
@@ -1679,7 +1685,7 @@ mod tests {
     /// Bumping the revision returns the value a compare-and-swap must expect.
     #[test]
     fn test_bump_version_returns_the_expected_revision() {
-        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let mut simulation = SessionV2::new(parameters(reference_request()));
 
         match simulation.bump_version() {
             Ok(expected) => {
@@ -1694,7 +1700,7 @@ mod tests {
     /// would let a stale writer pass the compare-and-swap.
     #[test]
     fn test_bump_version_overflow_is_a_typed_error() {
-        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let mut simulation = SessionV2::new(parameters(reference_request()));
         simulation.version = u64::MAX;
 
         match simulation.bump_version() {
@@ -1708,7 +1714,7 @@ mod tests {
     fn test_is_complete_tracks_the_cursor() {
         let mut request = reference_request();
         request.steps = 2;
-        let mut simulation = SessionV2::new(parameters(request), &generator());
+        let mut simulation = SessionV2::new(parameters(request));
 
         assert!(!simulation.is_complete());
         simulation.current_step = 2;
@@ -1718,7 +1724,7 @@ mod tests {
     /// The simulation's own `simulated_at` follows its cursor.
     #[test]
     fn test_simulation_simulated_at_follows_the_cursor() {
-        let mut simulation = SessionV2::new(parameters(reference_request()), &generator());
+        let mut simulation = SessionV2::new(parameters(reference_request()));
         simulation.current_step = 2;
 
         match simulation.simulated_at() {

--- a/src/session/snapshot_record.rs
+++ b/src/session/snapshot_record.rs
@@ -1,0 +1,251 @@
+//! The domain snapshot, in the shape the warehouse stores.
+//!
+//! The conversion lives here rather than in `infrastructure` because
+//! [`SeriesSnapshot`] is `pub(crate)` inside the private `domain` module: the
+//! persistence layer cannot name it, and must not, or the layering would run
+//! backwards. The session layer sees both sides, so it owns the translation —
+//! the same place the f64 ↔ typed conversion already happens for the REST
+//! boundary.
+//!
+//! What crosses is a flat, owned record. Nothing here interprets the numbers:
+//! a quote that upstream did not price stays `None` rather than becoming a
+//! zero, because a zero premium is a statement and a missing one is not.
+
+use crate::domain::series::SeriesSnapshot;
+use crate::infrastructure::{
+    CURRENT_SNAPSHOT_GENERATION, ExpirationRecord, QuoteRow, SnapshotRecord,
+};
+
+/// The tape generation persisted snapshots are filed under.
+///
+/// Defers to [`CURRENT_SNAPSHOT_GENERATION`], which the persistence layer owns
+/// and publishes: an external reader has to pass the same number to address a
+/// row, so one definition rather than two that could drift.
+///
+/// **Not** the session's compare-and-swap revision, which changes on every
+/// advance — filing steps under a moving version would scatter one simulation
+/// across as many generations as it has steps, and make a retry a new row
+/// instead of the same one.
+///
+/// A v2 simulation is immutable after creation, so its tape has exactly one
+/// generation for its lifetime. This constant is bumped only if a change to the
+/// walk mathematics would make the same effective inputs produce a different
+/// tape — at which point stored snapshots from the old generation are still
+/// readable, still correct for the binary that wrote them, and distinguishable
+/// from the new ones.
+pub(crate) const SNAPSHOT_TAPE_GENERATION: u64 = CURRENT_SNAPSHOT_GENERATION;
+
+/// Builds the persistence record for a snapshot the manager just served.
+///
+/// Ordering is inherited, not imposed: the planner already yields expirations
+/// chronologically and upstream holds strikes in a `BTreeSet`, so the record
+/// reproduces the canonical order without sorting anything. That is what lets a
+/// reconstruction from the warehouse compare equal to the in-memory snapshot.
+pub(crate) fn snapshot_record(
+    simulation: uuid::Uuid,
+    symbol: &str,
+    snapshot: &SeriesSnapshot,
+) -> SnapshotRecord {
+    let expirations = snapshot
+        .chains
+        .iter()
+        .map(|chain| ExpirationRecord {
+            expires_at: chain.expires_at,
+            days_to_expiration: chain.days_to_expiration,
+            labels: chain.labels.clone(),
+            quotes: chain
+                .chain
+                .iter()
+                .map(|data| QuoteRow {
+                    strike: data.strike_price,
+                    implied_volatility: data.implied_volatility,
+                    call_bid: data.call_bid,
+                    call_ask: data.call_ask,
+                    call_mid: data.call_middle,
+                    put_bid: data.put_bid,
+                    put_ask: data.put_ask,
+                    put_mid: data.put_middle,
+                    delta_call: data.delta_call,
+                    delta_put: data.delta_put,
+                    gamma: data.gamma,
+                })
+                .collect(),
+        })
+        .collect();
+
+    SnapshotRecord {
+        simulation,
+        generation: SNAPSHOT_TAPE_GENERATION,
+        step: snapshot.step,
+        simulated_at: snapshot.simulated_at,
+        symbol: symbol.to_string(),
+        spot: snapshot.spot,
+        base_volatility: snapshot.base_volatility,
+        expirations,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::domain::factors::FactorTape;
+    use crate::domain::series::SeriesBuilder;
+    use crate::session::{ExpiryRule, ExpiryRuleKind, SimulationParametersV2};
+    use chrono::{TimeZone, Utc, Weekday};
+    use uuid::Uuid;
+
+    fn parameters() -> SimulationParametersV2 {
+        let start_at = match Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        };
+        let rule =
+            |id: &str, kind: ExpiryRuleKind, count: usize| match ExpiryRule::new(id, kind, count) {
+                Ok(rule) => rule,
+                Err(error) => panic!("the test rule must be valid: {error}"),
+            };
+
+        let request = CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 2,
+            start_at: Some(start_at),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: Some("weekdays_v1".to_string()),
+            expiration_time: "17:00".to_string(),
+            schedules: vec![
+                rule("zero_dte", ExpiryRuleKind::Daily, 1),
+                rule(
+                    "weeklies",
+                    ExpiryRuleKind::weekly([Weekday::Mon, Weekday::Wed, Weekday::Fri]),
+                    2,
+                ),
+            ],
+            initial_price: 5000.0,
+            volatility: 0.18,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.012,
+            method: ApiWalkType::Brownian {
+                dt: 0.004,
+                drift: 0.0,
+                volatility: 0.18,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(5),
+            strike_interval: Some(25.0),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(0.02),
+            seed: Some(42),
+        };
+
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the request must convert: {error}"),
+        }
+    }
+
+    /// The record carries every value the snapshot did, in the same order.
+    ///
+    /// This is the reconstruction guarantee at its source: whatever the
+    /// warehouse can return is bounded above by what leaves here, so a field
+    /// dropped in this conversion is a field no query can bring back.
+    #[test]
+    fn test_the_record_carries_the_whole_snapshot() {
+        let parameters = parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let builder = match SeriesBuilder::new(&parameters, &tape) {
+            Ok(builder) => builder,
+            Err(error) => panic!("the builder must accept the parameters: {error}"),
+        };
+        let snapshot = match builder.snapshot(1) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the snapshot must build: {error}"),
+        };
+
+        let simulation = Uuid::new_v4();
+        let record = snapshot_record(simulation, &parameters.symbol, &snapshot);
+
+        assert_eq!(record.simulation, simulation);
+        assert_eq!(record.generation, SNAPSHOT_TAPE_GENERATION);
+        assert_eq!(record.step, snapshot.step);
+        assert_eq!(record.simulated_at, snapshot.simulated_at);
+        assert_eq!(record.symbol, parameters.symbol);
+        assert_eq!(record.spot, snapshot.spot);
+        assert_eq!(record.base_volatility, snapshot.base_volatility);
+        assert_eq!(record.expirations.len(), snapshot.chains.len());
+        assert!(
+            !record.expirations.is_empty(),
+            "the fixture must price something"
+        );
+
+        for (stored, live) in record.expirations.iter().zip(&snapshot.chains) {
+            assert_eq!(stored.expires_at, live.expires_at);
+            assert_eq!(stored.days_to_expiration, live.days_to_expiration);
+            assert_eq!(stored.labels, live.labels);
+
+            let quotes = live.chain.iter().count();
+            assert_eq!(stored.quotes.len(), quotes, "every strike must be carried");
+
+            for (row, data) in stored.quotes.iter().zip(live.chain.iter()) {
+                assert_eq!(row.strike, data.strike_price);
+                assert_eq!(row.implied_volatility, data.implied_volatility);
+                assert_eq!(row.call_bid, data.call_bid);
+                assert_eq!(row.call_ask, data.call_ask);
+                assert_eq!(row.call_mid, data.call_middle);
+                assert_eq!(row.put_bid, data.put_bid);
+                assert_eq!(row.put_ask, data.put_ask);
+                assert_eq!(row.put_mid, data.put_middle);
+                assert_eq!(row.delta_call, data.delta_call);
+                assert_eq!(row.delta_put, data.delta_put);
+                assert_eq!(row.gamma, data.gamma);
+            }
+        }
+
+        match record.validate() {
+            Ok(()) => {}
+            Err(error) => panic!("a record built from a real snapshot must be valid: {error}"),
+        }
+    }
+
+    /// The same step files under the same id however often it is served, which
+    /// is what makes a retry replace a row instead of adding one.
+    #[test]
+    fn test_the_same_step_files_under_a_stable_id() {
+        let parameters = parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let builder = match SeriesBuilder::new(&parameters, &tape) {
+            Ok(builder) => builder,
+            Err(error) => panic!("the builder must accept the parameters: {error}"),
+        };
+        let simulation = Uuid::new_v4();
+
+        let first = match builder.snapshot(0) {
+            Ok(snapshot) => snapshot_record(simulation, &parameters.symbol, &snapshot),
+            Err(error) => panic!("the snapshot must build: {error}"),
+        };
+        let second = match builder.snapshot(0) {
+            Ok(snapshot) => snapshot_record(simulation, &parameters.symbol, &snapshot),
+            Err(error) => panic!("the snapshot must build: {error}"),
+        };
+        let next_step = match builder.snapshot(1) {
+            Ok(snapshot) => snapshot_record(simulation, &parameters.symbol, &snapshot),
+            Err(error) => panic!("the snapshot must build: {error}"),
+        };
+
+        assert_eq!(first.snapshot_id(), second.snapshot_id());
+        assert_ne!(
+            first.snapshot_id(),
+            next_step.snapshot_id(),
+            "two steps of one simulation are two rows"
+        );
+    }
+}

--- a/src/session/snapshot_record.rs
+++ b/src/session/snapshot_record.rs
@@ -35,6 +35,19 @@ use crate::infrastructure::{
 /// from the new ones.
 pub(crate) const SNAPSHOT_TAPE_GENERATION: u64 = CURRENT_SNAPSHOT_GENERATION;
 
+/// How many quote rows a snapshot would become.
+///
+/// Counted from the domain snapshot rather than from a built record, so a
+/// caller can decide whether to build one at all.
+#[must_use]
+pub(crate) fn snapshot_quote_count(snapshot: &SeriesSnapshot) -> usize {
+    snapshot
+        .chains
+        .iter()
+        .map(|chain| chain.chain.options.len())
+        .sum()
+}
+
 /// Builds the persistence record for a snapshot the manager just served.
 ///
 /// Ordering is inherited, not imposed: the planner already yields expirations

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -170,7 +170,6 @@ mod tests {
     use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind};
     use crate::session::model::SessionState;
     use crate::session::model_v2::SimulationParametersV2;
-    use crate::utils::UuidGenerator;
     use chrono::{TimeZone, Utc, Weekday};
 
     fn request() -> CreateSimulationRequest {
@@ -224,11 +223,7 @@ mod tests {
             Ok(parameters) => parameters,
             Err(error) => panic!("the request must convert: {error}"),
         };
-        let namespace = match uuid::Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE) {
-            Ok(namespace) => namespace,
-            Err(error) => panic!("the default namespace must parse: {error}"),
-        };
-        SessionV2::new(parameters, &UuidGenerator::new(namespace))
+        SessionV2::new(parameters)
     }
 
     /// An invalid simulation is refused on the way in.
@@ -425,11 +420,8 @@ mod tests {
         let store = InMemorySimulationStore::with_idle_retention(Duration::from_secs(1));
         let mut stale = simulation();
         stale.updated_at = SystemTime::now() - Duration::from_secs(3_600);
+        // `simulation()` mints a random id, so the two are already distinct.
         let fresh = simulation();
-        let fresh = SessionV2 {
-            id: Uuid::new_v4(),
-            ..fresh
-        };
 
         match store.create(stale.clone()).await {
             Ok(()) => {}

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -496,7 +496,6 @@ mod live_tests {
     use crate::session::model::SessionState;
     use crate::session::model_v2::SimulationParametersV2;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
-    use crate::utils::UuidGenerator;
     use chrono::{TimeZone, Utc, Weekday};
     use tokio::test;
 
@@ -555,13 +554,8 @@ mod live_tests {
 
         let parameters =
             SimulationParametersV2::try_from(request).expect("the reference request must convert");
-        let namespace = Uuid::parse_str(crate::session::manager::DEFAULT_NAMESPACE)
-            .expect("the default namespace must parse");
-        let mut simulation = SessionV2::new(parameters, &UuidGenerator::new(namespace));
-        // The uuid generator is a deterministic counter, so give each test its
-        // own id rather than letting parallel tests share one.
-        simulation.id = Uuid::new_v4();
-        simulation
+        // Ids are random now, so each test already gets its own.
+        SessionV2::new(parameters)
     }
 
     /// A created simulation round-trips through Redis unchanged, and its


### PR DESCRIPTION
## Summary

v2 snapshots had exactly one read path: replay. That is the right canonical answer and a poor operational one — a client wanting one contract's premium across a year had to walk the whole tape, and a restart lost everything a run had produced.

Snapshots are now filed in ClickHouse as an immutable, queryable tape. **Opt-in** (`OCS_SNAPSHOT_PERSISTENCE_ENABLED`, default off) and absent by construction when off: the manager holds `Option<Sender>`, so a deployment without ClickHouse does not have to name the feature to not use it.

## Storage model

Two tables, because the two query patterns are different shapes: one metadata row per step in `simulation_snapshots`, and one flattened row per `(step, expiration, strike)` in `simulation_option_quotes` — which is what turns "this contract over time" into a range scan rather than an unwind of nested documents.

- `ReplacingMergeTree(inserted_at_ms)`, ordered on the coordinate that identifies a row; `simulation_option_quotes` adds a minmax index on `(expires_at, strike)` for the contract-history pattern.
- `PARTITION BY toYYYYMM(simulated_at)` — **content**-derived on purpose. The engine only deduplicates within a partition, so an ingestion-derived key would let a backfill written a month later survive as a permanent duplicate. Retention is a row-level TTL anchored on ingestion time, so a backfill still keeps its full window.
- Money and Greeks are `Decimal(38, 28)`, timestamps `DateTime64(9)`, so a value reconstructs exactly rather than approximately.
- DDL is checked in under `src/infrastructure/clickhouse/schema/` and `include_str!`-ed, so the SQL and the Rust row structs are one artifact — the driver validates the struct against the live schema on every first insert.

## The four properties that make it safe to read

**Identity is derived, not generated.** A row's id comes from `(simulation, tape generation, step)`, and the tables collapse on that sorting key, so retrying a step replaces its rows instead of adding a copy. The generation is the *tape's*, not the session's compare-and-swap revision — filing under a revision that changes on every advance would scatter one simulation across as many generations as it has steps.

**A partial write never reads as complete.** Quote rows go first, in one batch; the metadata row carrying the expected count goes last. Every read compares what it got against that count and treats a mismatch as absent, so a torn write reads as a missing step rather than a short chain.

**Filing cannot fail or delay an advance.** It happens after the cursor commits, through a bounded queue that one writer task drains. A full queue drops the record with a `WARN` naming the step — the same trade as a failed write, made explicit: the step stays reproducible, replay rebuilds it, a retry writes the same rows.

**Nothing about v1 moves.** MongoDB stays event and audit only; no v2 chain is written as a nested document; `/api/v1/chain` routes, DTOs and logging are untouched (the 16 contract tests still pass).

## v2 simulation ids become random

`UuidGenerator` derives from a process-local counter starting at zero — v1 abandoned it for exactly this reason. That was survivable while an id only had to be unique among live sessions. It is not now that the id is a durable row key for the retention window: a second run would write the first run's coordinates, and either the engine collapses two different tapes into one or the completeness guard marks the step permanently absent.

The id reaches nothing seeded — the tape, the planner and the snapshot builder are functions of the parameters alone — so the same-seed ⇒ identical-tape contract is untouched. A test now pins that: two simulations sharing every parameter get different ids and produce identical snapshots, compared premium by premium.

`SessionV2::new` drops the generator argument it was ignoring rather than keeping a signature that lies to an external caller.

## Reviews run before this was opened

Both were on the diff, both are reflected in it.

- **architect** — found the id collision above as blocking, plus: docs claiming "every served snapshot" when only an advance files; the write being inline and able to hold a response for the insert timeout; a `version` field that would be confused with the CAS revision on the wire; the read half of the API being unusable externally because its generation constant was crate-private. All fixed.
- **reproducibility-reviewer** — confirmed the id change does not touch the seed contract, the stored-session shape or any test's meaning. Its findings: the detached write was unbounded (now a bounded queue), an empty-quotes expiration could disappear on read, the constructor lying about its argument, and the missing test for the property the id change rests on. Fixed.

## Testing

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `LOGLEVEL=WARN cargo test --workspace` — 692 unit tests, 16 v1-contract tests, 3 doctests, 18 ignored
- [x] `cargo build --release` clean
- [x] The 5 `#[ignore]`d live tests pass against the **exact CI image** (`clickhouse/clickhouse-server:26.3.17.110`): round-trip, double-persist idempotence, torn write, short batch, contract history. A column rename is precisely what the driver's schema validation catches, so this was run after the rename, not before.
- [x] CI needs no change — the integration job already runs `cargo test --workspace -- --ignored` with a ClickHouse service whose credentials match `ClickHouseConfig::default()`.

## Left deliberately

The export path (#49) still replays rather than reading the warehouse. Persistence is off by default, so replay is the only source that is always correct today; making the warehouse preferred is a follow-up that needs its own decision about what a partially-persisted range should return. Noted rather than half-done.

## Stack

- **Stack:** #63 → #62 → #56 — **this is PR 3 (top)**
- **Base branch:** `stack/2-62-snapshot-work-caps` (PR #68)
- **Stacked on:** #68 · **Blocks:** — (last in the chain)
- The diff is cumulative until #67 and #68 merge — review it against the base branch, not `main`.

Closes #56