### PR TITLE
chore: bump the version to 0.2.0 and clear every doc warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionChain-Simulator is a lightweight REST API service that simulates an evolving option chain with every request. It is designed for developers building or testing trading systems, backtesters, and visual tools that depend on option data streams but want to avoid relying on live data feeds."

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.1.0}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.0}
     deploy:
       replicas: 1
       restart_policy:

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -284,7 +284,7 @@ pub(crate) fn json_error_handler(
 ///
 /// Best effort by design: serde's own messages name the field for the cases
 /// that matter (`unknown field \`x\``, and this crate's own validation errors,
-/// which are formatted as `Validation Error: <field>: <reason>`). Anything else
+/// which are formatted as ``Validation Error: `field`: `reason` ``). Anything else
 /// reports an empty field rather than inventing one, which is more useful to a
 /// client than a confident wrong answer.
 #[must_use]

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -412,12 +412,12 @@ pub(crate) fn validate_walk_type(walk: &WalkType) -> Result<(), ChainError> {
 impl TryFrom<ApiWalkType> for WalkType {
     type Error = ChainError;
 
-    /// Validates a client-supplied [`ApiWalkType`] and converts it into the domain
+    /// Validates a client-supplied `ApiWalkType` and converts it into the domain
     /// [`WalkType`]. Every raw `f64` field is checked before conversion: `dt` must be
     /// strictly positive, volatilities and other `Positive` fields must be finite and
     /// non-negative, `Decimal` fields must be finite, an `autocorrelation` (when present)
     /// must lie in `[-1, 1]`, and a `Historical` price series must be non-negative and no
-    /// longer than [`MAX_HISTORICAL_PRICES`]. Invalid input yields a
+    /// longer than `MAX_HISTORICAL_PRICES`. Invalid input yields a
     /// [`ChainError::Validation`] naming the offending field instead of panicking.
     ///
     /// # Errors

--- a/src/api/rest/patch.rs
+++ b/src/api/rest/patch.rs
@@ -29,7 +29,7 @@ use serde::ser::{Serialize, Serializer};
 /// Tri-state wrapper distinguishing an absent JSON key, an explicit `null`, and
 /// a present value in a partial-update (PATCH) request body.
 ///
-/// See the [module documentation](self) for how each state maps to serde and to
+/// See this module's documentation for how each state maps to serde and to
 /// the PATCH merge semantics (absent = keep, null = clear, value = replace).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum Patch<T> {

--- a/src/domain/expiry.rs
+++ b/src/domain/expiry.rs
@@ -153,7 +153,7 @@ impl CalendarVersion {
     /// expiry back to the previous eligible weekday here without touching any
     /// simulation stored under `weekdays_v1`. Note that such a hook can map two
     /// candidates onto the same date, which is why per-rule projection counts
-    /// **distinct instants** (see [`RollingPlanner::project_rule`]).
+    /// **distinct instants** (see `RollingPlanner::project_rule`).
     #[must_use]
     pub fn eligible_date(self, date: NaiveDate) -> Option<NaiveDate> {
         match self {
@@ -175,7 +175,7 @@ impl CalendarVersion {
 
 /// What a rule expires on, independent of how many expirations it keeps.
 ///
-/// The wire form is flat and tagged by `kind` — see [`ExpiryRuleWire`], which
+/// The wire form is flat and tagged by `kind` — see `ExpiryRuleWire`, which
 /// carries the serde derives so that `deny_unknown_fields` and per-kind field
 /// validity both hold. A stored rule reads exactly as ADR 0001 §14.2 shows it:
 /// `{"rule_id": "monthlies", "kind": "monthly", "target_count": 12, "weekday": "Fri"}`.
@@ -260,7 +260,7 @@ impl ExpiryRuleKind {
 ///
 /// Fields are private and the constructor validates, so an out-of-range
 /// `target_count` or a malformed `rule_id` is unrepresentable. Both directions
-/// of serde go through [`ExpiryRuleWire`], which is what makes a schedule
+/// of serde go through `ExpiryRuleWire`, which is what makes a schedule
 /// loaded from the session store as safe as one built from a request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(into = "ExpiryRuleWire", try_from = "ExpiryRuleWire")]
@@ -385,7 +385,7 @@ impl TryFrom<ExpiryRuleWire> for ExpiryRule {
 
 impl ExpiryRule {
     /// Builds a rule, rejecting a malformed `rule_id` and a `target_count` of
-    /// zero or above [`MAX_TARGET_COUNT`].
+    /// zero or above `MAX_TARGET_COUNT`.
     ///
     /// A rule keeping zero expirations is not a rule, and the type reflects
     /// that: `target_count` is a [`NonZeroUsize`] internally, so the invalid
@@ -395,7 +395,7 @@ impl ExpiryRule {
     ///
     /// Returns [`ChainError::Validation`] naming
     /// `schedules.<rule_id>.target_count` when the count is zero or exceeds
-    /// [`MAX_TARGET_COUNT`], or `schedules.rule_id` when the id is empty, too
+    /// `MAX_TARGET_COUNT`, or `schedules.rule_id` when the id is empty, too
     /// long, or carries a character outside `[A-Za-z0-9_-]`.
     pub fn new(
         rule_id: impl Into<String>,
@@ -576,17 +576,17 @@ impl ExpirationSchedule {
     ///
     /// Per-rule invariants — the `rule_id` charset and length, the
     /// `target_count` bound, and the kind-specific fields — are already
-    /// established by [`ExpiryRule::from_parts`]; this checks what only the
+    /// established by `ExpiryRule::from_parts`; this checks what only the
     /// whole schedule knows.
     ///
     /// # Errors
     ///
     /// Returns [`ChainError::Validation`] naming the offending field when:
     ///
-    /// - the rule list is empty, or longer than [`MAX_SCHEDULE_RULES`];
+    /// - the rule list is empty, or longer than `MAX_SCHEDULE_RULES`;
     /// - a `rule_id` is duplicated;
     /// - the pre-deduplication sum of `target_count` exceeds
-    ///   [`MAX_EXPIRATIONS_PER_SNAPSHOT`], or overflows.
+    ///   `MAX_EXPIRATIONS_PER_SNAPSHOT`, or overflows.
     pub fn validate(&self) -> Result<(), ChainError> {
         if self.rules.is_empty() {
             return Err(ChainError::Validation {

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -208,7 +208,14 @@ impl FactorTape {
 
     /// The rows, in step order.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "consumed by the export in #49"))]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the whole-tape accessor the tests compare against; the service reads \
+                      one row at a time through `row`"
+        )
+    )]
     pub(crate) fn rows(&self) -> &[FactorRow] {
         &self.rows
     }
@@ -223,7 +230,14 @@ impl FactorTape {
     /// validated at the request boundary — but the accessor keeps clippy and
     /// callers honest.
     #[must_use]
-    #[cfg_attr(not(test), expect(dead_code, reason = "consumed by the export in #49"))]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "clippy's len_without_is_empty requires this alongside `len`; a built \
+                      tape is never empty, since `steps >= 1` is validated at creation"
+        )
+    )]
     pub(crate) fn is_empty(&self) -> bool {
         self.rows.is_empty()
     }

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -128,7 +128,8 @@ impl SeriesSnapshot {
         not(test),
         expect(
             dead_code,
-            reason = "consumed by the export in #49 and the cache metrics in #48"
+            reason = "the by-expiration lookup the tests use; the DTO layer walks \
+                      `chains` in order instead"
         )
     )]
     pub(crate) fn chain_at(&self, expires_at: DateTime<Utc>) -> Option<&ExpiryChain> {
@@ -145,7 +146,8 @@ impl SeriesSnapshot {
         not(test),
         expect(
             dead_code,
-            reason = "consumed by the export in #49 and the cache metrics in #48"
+            reason = "the per-rule view the inventory tests assert on; nothing served \
+                      needs it, because a chain carries its own labels"
         )
     )]
     pub(crate) fn chains_for(&self, rule_id: &str) -> impl Iterator<Item = &ExpiryChain> {
@@ -333,7 +335,7 @@ impl SnapshotCache {
         not(test),
         expect(
             dead_code,
-            reason = "consumed by the export in #49 and the cache metrics in #48"
+            reason = "clippy's len_without_is_empty requires this alongside `len`"
         )
     )]
     pub(crate) fn is_empty(&self) -> bool {
@@ -346,7 +348,8 @@ impl SnapshotCache {
         not(test),
         expect(
             dead_code,
-            reason = "consumed by the export in #49 and the cache metrics in #48"
+            reason = "the configured bound, asserted by the tests that pin the \
+                      zero-capacity floor"
         )
     )]
     pub(crate) fn capacity(&self) -> usize {

--- a/src/infrastructure/repositories/historical_repo.rs
+++ b/src/infrastructure/repositories/historical_repo.rs
@@ -33,6 +33,13 @@ const DATE_RANGE_QUERY: &str = "SELECT \
     FROM ohlcv \
     WHERE symbol = ?";
 
+/// Reads historical OHLCV series from ClickHouse.
+///
+/// The [`HistoricalDataRepository`] implementation behind a `Historical` walk:
+/// it lists the symbols the warehouse holds, reports the date range available
+/// for one, and fetches a price series from a given start. Every query binds
+/// its symbol as an escaped parameter rather than interpolating it, and every
+/// driver error is mapped into [`ChainError`] before it leaves this layer.
 pub struct ClickHouseHistoricalRepository {
     /// The underlying ClickHouse client
     client: Arc<ClickHouseClient>,

--- a/src/infrastructure/telemetry/collector.rs
+++ b/src/infrastructure/telemetry/collector.rs
@@ -303,6 +303,7 @@ impl MetricsCollector {
         self.v2_simulations_expired.inc_by(count as u64);
     }
 
+    /// Records the current memory usage
     pub fn record_memory_usage(&self, bytes: f64) {
         self.memory_usage.set(bytes);
     }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -387,7 +387,7 @@ impl SessionManager {
     ///
     /// Read-only helper the API layer uses to publish the `simulation_cache_size`
     /// gauge after operations that grow or shrink the cache (advance, delete). It
-    /// delegates to [`crate::domain`]'s simulator without touching session state or
+    /// delegates to the domain simulator without touching session state or
     /// the store.
     pub async fn simulation_cache_len(&self) -> usize {
         self.simulator.cache_len().await

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -261,7 +261,7 @@ pub struct Session {
     /// * `state` - The current state of the session, represented by an instance
     pub state: SessionState,
     /// * `version` - Optimistic-concurrency revision counter. It starts at `0` at
-    ///   creation and is bumped by the [`SessionManager`] (via
+    ///   creation and is bumped by the [`crate::session::SessionManager`] (via
     ///   [`Session::bump_version`]) immediately before a compare-and-swap save, so
     ///   two concurrent mutations that read the same snapshot cannot silently
     ///   overwrite one another: the second save fails with
@@ -473,7 +473,7 @@ impl Session {
     ///
     /// The state-transition methods (`advance_step`, `modify_parameters`,
     /// `reinitialize`) are deliberately kept as pure state changes and do NOT
-    /// touch the version. The [`SessionManager`] calls this helper right before a
+    /// touch the version. The [`crate::session::SessionManager`] calls this helper right before a
     /// compare-and-swap save so the persisted revision advances exactly once per
     /// successfully served mutation. Uses `checked_add` (the ruleset forbids
     /// `saturating_*`): saturating at `u64::MAX` would freeze the revision and let


### PR DESCRIPTION
## Why a separate PR

#66 was asked to carry the bump, but it had already merged and its branch was deleted, so this is the follow-up. Nothing else is outstanding — the whole v0.2.0 stack (#42–#49) is on `main`.

## The bump is not inert

`.github/workflows/docker-publish.yml` watches the `[package]` version at HEAD against its first parent, so **merging this publishes a GHCR image tagged `0.2.0`**. Worth knowing before you hit merge; it is the intended behaviour, not a surprise.

`Docker/docker-compose.yml`'s default tag moves with it — leaving the fallback at `0.1.0` would have `make deploy` keep pulling the previous image after the new one exists. Following the precedent of `63eac03` (the 0.1.0 bump), the example crates are left alone: they are path-only workspace members and never published.

Publishing to crates.io is **not** part of this. That stays the separate `release-crate` procedure, after CI is green on the release commit.

## Every warning cleared, none silenced

You asked for `make lint-fix` and `make pre-push` to come out free of warnings without hiding anything behind an `allow`. Both were exiting `0` while `make doc` and the rustdoc pass inside `make readme` printed **eighteen warnings** between them — exactly the noise that hides the next real one.

**Nothing here adds an `allow`.** Every fix is at the root.

### Two were regressions from this stack

- `MetricsCollector::record_memory_usage` **lost its doc comment in #65**. The v2 cache metrics were inserted anchored on its `pub fn` line, so the new methods inherited the comment and the old one was left bare. Restored.
- `ClickHouseHistoricalRepository` was never documented, which `-W missing-docs` reports now that it is reachable. Documented.

### Ten were broken intra-doc links

Links from **public** documentation to **private** items resolve only under `--document-private-items` and break in a published doc build. Eight came from `src/domain/expiry.rs`, whose configuration types became public in #44 while their doc comments kept linking to the wire types, the constants and the private constructors beside them — they become plain code spans. The two unresolved `SessionManager` links in `src/session/model.rs` become the full path, which resolves properly.

### Two were markup

A doc comment in `handlers_v2.rs` wrote an error format with angle brackets that rustdoc read as unclosed HTML tags.

### Four stale claims

Four dead-code expectations still said *"consumed by the export in #49"* — on accessors #49 shipped without touching. The expectations are still **correct** (the items are genuinely dead outside tests, which is why `-D warnings` stays green), so they stay; their reasons now say what is actually true: the tests use them and the service reads one row at a time, or clippy's `len_without_is_empty` requires them alongside `len`.

## Verification

- `make lint-fix` — clean
- `make pre-push` — **0 warnings, 0 errors**, end to end: `fix`, `fmt`, `lint-fix`, `test`, `readme`, `doc`
- `cargo doc --no-deps --document-private-items` — clean
- `LOGLEVEL=WARN cargo test --workspace` — **608 passed, 0 failed, 13 ignored**, plus 16 golden contract tests and 2 doctests
- `cargo build --release`
- `git diff` carries no `#[allow(...)]`

No behaviour change: the only non-documentation edits are the two version strings.