### PR TITLE
feat(domain): price historical v2 steps at a causal volatility estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,12 @@ which means another writer committed first.
 changing the seed, the start, the schedules or the chain shape changes the
 tape, so it creates a new simulation instead of mutating one.
 
-**A historical v2 walk is priced at the volatility you send.** A
-`Historical` method carries no volatility of its own, and v2 does not enter
-the upstream walk driver that estimates one per step, so every step of a
-historical v2 simulation prices at the request's constant `volatility`. v1
-uses a rolling causal estimate for the same series, so the two produce the
-same price path and different premiums. It is a stated difference, tracked
-in issue #63 and asked for upstream in optionstratlib#423.
+**A historical v2 walk prices itself.** A `Historical` method carries no
+volatility of its own, so each step is priced by the realized volatility of
+everything observed up to that step and nothing later — the same expanding
+window v1 uses, so the two agree on the volatility path as well as the price
+path. The `volatility` you send prices none of its steps; the values that
+did are the per-step ones every snapshot and the `volatility` export report.
 
 **Advanced steps can be filed in ClickHouse.** With
 `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/README.md
+++ b/README.md
@@ -141,9 +141,13 @@ tape, so it creates a new simulation instead of mutating one.
 **A historical v2 walk prices itself.** A `Historical` method carries no
 volatility of its own, so each step is priced by the realized volatility of
 everything observed up to that step and nothing later — the same expanding
-window v1 uses, so the two agree on the volatility path as well as the price
-path. The `volatility` you send prices none of its steps; the values that
-did are the per-step ones every snapshot and the `volatility` export report.
+window v1 uses, so from step 1 on the two agree on the volatility path as
+well as the price path. (Step 0 differs by construction: v1 prices its first
+chain at the request's constant.) The `volatility` you send prices none of
+its steps; the values that did are the per-step ones every snapshot and the
+`volatility` export report. A series with no dispersion, or one too
+turbulent to price a chain at, is refused when the simulation is first
+served.
 
 **Advanced steps can be filed in ClickHouse.** With
 `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ window v1 uses, so from step 1 on the two agree on the volatility path as
 well as the price path. (Step 0 differs by construction: v1 prices its first
 chain at the request's constant.) The `volatility` you send prices none of
 its steps; the values that did are the per-step ones every snapshot and the
-`volatility` export report. A series with no dispersion, or one too
-turbulent to price a chain at, is refused when the simulation is first
-served.
+`volatility` export report. A series too turbulent to price a chain at, or
+one whose first three prices are equal, is refused when the simulation is
+first served.
 
 **Advanced steps can be filed in ClickHouse.** With
 `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -496,13 +496,36 @@ observed by step `i` and nothing later.
 
 v2 never enters that driver — the factor tape exists precisely to stop
 materialising a chain per step — so it is its own caller and estimates the same
-way, composing the window from the same public upstream functions v1's driver
-composes its own from. There is no second copy of upstream's kernel in this
-repo. **Every step of a historical v2 tape therefore carries its own causal
+way. It composes the window from public upstream primitives rather than copying
+the private kernel: upstream's expanding estimator inlines its own prefix-sum
+variance, but records that the result is algebraically identical to
+`constant_volatility`, which *is* public, so v2 writes an indexing policy over
+upstream mathematics. There is no second copy of upstream's kernel in this repo.
+**Every step of a historical v2 tape therefore carries its own causal
 volatility, and the request's `volatility` field prices none of them.** It is
 not silently swallowed: the values actually used are the per-step ones in
 `FactorRow.base_volatility`, which every snapshot and the `volatility` export
 report, so a client reads back what priced its chains.
+
+Nothing outside the horizon is read, the seeding chain's volatility included: a
+historical walk replays `prices[..steps]`, and every reduction is taken over
+that prefix. This is a deliberate divergence from v1, whose fallback reduces the
+whole embedded series. Two consequences follow, both of which **refuse a request
+that v1 would have served**, which §11's error table lists and which issue #63
+accepts as an answer:
+
+- A horizon of fewer than three steps has one return at most and therefore no
+  dispersion to measure. v1 falls back to the whole-series constant, pricing the
+  simulation from observations past its own horizon; v2 refuses it.
+- A series whose realized volatility over the horizon is zero, or above the
+  `1.0` an option chain can be priced at, is refused. Both were previously
+  masked by pricing every step at the request's constant.
+
+Both refusals arrive **when the simulation is first served, not when it is
+created**: creation does not build a tape, deliberately, so a historical
+simulation with an unpriceable series returns `201` and then `400` from its
+first peek. The error names `method.prices`, because the volatility comes from
+the series and lowering the request's would change nothing.
 
 The same series and the same seed produce the same price path *and* the same
 volatility path under v1 and v2, to a numeric tolerance rather than bit-exactly:
@@ -517,9 +540,19 @@ answer.
 
 Composing costs quadratic time where upstream's recurrence is linear, because
 the recurrence is not reachable from outside it: at the 10 000-step cap the
-estimate takes seconds. It is paid once per simulation, only by `Historical`,
-and on the blocking pool rather than a request worker. optionstratlib#423 asks
-for the estimator to be exposed, which would make it a single linear call.
+estimate measures 3.3 s. Only `Historical` pays it, and it runs on the blocking
+pool rather than a request worker. It is paid once per **tape build**, which is
+not once per simulation: the tape cache is a bounded LRU, so an eviction, a
+restart, or an export — which builds its own tape and does not consult the
+cache — pays it again. optionstratlib#423 asks for the estimator to be exposed,
+which would make it a single linear call.
+
+A last note for the day v2 ships. The per-step values are a function of the
+binary as well as the inputs, so a change to how they are estimated changes what
+a replay produces. Snapshots persisted by an older binary and steps replayed by
+a newer one would then disagree inside a single export. Today that is free —
+this behaviour has never been released — but once it has, a change here is a
+schema event and not only a code change.
 
 Three properties keep the guarantee honest, and each is a test in the issues
 that implement it:
@@ -727,6 +760,14 @@ v2 maps failures through `ChainError` and the single existing HTTP boundary
 | `410` | the simulation is completed / the tape is exhausted | `{ "error": "..." }` |
 | `412` | `expected_step` does not match the stored cursor | `{ "error": "...", "current_step": N }` |
 | `500` | internal failure | `{ "error": "Internal server error" }` |
+
+One `400` does not arrive at the request that caused it. A historical series
+whose realized volatility cannot price a chain — zero, above `1.0`, or a horizon
+too short to estimate one from (§8.1) — is only discovered when the tape is
+built, and creation deliberately does not build one. That simulation is created
+with a `201` and returns `400` naming `method.prices` from its first peek
+onward. Building the tape at creation instead would trade this for a
+multi-second `POST` on every historical simulation, which is the worse deal.
 
 The `400` body is the existing `ValidationErrorResponse` shape — `error` plus
 the offending `field` — so a client can point a user at one input. The `412`

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -307,8 +307,10 @@ simulation:
   pair and silently prices step zero at one while walking on the other, and v2
   refuses the contradiction at the boundary rather than letting the domain pick
   a winner. `Historical` carries no model volatility, so there is nothing to
-  disagree with. The check runs on the stored document too, so a hand-edited
-  simulation cannot smuggle the contradiction back in.
+  disagree with — and nothing to supply either: it prices itself from the series
+  (§8.1), and the request's `volatility` prices none of its steps. The check
+  runs on the stored document too, so a hand-edited simulation cannot smuggle
+  the contradiction back in.
 
 ---
 
@@ -484,24 +486,40 @@ unversioned would be a false guarantee, so the effective tzdb release
 the seed. A replay against a different tzdb is still a replay — it is just one
 the client can now detect.
 
-**What a `Historical` walk is priced at.** A historical walk carries no
-volatility of its own — it is a price series, and `WalkType::volatility()`
-returns `None` for it. v1 prices one with a rolling causal estimate, because its
-walk driver computes an expanding-window realized volatility per step. v2 never
-enters that driver — the factor tape exists precisely to stop materialising a
-chain per step — and upstream keeps the estimator private to it, so **every step
-of a historical v2 tape is priced at the constant `volatility` the request
-supplied**.
+### 8.1 What a `Historical` walk is priced at
 
-This is part of the contract, not an accident. The same series and the same seed
-produce the *same price path* under v1 and v2, and *different premiums*, because
-the volatility pricing them differs. A client comparing the two should expect
-that. Closing the gap needs the estimator reachable from outside the driver,
-which is asked for in optionstratlib#423; porting a second copy of the
-mathematics into the tape would contradict the module's stated premise of not
-reimplementing upstream. Issue #63 tracks it, and if the estimator lands the
-per-step value goes into `FactorRow.base_volatility`, which is already defined
-as the exact number that step's chains are priced at.
+A historical walk carries no volatility of its own — it is a price series, and
+`WalkType::volatility()` returns `None` for it. Upstream leaves the per-step
+estimate to the caller and says so; v1's caller is its walk driver, which
+estimates over an **expanding window**, so step `i` is priced by what had been
+observed by step `i` and nothing later.
+
+v2 never enters that driver — the factor tape exists precisely to stop
+materialising a chain per step — so it is its own caller and estimates the same
+way, composing the window from the same public upstream functions v1's driver
+composes its own from. There is no second copy of upstream's kernel in this
+repo. **Every step of a historical v2 tape therefore carries its own causal
+volatility, and the request's `volatility` field prices none of them.** It is
+not silently swallowed: the values actually used are the per-step ones in
+`FactorRow.base_volatility`, which every snapshot and the `volatility` export
+report, so a client reads back what priced its chains.
+
+The same series and the same seed produce the same price path *and* the same
+volatility path under v1 and v2, to a numeric tolerance rather than bit-exactly:
+upstream accumulates its window with prefix sums where the composed form centres
+in two passes, which is the same expression and not the same last `Decimal`
+digits (observed deviation ~1e-23 on an annualised volatility, pinned by a
+test). One step differs by construction: v1 never asks its estimator about step
+zero and prices its first chain at the request's constant, while v2 serves step
+zero as a snapshot and prices it with the first computable estimate — pricing a
+served step at a volatility its own series contradicts would be the worse
+answer.
+
+Composing costs quadratic time where upstream's recurrence is linear, because
+the recurrence is not reachable from outside it: at the 10 000-step cap the
+estimate takes seconds. It is paid once per simulation, only by `Historical`,
+and on the blocking pool rather than a request worker. optionstratlib#423 asks
+for the estimator to be exposed, which would make it a single linear call.
 
 Three properties keep the guarantee honest, and each is a test in the issues
 that implement it:

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -517,9 +517,14 @@ accepts as an answer:
 - A horizon of fewer than three steps has one return at most and therefore no
   dispersion to measure. v1 falls back to the whole-series constant, pricing the
   simulation from observations past its own horizon; v2 refuses it.
-- A series whose realized volatility over the horizon is zero, or above the
-  `1.0` an option chain can be priced at, is refused. Both were previously
-  masked by pricing every step at the request's constant.
+- A series whose realized volatility over the horizon is above the `1.0` an
+  option chain can be priced at is refused, as is one whose estimate is zero.
+  Zero is reached more easily than "a flat series" suggests: the first two
+  points carry the first computable estimate, so **three equal opening prices**
+  are enough to refuse a simulation that moves freely afterwards. v1 fails on
+  the same input from inside the chain builder, as a `500`; this is the same
+  refusal with a status and a field a client can act on. Both cases were
+  previously masked by pricing every step at the request's constant.
 
 Both refusals arrive **when the simulation is first served, not when it is
 created**: creation does not build a tape, deliberately, so a historical

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -56,7 +56,7 @@ pub struct CreateSimulationRequest {
     pub schedules: Vec<ExpiryRule>,
     /// Initial price of the underlying.
     pub initial_price: f64,
-    /// Initial (and, for constant-volatility models, the only) volatility.
+    /// The base volatility, for every walk model that carries one.
     ///
     /// Must equal the walk model's own `volatility` where the model carries
     /// one: a simulation has exactly one base volatility, and a disagreement is
@@ -64,9 +64,12 @@ pub struct CreateSimulationRequest {
     /// (ADR 0001 §4.4).
     ///
     /// `Historical` carries none and needs none — it prices every step from the
-    /// realized volatility of the series up to that step, so this field prices
-    /// nothing there (ADR 0001 §8.1). The values that did price the chains are
-    /// the per-step ones in each snapshot's `base_volatility`.
+    /// realized volatility of its own series up to that step, so this field
+    /// prices nothing there (ADR 0001 §8.1). The values that did price the
+    /// chains are the per-step ones in each snapshot's `base_volatility`. A
+    /// historical series whose realized volatility is zero or above `1.0`
+    /// cannot price a chain at all, and is refused when the simulation is first
+    /// served rather than when it is created.
     pub volatility: f64,
     /// Annualised risk-free rate, as a decimal fraction.
     pub risk_free_rate: f64,

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -67,7 +67,8 @@ pub struct CreateSimulationRequest {
     /// realized volatility of its own series up to that step, so this field
     /// prices nothing there (ADR 0001 §8.1). The values that did price the
     /// chains are the per-step ones in each snapshot's `base_volatility`. A
-    /// historical series whose realized volatility is zero or above `1.0`
+    /// historical series whose realized volatility is above `1.0`, or whose
+    /// first three prices are equal — which makes the opening estimate zero —
     /// cannot price a chain at all, and is refused when the simulation is first
     /// served rather than when it is created.
     pub volatility: f64,

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -61,7 +61,12 @@ pub struct CreateSimulationRequest {
     /// Must equal the walk model's own `volatility` where the model carries
     /// one: a simulation has exactly one base volatility, and a disagreement is
     /// a `400` naming this field rather than a silent choice made later
-    /// (ADR 0001 §4.4). `Historical` carries none, so nothing has to match.
+    /// (ADR 0001 §4.4).
+    ///
+    /// `Historical` carries none and needs none — it prices every step from the
+    /// realized volatility of the series up to that step, so this field prices
+    /// nothing there (ADR 0001 §8.1). The values that did price the chains are
+    /// the per-step ones in each snapshot's `base_volatility`.
     pub volatility: f64,
     /// Annualised risk-free rate, as a decimal fraction.
     pub risk_free_rate: f64,

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -107,7 +107,12 @@ pub struct SimulationParametersResponse {
     pub schedules: Vec<ScheduleRuleResponse>,
     /// Initial price of the underlying.
     pub initial_price: f64,
-    /// The one base volatility of the simulation.
+    /// The volatility the simulation was created with, echoed back for replay.
+    ///
+    /// It is the one base volatility for every walk model that carries one. For
+    /// `Historical` it prices nothing — that walk estimates a volatility per
+    /// step from its own series (ADR 0001 §8.1) — and the values that did price
+    /// the chains are each snapshot's `base_volatility`.
     pub volatility: f64,
     /// Annualised risk-free rate.
     pub risk_free_rate: f64,

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -83,10 +83,9 @@ use optionstratlib::chains::{
 use optionstratlib::simulation::steps::{Step, Xstep, Ystep};
 use optionstratlib::simulation::{WalkParams, WalkTypeAble};
 use optionstratlib::utils::TimeFrame;
-use optionstratlib::utils::others::calculate_log_returns;
 use optionstratlib::volatility::{adjust_volatility, constant_volatility};
 use positive::Positive;
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, MathematicalOps};
 use tracing::{debug, instrument};
 
 /// One step of the market path: everything a snapshot needs that is not an
@@ -628,27 +627,65 @@ fn expanding_window_volatilities(
 
 /// The log returns of a price series as decimals.
 ///
-/// `Positive::ln` builds its result without revalidating, so a falling price
-/// yields a negative value wearing a `Positive`. Reading each one back as a
-/// `Decimal` — which is what upstream's own estimator does — recovers the true
-/// sign before any arithmetic touches it.
+/// Computed here rather than through upstream's `calculate_log_returns`, which
+/// divides two `Positive`s: that operator panics on a zero divisor **and on a
+/// ratio it cannot represent**, and it never returns an error for either. Both
+/// operands come straight from a request, and a `Decimal` holds about 29
+/// significant digits, so a series stepping from `1e-28` to `7e28` is a
+/// perfectly legal pair of strictly positive prices whose ratio is not
+/// representable. A request must not be able to abort the process, so the
+/// division is checked and an unrepresentable ratio is a rejection naming the
+/// field.
+///
+/// The log itself is taken on the `Decimal`, which is what recovers the true
+/// sign: `Positive::ln` builds its result without revalidating, so a falling
+/// price would otherwise yield a negative value wearing a `Positive`.
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Validation`] naming `method.prices` if upstream's
-/// log-return computation ever reports a failure.
-///
-/// It cannot report a **zero price**, and this is a precondition rather than an
-/// error case: the computation divides by the previous price and takes the log
-/// of the ratio, and both of those panic on a zero instead of returning.
-/// [`ensure_historical_series_covers_the_horizon`] is what makes that
-/// unreachable, and it has to run first.
+/// Returns [`ChainError::Validation`] naming `method.prices` when a ratio is
+/// not representable, when a price is zero, or when the log of a ratio is not
+/// representable.
 fn log_returns(prices: &[Positive]) -> Result<Vec<Decimal>, ChainError> {
-    let returns = calculate_log_returns(prices).map_err(|e| ChainError::Validation {
+    let unusable = |reason: String| ChainError::Validation {
         field: "method.prices".to_string(),
-        reason: format!("the historical series has no usable log returns: {e}"),
-    })?;
-    Ok(returns.iter().map(Positive::to_dec).collect())
+        reason,
+    };
+
+    let mut returns = Vec::with_capacity(prices.len().saturating_sub(1));
+    for (index, pair) in prices.windows(2).enumerate() {
+        let [previous, current] = pair else {
+            // `windows(2)` yields pairs; destructuring keeps it indexing-free.
+            continue;
+        };
+
+        let previous = previous.to_dec();
+        let current = current.to_dec();
+        if previous.is_zero() {
+            return Err(unusable(format!(
+                "the price at index {index} is zero, so the series has no return at {}",
+                index + 1
+            )));
+        }
+
+        let ratio = current.checked_div(previous).ok_or_else(|| {
+            unusable(format!(
+                "the price ratio at index {} is not representable ({current} over {previous})",
+                index + 1
+            ))
+        })?;
+
+        let log = ratio.checked_ln().ok_or_else(|| {
+            unusable(format!(
+                "the log return at index {} is not representable (ratio {ratio})",
+                index + 1
+            ))
+        })?;
+
+        returns.push(log);
+    }
+
+    Ok(returns)
 }
 
 /// Rescales a volatility from the series' timeframe to a year.
@@ -1783,6 +1820,82 @@ mod tests {
             symbol: Some("SPX".to_string()),
         };
         historical
+    }
+
+    /// A ratio too large to represent is a rejection, not a panic.
+    ///
+    /// Both prices are strictly positive and perfectly legal on their own; it
+    /// is the jump between them that no `Decimal` can hold. Upstream's
+    /// `calculate_log_returns` divides two `Positive`s, which aborts the
+    /// process on exactly this, so the estimator computes the ratio itself.
+    #[test]
+    fn test_an_unrepresentable_price_jump_is_rejected() {
+        let mut prices = vec![1e-28_f64; 4];
+        prices.push(7e28);
+        prices.extend(std::iter::repeat_n(7e28, 8));
+
+        let mut historical = request(4, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "method.prices"),
+            other => panic!("an unrepresentable ratio must be a 400, got {other:?}"),
+        }
+    }
+
+    /// And the same in the other direction, where the ratio underflows to
+    /// something whose log is not representable.
+    #[test]
+    fn test_an_unrepresentable_price_collapse_is_rejected() {
+        let mut prices = vec![7e28_f64; 4];
+        prices.push(1e-28);
+        prices.extend(std::iter::repeat_n(1e-28, 8));
+
+        let mut historical = request(4, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "method.prices"),
+            other => panic!("an unrepresentable ratio must be a 400, got {other:?}"),
+        }
+    }
+
+    /// A series a client could plausibly send still estimates, so the guard
+    /// above rejects the unrepresentable rather than the merely volatile.
+    ///
+    /// The ceiling on a priceable volatility is a separate check with its own
+    /// tests; this one only has to stay under it.
+    #[test]
+    fn test_a_violently_volatile_series_still_estimates() {
+        // Two percent daily moves, which annualise to about a third — well
+        // inside what a chain can be priced at, and far outside anything the
+        // ratio guard should touch.
+        let prices: Vec<f64> = (0..40)
+            .map(|i| 5000.0 * (1.0 + 0.02 * f64::from(i).sin()))
+            .collect();
+
+        let mut historical = request(20, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => assert_eq!(tape.len(), 20),
+            Err(error) => panic!("a two percent daily move is legal, got {error}"),
+        }
     }
 
     /// A historical tape replays the supplied series in order, with no

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -349,14 +349,14 @@ fn ensure_method_matches(
 ///   the embedded series is shorter than the walk — a request embedding five
 ///   prices and asking for a hundred steps — so it is caught here and named,
 ///   the way v1 avoids the problem entirely by refetching from the database.
-/// - **A zero price.** A log return divides by the previous price, and
-///   `Positive`'s division *panics* on a zero divisor rather than returning an
-///   error, so one zero close would take down the thread building the tape.
-///   `SimulationParametersV2::validate` already rejects it on the stored
-///   series, but the method passed here is the **resolved** one — the whole
-///   reason the argument exists is that a `Historical` walk may have been
-///   filled in from the database since — and that series has passed no
-///   validation at all.
+/// - **A zero price inside the walked window.** A log return divides by the
+///   previous price and takes the log of the ratio, and *both* panic on a zero
+///   rather than returning an error, so one zero close would take down the
+///   thread building the tape. `SimulationParametersV2::validate` already
+///   rejects it on the stored series, but the method passed here is the
+///   **resolved** one — the whole reason the argument exists is that a
+///   `Historical` walk may have been filled in from the database since — and
+///   that series has passed no validation at all.
 ///
 /// # Errors
 ///
@@ -380,12 +380,19 @@ fn ensure_historical_series_covers_the_horizon(
         });
     }
 
-    if let Some(index) = prices.iter().position(|price| price.is_zero()) {
+    // Only the walked window, for the same reason nothing else reads past it: a
+    // zero at index `steps + 50` is touched by no division, no logarithm and no
+    // reduction, and refusing the request over it would be exactly the
+    // look-ahead this module removed.
+    let window = prices
+        .get(..parameters.steps)
+        .ok_or_else(|| ChainError::Internal("the horizon guard above did not hold".to_string()))?;
+    if let Some(index) = window.iter().position(|price| price.is_zero()) {
         return Err(ChainError::Validation {
             field: "method.prices".to_string(),
             reason: format!(
                 "must be strictly positive: the price at index {index} is zero, and a log \
-                 return cannot divide by it"
+                 return divides by the previous price and takes the log of the ratio"
             ),
         });
     }
@@ -504,9 +511,9 @@ fn resolve_base_volatility(
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Validation`] naming `method.prices` when a price is
-/// not usable as a log-return input, or `volatility` when the reduction or the
-/// annualisation fails.
+/// Returns [`ChainError::Validation`] naming `volatility` when the reduction or
+/// the annualisation fails. Prices are a precondition, not an error case — see
+/// [`log_returns`].
 fn historical_constant_volatility(
     prices: &[Positive],
     timeframe: TimeFrame,
@@ -560,8 +567,9 @@ fn historical_constant_volatility(
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Validation`] when a price is not usable as a
-/// log-return input, or when a window cannot be reduced or annualised.
+/// Returns [`ChainError::Validation`] when a window cannot be reduced or
+/// annualised. Prices are a precondition, not an error case — see
+/// [`log_returns`].
 fn expanding_window_volatilities(
     prices: &[Positive],
     timeframe: TimeFrame,
@@ -627,8 +635,14 @@ fn expanding_window_volatilities(
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Validation`] naming `method.prices` when a price is
-/// zero, negative, or otherwise not usable as a log-return input.
+/// Returns [`ChainError::Validation`] naming `method.prices` if upstream's
+/// log-return computation ever reports a failure.
+///
+/// It cannot report a **zero price**, and this is a precondition rather than an
+/// error case: the computation divides by the previous price and takes the log
+/// of the ratio, and both of those panic on a zero instead of returning.
+/// [`ensure_historical_series_covers_the_horizon`] is what makes that
+/// unreachable, and it has to run first.
 fn log_returns(prices: &[Positive]) -> Result<Vec<Decimal>, ChainError> {
     let returns = calculate_log_returns(prices).map_err(|e| ChainError::Validation {
         field: "method.prices".to_string(),
@@ -678,16 +692,29 @@ impl VolatilitySource {
         }
     }
 
-    /// What the client has to change.
-    fn remedy(self) -> &'static str {
+    /// What the client has to change to get under the upper bound.
+    fn remedy_too_high(self) -> &'static str {
         match self {
             Self::Model => "lower the model's volatility or shorten the horizon",
-            Self::Series => {
-                "the volatility is estimated from the series, so it is the series that has to \
-                 change — the request's volatility prices nothing for a historical walk"
-            }
+            Self::Series => Self::SERIES_REMEDY,
         }
     }
+
+    /// What the client has to change to get off zero. Telling a model to lower
+    /// its volatility here would make the zero *more* likely, not less.
+    fn remedy_zero(self) -> &'static str {
+        match self {
+            Self::Model => {
+                "raise the model's volatility, or change the parameters that let its variance \
+                 collapse to zero"
+            }
+            Self::Series => Self::SERIES_REMEDY,
+        }
+    }
+
+    /// The same either way: the request's `volatility` is not the input.
+    const SERIES_REMEDY: &'static str = "the volatility is estimated from the series, so it is the series that has to change — \
+         the request's volatility prices nothing for a historical walk";
 }
 
 /// Rejects a volatility no option chain can be priced at.
@@ -699,11 +726,13 @@ impl VolatilitySource {
 /// historical one, at whatever step crosses first. All of them become one 400
 /// naming a field, at tape build, where the whole path is in hand.
 ///
-/// The lower bound is not theoretical for a historical walk: three equal prices
-/// give two zero log returns, so the estimate over that window is exactly zero.
-/// The session layer already refuses a zero the *request* supplies; an
-/// estimated one has to be refused here, because this is the only gate it
-/// passes through.
+/// The lower bound is not theoretical for a historical walk, and it fires on
+/// **a flat opening, not only a flat series**: the estimate needs two returns,
+/// so points 0 and 1 carry the first computable one, and if the first three
+/// prices are equal that value is zero. A series that is flat for three ticks
+/// and lively afterwards is refused at step 0. v1 fails on the same input, from
+/// inside the chain builder and as a `500`; this is the same refusal with a
+/// status and a field a client can act on.
 ///
 /// Rejecting rather than clamping: a clamped path is a different tape, and the
 /// seed would no longer reproduce it.
@@ -712,18 +741,14 @@ fn reject_unpriceable_volatility(
     step: Option<usize>,
     source: VolatilitySource,
 ) -> Result<(), ChainError> {
-    let at = match step {
-        Some(step) => format!(" at step {step}"),
-        None => String::new(),
-    };
-
     if volatility.is_zero() {
         return Err(ChainError::Validation {
             field: source.field().to_string(),
             reason: format!(
-                "the volatility is zero{at}, and an option chain priced at zero volatility is a \
+                "the volatility is zero{}, and an option chain priced at zero volatility is a \
                  chain of zero-value options; {}",
-                source.remedy()
+                at_step(step),
+                source.remedy_zero()
             ),
         });
     }
@@ -735,11 +760,21 @@ fn reject_unpriceable_volatility(
     Err(ChainError::Validation {
         field: source.field().to_string(),
         reason: format!(
-            "the volatility reaches {volatility}{at}, above the 1.0 maximum an option chain can \
+            "the volatility reaches {volatility}{}, above the 1.0 maximum an option chain can \
              be priced at; {}",
-            source.remedy()
+            at_step(step),
+            source.remedy_too_high()
         ),
     })
+}
+
+/// Names the step in an error, when there is one. Built only on the failing
+/// path — the check above runs once per row.
+fn at_step(step: Option<usize>) -> String {
+    match step {
+        Some(step) => format!(" at step {step}"),
+        None => String::new(),
+    }
 }
 
 /// Builds one option chain from a simulation's shape and a point in the market
@@ -1710,9 +1745,13 @@ mod tests {
     /// A price series with a calm opening and a turbulent tail, so an expanding
     /// window has something to move over.
     fn volatile_series(length: usize) -> Vec<Positive> {
-        volatile_prices(length)
-            .into_iter()
-            .map(|price| match Positive::new(price) {
+        volatile_series_from(&volatile_prices(length))
+    }
+
+    fn volatile_series_from(prices: &[f64]) -> Vec<Positive> {
+        prices
+            .iter()
+            .map(|price| match Positive::new(*price) {
                 Ok(price) => price,
                 Err(error) => panic!("the test price must be positive: {error}"),
             })
@@ -1778,11 +1817,11 @@ mod tests {
     /// Later observations cannot change an earlier step's base volatility.
     ///
     /// The property the estimator turns on (#63): whatever prices a historical
-    /// step must be a function of that step and what came before it. Now that
-    /// the price is an estimate rather than a constant, this is where it is
-    /// load-bearing — it proves the estimate is taken over the *walked* prefix
-    /// and not the embedded series, the one place v2 could have diverged from
-    /// v1 while every other test still passed.
+    /// step must be a function of that step and what came before it. It held
+    /// when the answer was a constant and it holds now that it is an estimate,
+    /// which is the point — it is the invariant, not the implementation, that
+    /// this pins. The narrower claim, that no reduction reads past the horizon,
+    /// is the next test's.
     #[test]
     fn test_a_longer_series_leaves_earlier_steps_untouched() {
         // The observation count is a `u32` so the index converts to `f64`
@@ -1815,6 +1854,68 @@ mod tests {
                 "step {} replayed differently",
                 early.step
             );
+        }
+    }
+
+    /// Turbulence past the horizon cannot refuse a request whose own horizon is
+    /// calm.
+    ///
+    /// This is the case the reduction over the walked prefix exists for. The
+    /// tail here annualises far above the 1.0 a chain can be priced at, so
+    /// reducing the whole embedded series — which is what v1 does for its own
+    /// fallback — would 400 the simulation over observations it never reaches.
+    /// The calm prefix is priceable, so it builds.
+    #[test]
+    fn test_turbulence_past_the_horizon_cannot_refuse_a_calm_one() {
+        let mut prices: Vec<f64> = (0..10).map(|index| 5000.0 + f64::from(index)).collect();
+        prices.extend((0..10).map(|index| if index % 2 == 0 { 5000.0 } else { 5500.0 }));
+
+        let mut historical = request(10, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: prices.clone(),
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        let tape = tape(&parameters);
+        assert_eq!(tape.len(), 10);
+
+        // The guard is only meaningful if the tail really is unpriceable: a
+        // whole-series reduction has to be the thing that would have failed.
+        let whole_series = volatile_series_from(&prices);
+        match historical_constant_volatility(&whole_series, TimeFrame::Day) {
+            Ok(volatility) => assert!(
+                volatility > Positive::ONE,
+                "the fixture's tail must be unpriceable for this test to mean anything, got \
+                 {volatility}"
+            ),
+            Err(error) => panic!("the fixture must reduce: {error}"),
+        }
+    }
+
+    /// A flat opening is enough to refuse the simulation, because points 0 and 1
+    /// carry the first computable estimate and three equal prices make that
+    /// estimate zero. The rest of the horizon never gets a say.
+    #[test]
+    fn test_a_flat_opening_is_refused_even_when_the_rest_moves() {
+        let mut prices = vec![5000.0, 5000.0, 5000.0];
+        prices.extend((0..10).map(|index| if index % 2 == 0 { 5050.0 } else { 4980.0 }));
+
+        let mut historical = request(8, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "method.prices");
+                assert!(reason.contains("zero at step 0"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
         }
     }
 

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -39,23 +39,26 @@
 //!   path from `generate_with_vol`. It does not reimplement the mathematics, so
 //!   there is no second copy to diverge.
 //!
-//! # Where v2 knowingly differs from v1: historical volatility
+//! # Historical volatility is estimated, causally
 //!
 //! A `Historical` walk carries no volatility of its own — it is a price series,
-//! and `WalkType::volatility()` returns `None` for it. v1 prices such a walk
-//! with a rolling causal estimate, because `walk_steps_par` computes one with
-//! upstream's `expanding_window_vols`. v2 never enters that driver, and the
-//! estimator is private to it, so **every step of a historical v2 tape is
-//! priced at the constant `volatility` the request supplied**.
+//! and `WalkType::volatility()` returns `None` for it. Upstream leaves the
+//! per-step estimate to the caller (`WalkTypeAble::generate_with_vol` says so,
+//! and returns `vols: None` for the variant); v1's caller is `walk_steps_par`,
+//! which estimates it over an expanding window so that step `i` is priced by
+//! what had been observed by step `i` and nothing later.
 //!
-//! This is a stated behaviour, not an oversight. The same series and seed run
-//! through v1 and v2 produce the same price path — the tape pins that — and
-//! different premiums, because the volatility pricing them differs. Closing the
-//! gap needs the estimator to be reachable from outside the driver, which is
-//! asked for upstream in optionstratlib#423; porting a second copy of the
-//! mathematics into this module would contradict the property directly above
-//! it. Issue #63 tracks it here, and ADR 0001 §8 records it as part of the
-//! contract rather than leaving a client to infer it from two runs.
+//! v2 never enters that driver, so [`expanding_window_volatilities`] is v2's
+//! caller-side answer, **composed from the same public upstream functions v1's
+//! is composed from** rather than copied out of it — see that function for the
+//! indexing and the cost. A historical tape therefore carries a volatility per
+//! step, causally, and the request's own `volatility` field prices none of it
+//! (see [`resolve_base_volatility`]).
+//!
+//! Parity with v1 is numeric, not bit-exact: upstream accumulates the window
+//! with prefix sums while `constant_volatility` centres in two passes, and the
+//! two agree algebraically but not in the last `Decimal` digits. The tolerance
+//! is pinned by a test. ADR 0001 §8 records the contract.
 
 use crate::domain::Walker;
 use crate::domain::simulator::{
@@ -70,7 +73,11 @@ use optionstratlib::chains::{
 };
 use optionstratlib::simulation::steps::{Step, Xstep, Ystep};
 use optionstratlib::simulation::{WalkParams, WalkTypeAble};
+use optionstratlib::utils::TimeFrame;
+use optionstratlib::utils::others::calculate_log_returns;
+use optionstratlib::volatility::{adjust_volatility, constant_volatility};
 use positive::Positive;
+use rust_decimal::Decimal;
 use tracing::{debug, instrument};
 
 /// One step of the market path: everything a snapshot needs that is not an
@@ -191,16 +198,29 @@ impl FactorTape {
             )));
         }
 
+        // Where each step's volatility comes from, in v1's order of precedence
+        // (`walk_steps_par`): a stochastic-volatility model reports its own
+        // path, index-aligned with the prices; a historical walk reports none,
+        // so it is estimated causally from the path itself; everything else is
+        // the model's constant.
+        let step_volatilities = match path.vols {
+            Some(ref vols) => Some(vols.clone()),
+            None => match method {
+                SimulationMethod::Historical { timeframe, .. } => {
+                    expanding_window_volatilities(&path.prices, *timeframe)?
+                }
+                _ => None,
+            },
+        };
+
         let mut rows = Vec::with_capacity(parameters.steps);
         for step in 0..parameters.steps {
             let spot = *path.prices.get(step).ok_or_else(|| {
                 ChainError::Internal(format!("the walk has no price for step {step}"))
             })?;
 
-            // A stochastic-volatility model reports its own per-step path,
-            // index-aligned with the prices. Every other model is constant.
-            let row_volatility = match &path.vols {
-                Some(vols) => *vols.get(step).ok_or_else(|| {
+            let row_volatility = match step_volatilities {
+                Some(ref vols) => *vols.get(step).ok_or_else(|| {
                     ChainError::Internal(format!("the walk has no volatility for step {step}"))
                 })?,
                 None => base_volatility,
@@ -352,23 +372,24 @@ fn ensure_historical_series_covers_the_horizon(
 /// The rule: for the nine synthetic walk types the model's volatility is
 /// authoritative, and the parameters' must agree with it. For `Historical`
 /// there is no model volatility — `WalkType::volatility()` returns `None` — so
-/// the parameters' value is used as a constant.
+/// the series itself is authoritative and the value is **estimated** from it by
+/// [`historical_constant_volatility`], exactly as v1 does.
 ///
-/// **That is a deliberate simplification, and it changes behaviour relative to
-/// v1.** Upstream ships a causal estimator, `expanding_window_vols`, whose
-/// estimate at index `i` uses only the returns of `prices[..=i]`, and v1 prices
-/// its historical chains with it through `walk_steps_par`. v2 does not walk
-/// through that driver — the whole point of the factor tape is to stop
-/// materialising chains per step — and the estimator is private to it, so
-/// adopting it means either duplicating the mathematics here, which is exactly
-/// what this module exists to avoid, or a change upstream. Until then a
-/// historical v2 simulation prices every step at the requested constant
-/// volatility. Worth knowing before comparing a v1 and a v2 historical run.
+/// # What the request's `volatility` means for a `Historical` walk
+///
+/// Nothing. A price series already prices itself, and inventing a second answer
+/// would put the tape and the chains on different numbers again — the very
+/// thing this function exists to prevent. The field is not silently swallowed:
+/// the values actually used are the per-step ones in every row, which the
+/// snapshot and export surfaces report, so a client reads back what priced its
+/// chains rather than what it asked for. Dropping the field for this one
+/// variant is a DTO change and is deliberately not made here.
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Validation`] naming `volatility` when the two
-/// disagree.
+/// Returns [`ChainError::Validation`] naming `volatility` when a synthetic
+/// model's volatility and the parameters' disagree, or when the historical
+/// series cannot be reduced to a volatility.
 fn resolve_base_volatility(
     parameters: &SimulationParametersV2,
     method: &SimulationMethod,
@@ -387,8 +408,173 @@ fn resolve_base_volatility(
             }
             Ok(model_volatility)
         }
-        None => Ok(parameters.volatility),
+        None => match method {
+            SimulationMethod::Historical {
+                timeframe, prices, ..
+            } => historical_constant_volatility(prices, *timeframe),
+            // `volatility()` returns `None` only for `Historical`; the match is
+            // exhaustive over what can reach here, and a future variant that
+            // also returns `None` lands on the requested value rather than
+            // silently borrowing a historical estimator that does not apply.
+            _ => Ok(parameters.volatility),
+        },
     }
+}
+
+/// The whole-series volatility of a historical price series, annualised.
+///
+/// v1's fallback, composed from the same three public upstream functions v1
+/// composes it from (`walk_driver::walk_volatility`): log returns, the sample
+/// standard deviation of those returns, and a rescaling from the series'
+/// timeframe to a year. It prices the seeding chain, and it is what a series
+/// too short for an expanding window falls back to.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `method.prices` when a price is
+/// not usable as a log-return input, or `volatility` when the reduction or the
+/// annualisation fails.
+fn historical_constant_volatility(
+    prices: &[Positive],
+    timeframe: TimeFrame,
+) -> Result<Positive, ChainError> {
+    let returns = log_returns(prices)?;
+    let volatility = constant_volatility(&returns).map_err(|e| ChainError::Validation {
+        field: "volatility".to_string(),
+        reason: format!("the historical series has no usable volatility: {e}"),
+    })?;
+    annualise(volatility, timeframe)
+}
+
+/// The causal expanding-window volatility of a walked price path, one estimate
+/// per point.
+///
+/// # Why this exists
+///
+/// v1 prices a historical chain at step `i` with the volatility of everything
+/// observed **up to** `i`, never the whole series: `walk_steps_par` calls
+/// upstream's `expanding_window_vols`. A tape priced at one constant is a
+/// different, non-causal simulation — it lets a backtest see, at step 3, the
+/// turbulence of step 900. Issue #63.
+///
+/// # Why it composes rather than copies
+///
+/// Upstream's estimator is private to its driver, but its three ingredients are
+/// public, and upstream's own comment records that its prefix-sum variance is
+/// *algebraically identical to the two-pass form in `constant_volatility`*. So
+/// the window below writes the indexing policy and the backfill and **no
+/// mathematics**: there is no second copy of an upstream kernel in this repo to
+/// drift out of sync, which is the property the module docs above claim.
+///
+/// The cost of composing is quadratic time — `constant_volatility` reduces a
+/// whole slice and upstream's prefix-sum recurrence is not reachable from
+/// outside — where upstream is linear. It runs once per tape and only for
+/// `Historical`; the nine synthetic models never reach it. optionstratlib#423
+/// asks for the estimator to be exposed, which would make this a single call.
+///
+/// # Indexing
+///
+/// `prices[p]` has seen the returns `returns[..p]`, so an estimate needs
+/// `p >= 2` — one return has no dispersion. Points 0 and 1 are backfilled with
+/// the first computable estimate, matching upstream, so the vector is aligned
+/// index-by-index with `prices` and has no holes. Fewer than three prices leave
+/// nothing to expand over and return `None`, which is the caller's signal to
+/// fall back to the constant.
+///
+/// The `p >= 2` guard is explicit rather than delegated: `constant_volatility`
+/// answers `Positive::ZERO` for a shorter slice instead of refusing, and a
+/// zero volatility is an answer, not an absence.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when a price is not usable as a
+/// log-return input, or when a window cannot be reduced or annualised.
+fn expanding_window_volatilities(
+    prices: &[Positive],
+    timeframe: TimeFrame,
+) -> Result<Option<Vec<Positive>>, ChainError> {
+    // Two prices give one return, which has no sample dispersion; the first
+    // window that does is the one over `prices[..3]`.
+    if prices.len() < 3 {
+        return Ok(None);
+    }
+
+    let returns = log_returns(prices)?;
+    let mut volatilities = Vec::with_capacity(prices.len());
+    let mut first_computable: Option<Positive> = None;
+
+    for point in 0..prices.len() {
+        if point < 2 {
+            // Backfilled below, once the first real estimate is known.
+            continue;
+        }
+
+        let window = returns.get(..point).ok_or_else(|| ChainError::Validation {
+            field: "method.prices".to_string(),
+            reason: format!(
+                "the historical series yielded {} returns for {} prices, too few to \
+                     estimate the volatility at point {point}",
+                returns.len(),
+                prices.len()
+            ),
+        })?;
+
+        let volatility = constant_volatility(window).map_err(|e| ChainError::Validation {
+            field: "volatility".to_string(),
+            reason: format!("the historical window ending at point {point} has no volatility: {e}"),
+        })?;
+        let annualised = annualise(volatility, timeframe)?;
+
+        if first_computable.is_none() {
+            first_computable = Some(annualised);
+        }
+        volatilities.push(annualised);
+    }
+
+    let Some(fill) = first_computable else {
+        // Unreachable: `prices.len() >= 3` guarantees one pass through the loop
+        // body. Answering `None` rather than asserting keeps a future change to
+        // the guard above from turning a bad bound into a panic.
+        return Ok(None);
+    };
+
+    // Points 0 and 1 carry the first computable estimate, so the vector aligns
+    // with `prices` index by index.
+    let mut aligned = vec![fill; 2];
+    aligned.append(&mut volatilities);
+    Ok(Some(aligned))
+}
+
+/// The log returns of a price series as decimals.
+///
+/// `Positive::ln` builds its result without revalidating, so a falling price
+/// yields a negative value wearing a `Positive`. Reading each one back as a
+/// `Decimal` — which is what upstream's own estimator does — recovers the true
+/// sign before any arithmetic touches it.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `method.prices` when a price is
+/// zero, negative, or otherwise not usable as a log-return input.
+fn log_returns(prices: &[Positive]) -> Result<Vec<Decimal>, ChainError> {
+    let returns = calculate_log_returns(prices).map_err(|e| ChainError::Validation {
+        field: "method.prices".to_string(),
+        reason: format!("the historical series has no usable log returns: {e}"),
+    })?;
+    Ok(returns.iter().map(Positive::to_dec).collect())
+}
+
+/// Rescales a volatility from the series' timeframe to a year.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `volatility` when the rescaling
+/// fails.
+fn annualise(volatility: Positive, timeframe: TimeFrame) -> Result<Positive, ChainError> {
+    adjust_volatility(volatility, timeframe, TimeFrame::Year).map_err(|e| ChainError::Validation {
+        field: "volatility".to_string(),
+        reason: format!("the historical volatility cannot be annualised from {timeframe}: {e}"),
+    })
 }
 
 /// Rejects a volatility no option chain can be priced at.
@@ -523,6 +709,9 @@ mod tests {
     use crate::api::rest::requests_v2::CreateSimulationRequest;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use chrono::{TimeZone, Weekday};
+    use optionstratlib::error::SimulationError;
+    use optionstratlib::simulation::walk_steps_par;
+    use std::sync::Mutex;
 
     /// The reference market path: a modest daily Brownian walk over the
     /// simulated clock ADR 0001 §14 uses.
@@ -1012,10 +1201,10 @@ mod tests {
         }
     }
 
-    /// A historical walk has no model volatility, so the parameters' value is
-    /// the base — and the tape builds rather than failing the agreement check.
+    /// A historical walk prices itself: the volatility comes from the series,
+    /// never from the `volatility` the request happened to carry.
     #[test]
-    fn test_historical_uses_the_requested_volatility_as_the_base() {
+    fn test_historical_ignores_the_requested_volatility() {
         let prices: Vec<f64> = (0..40).map(|i| 5000.0 + f64::from(i)).collect();
         let mut historical = request(20, brownian(0.18), 0.18);
         historical.method = ApiWalkType::Historical {
@@ -1028,9 +1217,295 @@ mod tests {
         let tape = tape(&parameters);
 
         assert_eq!(tape.len(), 20);
+        // A near-linear ramp has almost no dispersion, so every estimate sits
+        // far below the 0.18 the request asked for. The point is not the
+        // number: it is that the request's value prices nothing.
         for row in tape.rows() {
-            assert_eq!(row.base_volatility, parameters.volatility);
+            assert_ne!(row.base_volatility, parameters.volatility);
+            assert!(
+                row.base_volatility < parameters.volatility,
+                "a flat series cannot be as volatile as {}, got {} at step {}",
+                parameters.volatility,
+                row.base_volatility,
+                row.step
+            );
         }
+    }
+
+    /// A series with a turbulent tail must not price its calm opening: the
+    /// estimate at each step is the one the prefix alone produces.
+    #[test]
+    fn test_historical_volatility_has_no_look_ahead() {
+        let series = volatile_series(40);
+        let full = match expanding_window_volatilities(&series, TimeFrame::Day) {
+            Ok(Some(volatilities)) => volatilities,
+            other => panic!("the full series must yield estimates, got {other:?}"),
+        };
+
+        for cut in 3..=series.len() {
+            let prefix = match series.get(..cut) {
+                Some(prefix) => prefix,
+                None => panic!("the cut must be within the series"),
+            };
+            let partial = match expanding_window_volatilities(prefix, TimeFrame::Day) {
+                Ok(Some(volatilities)) => volatilities,
+                other => panic!("the prefix of {cut} must yield estimates, got {other:?}"),
+            };
+
+            assert_eq!(partial.len(), cut);
+            for (point, volatility) in partial.iter().enumerate() {
+                assert_eq!(
+                    Some(volatility),
+                    full.get(point),
+                    "point {point} moved when the series grew to {cut} observations"
+                );
+            }
+        }
+    }
+
+    /// Fewer than three prices leave nothing to expand over, so the caller is
+    /// told to fall back rather than handed a fabricated estimate.
+    #[test]
+    fn test_expanding_window_needs_three_prices() {
+        let series = volatile_series(4);
+
+        for length in 0..3 {
+            let prefix = match series.get(..length) {
+                Some(prefix) => prefix,
+                None => panic!("the prefix must be within the series"),
+            };
+            assert!(
+                matches!(
+                    expanding_window_volatilities(prefix, TimeFrame::Day),
+                    Ok(None)
+                ),
+                "{length} prices cannot yield an expanding window"
+            );
+        }
+
+        assert!(matches!(
+            expanding_window_volatilities(&series, TimeFrame::Day),
+            Ok(Some(_))
+        ));
+    }
+
+    /// The first two points have no window of their own, so they carry the
+    /// first computable estimate — the vector stays aligned with the prices and
+    /// has no holes.
+    #[test]
+    fn test_expanding_window_backfills_the_first_two_points() {
+        let series = volatile_series(12);
+
+        let volatilities = match expanding_window_volatilities(&series, TimeFrame::Day) {
+            Ok(Some(volatilities)) => volatilities,
+            other => panic!("the series must yield estimates, got {other:?}"),
+        };
+
+        assert_eq!(volatilities.len(), series.len());
+        assert_eq!(volatilities.first(), volatilities.get(2));
+        assert_eq!(volatilities.get(1), volatilities.get(2));
+    }
+
+    /// A constant log return has no dispersion. Upstream reports zero rather
+    /// than refusing, and so does this: an answer, not an error or a panic.
+    #[test]
+    fn test_expanding_window_of_a_constant_return_is_zero() {
+        let mut price = Positive::new(5000.0).unwrap_or(Positive::ONE);
+        let mut series = Vec::with_capacity(10);
+        for _ in 0..10 {
+            series.push(price);
+            price = price * Positive::new(1.01).unwrap_or(Positive::ONE);
+        }
+
+        let volatilities = match expanding_window_volatilities(&series, TimeFrame::Day) {
+            Ok(Some(volatilities)) => volatilities,
+            other => panic!("a constant-return series must still yield estimates, got {other:?}"),
+        };
+
+        assert_eq!(volatilities.len(), series.len());
+        for (point, volatility) in volatilities.iter().enumerate() {
+            assert!(
+                *volatility < Positive::new(1e-12).unwrap_or(Positive::ONE),
+                "point {point} of a constant-return series should be flat, got {volatility}"
+            );
+        }
+    }
+
+    /// The estimate moves with the series, which is the whole point: a tape
+    /// that reported one number would be the constant this issue removed.
+    #[test]
+    fn test_historical_tape_volatility_varies_across_steps() {
+        let parameters = parameters(volatile_historical_request(30));
+
+        let tape = tape(&parameters);
+
+        let first = match tape.row(0) {
+            Some(row) => row.base_volatility,
+            None => panic!("the tape must have a first row"),
+        };
+        assert!(
+            tape.rows().iter().any(|row| row.base_volatility != first),
+            "every step reported the same volatility, so nothing is being estimated"
+        );
+    }
+
+    /// Rebuilding after eviction is the same call, so the estimates come back
+    /// identical — the tape stays a pure function of the parameters.
+    #[test]
+    fn test_historical_tape_volatility_is_reproducible() {
+        let parameters = parameters(volatile_historical_request(30));
+
+        let first = tape(&parameters);
+        let second = tape(&parameters);
+
+        assert_eq!(first.rows(), second.rows());
+    }
+
+    /// The acceptance criterion of issue #63: v1 and v2 price a historical step
+    /// at the same volatility.
+    ///
+    /// v1's per-step value is the one its driver hands the chain builder, so
+    /// the comparison calls that driver — `walk_steps_par`, the exact function
+    /// `generator_optionchain` uses — and records the volatility it passes.
+    /// Reading it there rather than off a built chain keeps skew, smile and
+    /// quote rounding out of the comparison and leaves the two estimates facing
+    /// each other.
+    ///
+    /// Agreement is numeric, not bit-exact: upstream accumulates the window
+    /// with prefix sums and `constant_volatility` centres in two passes. They
+    /// are algebraically the same expression, so what is left is `Decimal`
+    /// rounding. The largest deviation this series produces is 3.4e-23 on an
+    /// annualised volatility; the tolerance below sits five orders above that
+    /// and fifteen below anything an option price could notice.
+    ///
+    /// Step 0 is excluded, and that exclusion is the one real difference: v1
+    /// never asks its estimator about step 0 (its driver starts at index 1 and
+    /// its first chain is the seeding chain, priced at the request's constant),
+    /// while v2 serves step 0 as a snapshot and prices it with the backfilled
+    /// estimate. Pricing a served step at a volatility the series contradicts
+    /// would be the worse answer.
+    #[test]
+    fn test_v1_and_v2_agree_on_historical_volatility() {
+        /// Absolute, on an annualised volatility.
+        const TOLERANCE: Decimal = Decimal::from_parts(1, 0, 0, false, 18);
+
+        let parameters = parameters(volatile_historical_request(30));
+        let tape = tape(&parameters);
+
+        let base_volatility = match resolve_base_volatility(&parameters, &parameters.method) {
+            Ok(volatility) => volatility,
+            Err(error) => panic!("the historical series must yield a volatility: {error}"),
+        };
+        let initial_chain = match build_initial_chain(&parameters, base_volatility) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the seeding chain must build: {error}"),
+        };
+        let walk_params = WalkParams {
+            size: parameters.steps,
+            init_step: Step {
+                x: Xstep::new(
+                    Positive::ONE,
+                    parameters.time_frame,
+                    // Far enough out that the driver's per-step expiry decay
+                    // cannot truncate the walk before the horizon ends; a
+                    // historical path ignores it either way.
+                    ExpirationDate::Days(Positive::new(3650.0).unwrap_or(Positive::ONE)),
+                ),
+                y: Ystep::new(0, initial_chain.clone()),
+            },
+            walk_type: parameters.method.clone(),
+            walker: Box::new(Walker::new_with_seed(parameters.seed)),
+        };
+
+        // The driver builds its steps in parallel, so the volatilities are
+        // recorded with the step index the driver itself assigns.
+        let observed: Mutex<Vec<(i32, Option<Positive>)>> = Mutex::new(Vec::new());
+        let walked = walk_steps_par::<OptionChain, SimulationError, _>(
+            &walk_params,
+            |_price, volatility, x_step| match observed.lock() {
+                Ok(mut guard) => {
+                    guard.push((*x_step.index(), volatility));
+                    Ok(Some(initial_chain.clone()))
+                }
+                Err(_) => Err(SimulationError::walk_error("the recorder lock is poisoned")),
+            },
+        );
+        if let Err(error) = walked {
+            panic!("the v1 driver must walk the series: {error}");
+        }
+
+        let mut v1_volatilities = match observed.into_inner() {
+            Ok(volatilities) => volatilities,
+            Err(_) => panic!("the recorder lock must not be poisoned"),
+        };
+        v1_volatilities.sort_by_key(|(index, _)| *index);
+
+        assert_eq!(
+            v1_volatilities.len(),
+            tape.len() - 1,
+            "v1 prices every step but the seeding one"
+        );
+
+        for (index, volatility) in &v1_volatilities {
+            let step = match usize::try_from(*index) {
+                Ok(step) => step,
+                Err(error) => panic!("the driver's step index must be non-negative: {error}"),
+            };
+            let v2_row = match tape.row(step) {
+                Some(row) => row,
+                None => panic!("the tape must have a row for step {step}"),
+            };
+            let v1_volatility = match volatility {
+                Some(volatility) => *volatility,
+                None => panic!("v1 must price historical step {step} with an estimate"),
+            };
+
+            let deviation = (v1_volatility.to_dec() - v2_row.base_volatility.to_dec()).abs();
+            assert!(
+                deviation <= TOLERANCE,
+                "step {step} disagrees by {deviation}: v1 {v1_volatility}, v2 {}",
+                v2_row.base_volatility
+            );
+        }
+    }
+
+    /// A price series with a calm opening and a turbulent tail, so an expanding
+    /// window has something to move over.
+    fn volatile_series(length: usize) -> Vec<Positive> {
+        volatile_prices(length)
+            .into_iter()
+            .map(|price| match Positive::new(price) {
+                Ok(price) => price,
+                Err(error) => panic!("the test price must be positive: {error}"),
+            })
+            .collect()
+    }
+
+    fn volatile_prices(length: usize) -> Vec<f64> {
+        let mut prices = Vec::with_capacity(length);
+        let mut price = 5000.0_f64;
+        for index in 0..length {
+            prices.push(price);
+            // Calm for the first half, then a widening zig-zag: the expanding
+            // window has to keep moving instead of settling.
+            let shock = if index < length / 2 {
+                1.0
+            } else {
+                20.0 + f64::from(u32::try_from(index).unwrap_or(0))
+            };
+            price += if index % 2 == 0 { shock } else { -shock };
+        }
+        prices
+    }
+
+    fn volatile_historical_request(steps: usize) -> CreateSimulationRequest {
+        let mut historical = request(steps, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: volatile_prices(steps * 2),
+            symbol: Some("SPX".to_string()),
+        };
+        historical
     }
 
     /// A historical tape replays the supplied series in order, with no

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -49,11 +49,20 @@
 //! what had been observed by step `i` and nothing later.
 //!
 //! v2 never enters that driver, so [`expanding_window_volatilities`] is v2's
-//! caller-side answer, **composed from the same public upstream functions v1's
-//! is composed from** rather than copied out of it — see that function for the
-//! indexing and the cost. A historical tape therefore carries a volatility per
-//! step, causally, and the request's own `volatility` field prices none of it
-//! (see [`resolve_base_volatility`]).
+//! caller-side answer. It is **composed from public upstream primitives rather
+//! than copied out of the private estimator**: upstream's expanding kernel
+//! inlines its own prefix-sum variance, but records that the result is
+//! algebraically identical to `constant_volatility`, which is public — so the
+//! window here writes an indexing policy over upstream mathematics instead of a
+//! second copy of it. See that function for the indexing and the cost. A
+//! historical tape therefore carries a volatility per step, causally, and the
+//! request's own `volatility` field prices none of it (see
+//! [`resolve_base_volatility`]).
+//!
+//! Every value read is inside the horizon, the seeding chain's included: a
+//! historical walk replays `prices[..steps]`, and nothing here reduces more
+//! than that. A horizon of fewer than three steps has no dispersion to measure
+//! and is refused rather than priced from observations it could not have seen.
 //!
 //! Parity with v1 is numeric, not bit-exact: upstream accumulates the window
 //! with prefix sums while `constant_volatility` centres in two passes, and the
@@ -94,10 +103,13 @@ pub(crate) struct FactorRow {
     /// The **canonical** base implied volatility used to price every chain at
     /// this step.
     ///
-    /// For a constant-volatility model this is the model's volatility at every
-    /// row. For `Garch`, `Heston`, `Custom` and `Telegraph` it is the
-    /// annualised volatility prevailing at this step, index-aligned with
-    /// `spot`, as upstream's `generate_with_vol` reports it.
+    /// Three cases, one field. For a constant-volatility model this is the
+    /// model's volatility at every row. For `Garch`, `Heston`, `Custom` and
+    /// `Telegraph` it is the annualised volatility prevailing at this step,
+    /// index-aligned with `spot`, as upstream's `generate_with_vol` reports it.
+    /// For `Historical` it is the realized volatility of the walked prices up
+    /// to and including this step, estimated here because upstream leaves it to
+    /// the caller — see [`expanding_window_volatilities`].
     pub(crate) base_volatility: Positive,
 }
 
@@ -125,12 +137,19 @@ impl FactorTape {
     ///
     /// Returns [`ChainError::Validation`] when the parameters are invalid, when
     /// the model's volatility disagrees with the parameters' (see
-    /// [`resolve_base_volatility`]), when a `Historical` series is too short
-    /// for the horizon, when a stochastic-volatility path exceeds the 1.0 an
-    /// option chain can be priced at, or when the simulated clock overflows;
-    /// and [`ChainError::Internal`] when the resolved method is not the one the
+    /// [`resolve_base_volatility`]), when a `Historical` series is too short for
+    /// the horizon or carries a zero price, when a volatility — a
+    /// stochastic-volatility path's or a historical estimate's — leaves the
+    /// range an option chain can be priced at, when a historical window cannot
+    /// be reduced or annualised, or when the simulated clock overflows; and
+    /// [`ChainError::Internal`] when the resolved method is not the one the
     /// parameters name, when the initial chain cannot be built, or when the
     /// walk returns fewer points than requested.
+    ///
+    /// A historical simulation is refused *lazily*, when its tape is first
+    /// built, because creation does not build one. A series whose realized
+    /// volatility leaves the priceable range therefore creates successfully and
+    /// fails at the first peek — see ADR 0001 §8.1.
     #[instrument(skip(parameters, method), level = "debug")]
     pub(crate) fn build(
         parameters: &SimulationParametersV2,
@@ -145,7 +164,7 @@ impl FactorTape {
         ensure_method_matches(parameters, method)?;
         ensure_historical_series_covers_the_horizon(parameters, method)?;
         let base_volatility = resolve_base_volatility(parameters, method)?;
-        reject_unpriceable_volatility(base_volatility, None)?;
+        reject_unpriceable_volatility(base_volatility, None, volatility_source(method))?;
         let walker = Walker::new_with_seed(parameters.seed);
 
         // The walk starts from an `OptionChain` because that is the shape v1's
@@ -226,7 +245,7 @@ impl FactorTape {
                 None => base_volatility,
             };
 
-            reject_unpriceable_volatility(row_volatility, Some(step))?;
+            reject_unpriceable_volatility(row_volatility, Some(step), volatility_source(method))?;
 
             rows.push(FactorRow {
                 step,
@@ -322,13 +341,22 @@ fn ensure_method_matches(
     }
 }
 
-/// Rejects a historical series too short to cover the requested horizon.
+/// Rejects a historical series that cannot be walked or priced.
 ///
-/// Upstream's `historical` kernel errors when the embedded series is shorter
-/// than the walk, and that error would surface as a `500`. It is a client
-/// mistake — a request embedding five prices and asking for a hundred steps —
-/// so it is caught here and named, the way v1 avoids the problem entirely by
-/// refetching from the database.
+/// Two client mistakes, both of which would otherwise surface as a `500`:
+///
+/// - **Too short for the horizon.** Upstream's `historical` kernel errors when
+///   the embedded series is shorter than the walk — a request embedding five
+///   prices and asking for a hundred steps — so it is caught here and named,
+///   the way v1 avoids the problem entirely by refetching from the database.
+/// - **A zero price.** A log return divides by the previous price, and
+///   `Positive`'s division *panics* on a zero divisor rather than returning an
+///   error, so one zero close would take down the thread building the tape.
+///   `SimulationParametersV2::validate` already rejects it on the stored
+///   series, but the method passed here is the **resolved** one — the whole
+///   reason the argument exists is that a `Historical` walk may have been
+///   filled in from the database since — and that series has passed no
+///   validation at all.
 ///
 /// # Errors
 ///
@@ -348,6 +376,16 @@ fn ensure_historical_series_covers_the_horizon(
                 "must carry at least one price per step: {} supplied for {} steps",
                 prices.len(),
                 parameters.steps
+            ),
+        });
+    }
+
+    if let Some(index) = prices.iter().position(|price| price.is_zero()) {
+        return Err(ChainError::Validation {
+            field: "method.prices".to_string(),
+            reason: format!(
+                "must be strictly positive: the price at index {index} is zero, and a log \
+                 return cannot divide by it"
             ),
         });
     }
@@ -385,11 +423,26 @@ fn ensure_historical_series_covers_the_horizon(
 /// chains rather than what it asked for. Dropping the field for this one
 /// variant is a DTO change and is deliberately not made here.
 ///
+/// # Only the walked window is read
+///
+/// The estimate covers `prices[..steps]` — the prefix upstream's historical
+/// kernel actually replays — and not the whole embedded series. Reducing the
+/// series would let an observation *past* the horizon price the simulation, or
+/// refuse it, in a change whose entire point is that nothing later may reach an
+/// earlier step. It is a deliberate divergence from v1, which reduces the whole
+/// series for its own fallback.
+///
+/// A consequence worth stating: a horizon shorter than three steps has at most
+/// one return and therefore no dispersion to measure, so the estimate is zero
+/// and [`reject_unpriceable_volatility`] refuses the simulation. v1 would have
+/// priced it from data it could not have seen; issue #63 lists refusing as an
+/// accepted answer, and it is the honest one.
+///
 /// # Errors
 ///
 /// Returns [`ChainError::Validation`] naming `volatility` when a synthetic
-/// model's volatility and the parameters' disagree, or when the historical
-/// series cannot be reduced to a volatility.
+/// model's volatility and the parameters' disagree, or `method.prices` when the
+/// walked window cannot be reduced to a volatility.
 fn resolve_base_volatility(
     parameters: &SimulationParametersV2,
     method: &SimulationMethod,
@@ -411,7 +464,24 @@ fn resolve_base_volatility(
         None => match method {
             SimulationMethod::Historical {
                 timeframe, prices, ..
-            } => historical_constant_volatility(prices, *timeframe),
+            } => {
+                // The length is guaranteed by
+                // `ensure_historical_series_covers_the_horizon`, which runs
+                // first; the checked slice keeps a future reordering from
+                // becoming a panic.
+                let window =
+                    prices
+                        .get(..parameters.steps)
+                        .ok_or_else(|| ChainError::Validation {
+                            field: "method.prices".to_string(),
+                            reason: format!(
+                                "must carry at least one price per step: {} supplied for {} steps",
+                                prices.len(),
+                                parameters.steps
+                            ),
+                        })?;
+                historical_constant_volatility(window, *timeframe)
+            }
             // `volatility()` returns `None` only for `Historical`; the match is
             // exhaustive over what can reach here, and a future variant that
             // also returns `None` lands on the requested value rather than
@@ -421,13 +491,16 @@ fn resolve_base_volatility(
     }
 }
 
-/// The whole-series volatility of a historical price series, annualised.
+/// The single volatility of a stretch of historical prices, annualised.
 ///
-/// v1's fallback, composed from the same three public upstream functions v1
-/// composes it from (`walk_driver::walk_volatility`): log returns, the sample
-/// standard deviation of those returns, and a rescaling from the series'
-/// timeframe to a year. It prices the seeding chain, and it is what a series
-/// too short for an expanding window falls back to.
+/// Composed from the same three public upstream functions v1's own whole-series
+/// fallback (`walk_driver::walk_volatility`) composes itself from: log returns,
+/// the sample standard deviation of those returns, and a rescaling from the
+/// series' timeframe to a year.
+///
+/// Callers pass the walked window, never the whole embedded series — see
+/// [`resolve_base_volatility`] for why. It prices the seeding chain, and it is
+/// what a window too short for an expanding estimate reduces to.
 ///
 /// # Errors
 ///
@@ -577,33 +650,94 @@ fn annualise(volatility: Positive, timeframe: TimeFrame) -> Result<Positive, Cha
     })
 }
 
+/// Which of the two a walk method's volatility comes from.
+fn volatility_source(method: &SimulationMethod) -> VolatilitySource {
+    match method {
+        SimulationMethod::Historical { .. } => VolatilitySource::Series,
+        _ => VolatilitySource::Model,
+    }
+}
+
+/// Where a volatility that failed the priceable range came from, so the error
+/// names a field the client can actually act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VolatilitySource {
+    /// The walk model's own volatility, or the request's, which must agree.
+    Model,
+    /// Estimated from a historical price series, where the request's
+    /// `volatility` prices nothing and lowering it would change nothing.
+    Series,
+}
+
+impl VolatilitySource {
+    /// The request field to name.
+    fn field(self) -> &'static str {
+        match self {
+            Self::Model => "volatility",
+            Self::Series => "method.prices",
+        }
+    }
+
+    /// What the client has to change.
+    fn remedy(self) -> &'static str {
+        match self {
+            Self::Model => "lower the model's volatility or shorten the horizon",
+            Self::Series => {
+                "the volatility is estimated from the series, so it is the series that has to \
+                 change — the request's volatility prices nothing for a historical walk"
+            }
+        }
+    }
+}
+
 /// Rejects a volatility no option chain can be priced at.
 ///
-/// Upstream refuses anything above 1.0 annualised, so without this a run whose
-/// volatility crosses it fails with an internal error the first time a chain is
-/// built — at creation for a constant model, and halfway through the horizon
-/// for a stochastic one, at whatever step crosses first. Both become one 400
-/// naming the field, at tape build, where the whole path is in hand.
+/// Upstream refuses anything above 1.0 annualised **and anything equal to
+/// zero**, so without this a run whose volatility leaves that range fails with
+/// an internal error the first time a chain is built — at creation for a
+/// constant model, and halfway through the horizon for a stochastic or
+/// historical one, at whatever step crosses first. All of them become one 400
+/// naming a field, at tape build, where the whole path is in hand.
+///
+/// The lower bound is not theoretical for a historical walk: three equal prices
+/// give two zero log returns, so the estimate over that window is exactly zero.
+/// The session layer already refuses a zero the *request* supplies; an
+/// estimated one has to be refused here, because this is the only gate it
+/// passes through.
 ///
 /// Rejecting rather than clamping: a clamped path is a different tape, and the
 /// seed would no longer reproduce it.
 fn reject_unpriceable_volatility(
     volatility: Positive,
     step: Option<usize>,
+    source: VolatilitySource,
 ) -> Result<(), ChainError> {
+    let at = match step {
+        Some(step) => format!(" at step {step}"),
+        None => String::new(),
+    };
+
+    if volatility.is_zero() {
+        return Err(ChainError::Validation {
+            field: source.field().to_string(),
+            reason: format!(
+                "the volatility is zero{at}, and an option chain priced at zero volatility is a \
+                 chain of zero-value options; {}",
+                source.remedy()
+            ),
+        });
+    }
+
     if volatility <= Positive::ONE {
         return Ok(());
     }
 
-    let found = match step {
-        Some(step) => format!("the walk reaches {volatility} at step {step}"),
-        None => format!("{volatility}"),
-    };
     Err(ChainError::Validation {
-        field: "volatility".to_string(),
+        field: source.field().to_string(),
         reason: format!(
-            "{found}, above the 1.0 maximum an option chain can be priced at; \
-             lower the model's volatility or shorten the horizon"
+            "the volatility reaches {volatility}{at}, above the 1.0 maximum an option chain can \
+             be priced at; {}",
+            source.remedy()
         ),
     })
 }
@@ -1201,6 +1335,110 @@ mod tests {
         }
     }
 
+    /// A horizon of fewer than three steps has one return at most, and one
+    /// return has no dispersion. v1 would price it from the whole embedded
+    /// series — data past the horizon — so v2 refuses instead, which issue #63
+    /// lists as an accepted answer.
+    #[test]
+    fn test_a_horizon_too_short_to_estimate_is_refused() {
+        let mut historical = request(2, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: volatile_prices(60),
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "method.prices");
+                assert!(reason.contains("zero"), "{reason}");
+                assert!(reason.contains("prices nothing"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A series that never moves has no volatility, and upstream refuses to
+    /// price a chain at zero. It becomes one 400 naming the series rather than
+    /// a 500 from inside the chain builder.
+    #[test]
+    fn test_a_series_without_dispersion_is_refused() {
+        let mut historical = request(4, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: vec![5000.0; 8],
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "method.prices");
+                assert!(reason.contains("zero-value options"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// A series too turbulent to price is refused with advice that applies: the
+    /// volatility comes from the series, so lowering the request's does nothing.
+    #[test]
+    fn test_a_series_above_the_priceable_volatility_is_refused() {
+        let prices: Vec<f64> = (0..20)
+            .map(|index| if index % 2 == 0 { 5000.0 } else { 5500.0 })
+            .collect();
+        let mut historical = request(10, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices,
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        match FactorTape::build(&parameters, &parameters.method) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "method.prices");
+                assert!(reason.contains("above the 1.0 maximum"), "{reason}");
+                assert!(reason.contains("the series that has to change"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
+    /// The resolved method is separately supplied and passes no boundary
+    /// validation, so a zero close reaching it from the database has to be
+    /// caught here — a log return would divide by it, and that division panics.
+    #[test]
+    fn test_a_zero_price_in_the_resolved_series_is_refused() {
+        let mut historical = request(4, brownian(0.18), 0.18);
+        historical.method = ApiWalkType::Historical {
+            timeframe: ApiTimeFrame::Day,
+            prices: volatile_prices(20),
+            symbol: Some("SPX".to_string()),
+        };
+        let parameters = parameters(historical);
+
+        let mut resolved = volatile_series(20);
+        match resolved.get_mut(3) {
+            Some(price) => *price = Positive::ZERO,
+            None => panic!("the fixture must have a fourth price"),
+        }
+        let resolved = SimulationMethod::Historical {
+            timeframe: TimeFrame::Day,
+            prices: resolved,
+            symbol: Some("SPX".to_string()),
+        };
+
+        match FactorTape::build(&parameters, &resolved) {
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "method.prices");
+                assert!(reason.contains("index 3 is zero"), "{reason}");
+            }
+            other => panic!("expected a validation error, got {other:?}"),
+        }
+    }
+
     /// A historical walk prices itself: the volatility comes from the series,
     /// never from the `volatility` the request happened to carry.
     #[test]
@@ -1539,12 +1777,12 @@ mod tests {
 
     /// Later observations cannot change an earlier step's base volatility.
     ///
-    /// The property the estimator question turns on (#63): whatever prices a
-    /// historical step, it must be a function of that step and what came before
-    /// it. Today the answer is the requested constant, so extending the series
-    /// changes nothing — and if optionstratlib#423 lands and a causal estimate
-    /// replaces the constant, this test keeps holding while a look-ahead one
-    /// would break it.
+    /// The property the estimator turns on (#63): whatever prices a historical
+    /// step must be a function of that step and what came before it. Now that
+    /// the price is an estimate rather than a constant, this is where it is
+    /// load-bearing — it proves the estimate is taken over the *walked* prefix
+    /// and not the embedded series, the one place v2 could have diverged from
+    /// v1 while every other test still passed.
     #[test]
     fn test_a_longer_series_leaves_earlier_steps_untouched() {
         // The observation count is a `u32` so the index converts to `f64`

--- a/src/infrastructure/clickhouse/snapshots/record.rs
+++ b/src/infrastructure/clickhouse/snapshots/record.rs
@@ -50,7 +50,18 @@ use uuid::Uuid;
 /// this build wrote is this one. It lives here, next to the records, so an
 /// external consumer of the `pub` read API has a name to pass instead of a
 /// hardcoded literal.
-pub const CURRENT_SNAPSHOT_GENERATION: u64 = 1;
+///
+/// # History
+///
+/// - `1` — the shape 0.2.0 shipped. A historical walk priced every step at the
+///   constant `volatility` the request supplied.
+/// - `2` — a historical walk prices each step at a causal realized-volatility
+///   estimate over the observations up to it. The price path is unchanged and
+///   every other walk type is unaffected, but the premiums of a historical
+///   simulation are not, so its rows are a different tape under the same
+///   coordinates. Generation 1 rows stay in place until their retention expires
+///   and are simply not read by this build.
+pub const CURRENT_SNAPSHOT_GENERATION: u64 = 2;
 
 /// The namespace every deterministic `snapshot_id` is derived under.
 ///
@@ -524,10 +535,35 @@ mod tests {
     fn test_the_current_generation_is_addressable() {
         let simulation = Uuid::from_u128(7);
 
-        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 1);
+        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 2);
         assert_eq!(
             record(simulation, CURRENT_SNAPSHOT_GENERATION, 0).snapshot_id(),
             snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 0)
+        );
+    }
+
+    /// One step of one simulation is a different row in each generation.
+    ///
+    /// This is what a generation is for. The tables collapse on
+    /// `(simulation, generation, step)`, so if two builds that price a step
+    /// differently shared a generation, the later one would not sit beside the
+    /// earlier tape — it would replace it, and a client replaying against
+    /// either would get whichever landed last.
+    #[test]
+    fn test_a_generation_bump_addresses_a_different_row() {
+        let simulation = Uuid::from_u128(7);
+
+        let previous = snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION - 1, 3);
+        let current = snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 3);
+
+        assert_ne!(
+            previous, current,
+            "the same step under two generations must be two rows"
+        );
+        assert_eq!(
+            current,
+            snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 3),
+            "and the current one must still be reproducible"
         );
     }
 

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -318,7 +318,7 @@ fn invalid(variable: &str, raw: &str) -> ChainError {
 
 /// The per-snapshot contract cap the running service applies.
 ///
-/// [`SimulationParametersV2::validate`] is a method on a value, not a service
+/// [`crate::session::SimulationParametersV2::validate`] is a method on a value, not a service
 /// with a config handle, so the parsed cap reaches it through here.
 /// [`SimulationV2Config::from_env`] publishes it once at startup, which keeps
 /// the parsing — and the failure that names the variable — in exactly one

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,9 @@
 //! well as the price path. (Step 0 differs by construction: v1 prices its first
 //! chain at the request's constant.) The `volatility` you send prices none of
 //! its steps; the values that did are the per-step ones every snapshot and the
-//! `volatility` export report. A series with no dispersion, or one too
-//! turbulent to price a chain at, is refused when the simulation is first
-//! served.
+//! `volatility` export report. A series too turbulent to price a chain at, or
+//! one whose first three prices are equal, is refused when the simulation is
+//! first served.
 //!
 //! **Advanced steps can be filed in ClickHouse.** With
 //! `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,13 +121,12 @@
 //! changing the seed, the start, the schedules or the chain shape changes the
 //! tape, so it creates a new simulation instead of mutating one.
 //!
-//! **A historical v2 walk is priced at the volatility you send.** A
-//! `Historical` method carries no volatility of its own, and v2 does not enter
-//! the upstream walk driver that estimates one per step, so every step of a
-//! historical v2 simulation prices at the request's constant `volatility`. v1
-//! uses a rolling causal estimate for the same series, so the two produce the
-//! same price path and different premiums. It is a stated difference, tracked
-//! in issue #63 and asked for upstream in optionstratlib#423.
+//! **A historical v2 walk prices itself.** A `Historical` method carries no
+//! volatility of its own, so each step is priced by the realized volatility of
+//! everything observed up to that step and nothing later — the same expanding
+//! window v1 uses, so the two agree on the volatility path as well as the price
+//! path. The `volatility` you send prices none of its steps; the values that
+//! did are the per-step ones every snapshot and the `volatility` export report.
 //!
 //! **Advanced steps can be filed in ClickHouse.** With
 //! `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,13 @@
 //! **A historical v2 walk prices itself.** A `Historical` method carries no
 //! volatility of its own, so each step is priced by the realized volatility of
 //! everything observed up to that step and nothing later — the same expanding
-//! window v1 uses, so the two agree on the volatility path as well as the price
-//! path. The `volatility` you send prices none of its steps; the values that
-//! did are the per-step ones every snapshot and the `volatility` export report.
+//! window v1 uses, so from step 1 on the two agree on the volatility path as
+//! well as the price path. (Step 0 differs by construction: v1 prices its first
+//! chain at the request's constant.) The `volatility` you send prices none of
+//! its steps; the values that did are the per-step ones every snapshot and the
+//! `volatility` export report. A series with no dispersion, or one too
+//! turbulent to price a chain at, is refused when the simulation is first
+//! served.
 //!
 //! **Advanced steps can be filed in ClickHouse.** With
 //! `OCS_SNAPSHOT_PERSISTENCE_ENABLED` on, every step an advance serves is

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
 
@@ -49,6 +49,15 @@ pub struct SimulationManager {
     store: Arc<dyn SimulationStore>,
     config: SimulationV2Config,
     tapes: Arc<Mutex<HashMap<Uuid, TapeEntry>>>,
+    /// Tape builds currently running, one entry per simulation.
+    ///
+    /// Without it, N concurrent first reads of one simulation start N identical
+    /// builds — and a build is the one place a v2 request does seconds of CPU,
+    /// so the duplicates are not a wasted allocation, they are the machine.
+    /// `spawn_blocking` does not bound that: its pool grows to hundreds of
+    /// threads, so the cache would still be cold while every core was busy
+    /// filling it with the same answer.
+    builds: Mutex<HashMap<Uuid, broadcast::Sender<Result<FactorTape, String>>>>,
     snapshots: Mutex<SnapshotCache>,
     /// Where served snapshots are queued for filing, when the operator turned
     /// persistence on. `None` is the default and the whole feature is then
@@ -102,6 +111,7 @@ impl SimulationManager {
             store,
             config,
             tapes: Arc::new(Mutex::new(HashMap::new())),
+            builds: Mutex::new(HashMap::new()),
             snapshots: Mutex::new(SnapshotCache::with_bounds(
                 config.max_cached_snapshots,
                 config.max_cached_snapshot_contracts,
@@ -488,6 +498,78 @@ impl SimulationManager {
             return Ok(tape);
         }
 
+        let id = simulation.id;
+
+        // Either this call owns the build or it waits on the one already
+        // running. Decided under the lock, so two callers cannot both decide
+        // they are the owner.
+        let subscription = {
+            let mut builds = match self.builds.lock() {
+                Ok(builds) => builds,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+
+            match builds.get(&id) {
+                Some(running) => Some(running.subscribe()),
+                None => {
+                    let (sender, _) = broadcast::channel(1);
+                    builds.insert(id, sender);
+                    None
+                }
+            }
+        };
+
+        if let Some(mut waiting) = subscription {
+            return match waiting.recv().await {
+                Ok(Ok(tape)) => Ok(tape),
+                // The owner failed; report what it reported rather than
+                // starting a second build that would fail the same way.
+                Ok(Err(reason)) => Err(ChainError::Internal(reason)),
+                // The owner's task died without publishing. Rare, and the
+                // honest answer is to build it here rather than hang.
+                Err(_) => self.build_tape(simulation).await,
+            };
+        }
+
+        let result = self.build_tape(simulation).await;
+
+        // Publish to whoever is waiting and stop being the owner, in that
+        // order: a caller that subscribes after the removal misses the
+        // broadcast, retries, and finds the tape in the cache.
+        let sender = {
+            let mut builds = match self.builds.lock() {
+                Ok(builds) => builds,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            builds.remove(&id)
+        };
+        if let Some(sender) = sender {
+            let published = match &result {
+                Ok(tape) => Ok(tape.clone()),
+                Err(error) => Err(error.to_string()),
+            };
+            // An error means nobody was waiting, which is the common case.
+            let _ = sender.send(published);
+        }
+
+        result
+    }
+
+    /// Builds a tape off the runtime and files it.
+    ///
+    /// `FactorTape::build` is pure and synchronous, and it is the one place a
+    /// v2 request does real CPU work up front: a historical walk estimates a
+    /// volatility per step, which at the 10 000-step cap measures over three
+    /// seconds. Left on a worker it would stall every other request that worker
+    /// holds, so it goes to the blocking pool, exactly as the export path
+    /// already does with the same call.
+    ///
+    /// The result is filed **inside** the blocking task rather than after the
+    /// await. A `spawn_blocking` task cannot be cancelled, but awaiting it can:
+    /// a client that disconnects or times out mid-build drops that future, and
+    /// filing afterwards would throw away a build that ran to completion
+    /// anyway.
+    async fn build_tape(&self, simulation: &SessionV2) -> Result<FactorTape, ChainError> {
         let parameters = simulation.parameters.clone();
         let id = simulation.id;
         let tapes = Arc::clone(&self.tapes);
@@ -817,6 +899,47 @@ mod tests {
                 left.step
             );
         }
+    }
+
+    /// Concurrent first reads of one simulation share a single build.
+    ///
+    /// The build is the one place a v2 request does seconds of CPU, so N
+    /// concurrent peeks starting N identical builds is not wasted allocation,
+    /// it is the machine. What proves the sharing is the snapshots: every
+    /// caller gets the same tape, and only one entry is cached.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_first_reads_share_one_build() {
+        let manager = Arc::new(manager());
+        let simulation = created(&manager, 3).await;
+
+        let mut readers = Vec::new();
+        for _ in 0..8 {
+            let manager = Arc::clone(&manager);
+            let id = simulation.id;
+            readers.push(tokio::spawn(async move { manager.peek(id).await }));
+        }
+
+        let mut snapshots = Vec::new();
+        for reader in readers {
+            match reader.await {
+                Ok(Ok((_, snapshot))) => snapshots.push(snapshot),
+                Ok(Err(error)) => panic!("every reader must be served: {error}"),
+                Err(error) => panic!("a reader panicked: {error}"),
+            }
+        }
+
+        assert_eq!(snapshots.len(), 8);
+        for snapshot in &snapshots {
+            assert_eq!(
+                snapshot, &snapshots[0],
+                "every reader must see the same tape"
+            );
+        }
+        assert_eq!(
+            manager.cached_tapes(),
+            1,
+            "eight readers of one simulation must leave one tape"
+        );
     }
 
     /// An advance files exactly the step it served.

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -228,7 +228,9 @@ impl SimulationManager {
         let simulation = self.store.get(id).await?;
         Self::reject_terminal(&simulation, "no current step")?;
 
-        let snapshot = self.snapshot_at(&simulation, simulation.current_step)?;
+        let snapshot = self
+            .snapshot_at(&simulation, simulation.current_step)
+            .await?;
         Ok((simulation, snapshot))
     }
 
@@ -258,7 +260,9 @@ impl SimulationManager {
         let expected_version = simulation.version;
         Self::reject_terminal(&simulation, "no further steps")?;
 
-        let snapshot = self.snapshot_at(&simulation, simulation.current_step)?;
+        let snapshot = self
+            .snapshot_at(&simulation, simulation.current_step)
+            .await?;
 
         simulation.current_step = simulation
             .current_step
@@ -427,7 +431,7 @@ impl SimulationManager {
     /// Locks are held only for the map operations, never across a build: the
     /// tape and the snapshot are produced outside any critical section, so a
     /// slow build cannot stall another simulation's request.
-    fn snapshot_at(
+    async fn snapshot_at(
         &self,
         simulation: &SessionV2,
         step: usize,
@@ -436,7 +440,7 @@ impl SimulationManager {
             return Ok(cached);
         }
 
-        let tape = self.tape_for(simulation)?;
+        let tape = self.tape_for(simulation).await?;
         let snapshot = SeriesBuilder::new(&simulation.parameters, &tape)?.snapshot(step)?;
 
         self.cache_snapshot(simulation.id, snapshot.clone());
@@ -462,16 +466,28 @@ impl SimulationManager {
     }
 
     /// Returns the simulation's factor tape, building it on a miss.
-    fn tape_for(&self, simulation: &SessionV2) -> Result<FactorTape, ChainError> {
+    ///
+    /// Built outside the lock — holding the map while it runs would serialise
+    /// every other simulation behind it — and off the runtime. `FactorTape::build`
+    /// is pure and synchronous, and it is the one place a v2 request does real
+    /// CPU work up front: a historical walk estimates a volatility per step,
+    /// which at the 10 000-step cap measures over three seconds. Left on a
+    /// worker that would stall every other request the worker holds, so it goes
+    /// to the blocking pool, exactly as the export path already does with the
+    /// same call.
+    async fn tape_for(&self, simulation: &SessionV2) -> Result<FactorTape, ChainError> {
         if let Some(tape) = self.cached_tape(simulation.id) {
             return Ok(tape);
         }
 
-        // Built outside the lock. `FactorTape::build` is pure and synchronous —
-        // it is the one place a v2 request does real CPU work up front — and
-        // holding the map while it runs would serialise every other simulation
-        // behind it.
-        let tape = FactorTape::build(&simulation.parameters, &simulation.parameters.method)?;
+        let parameters = simulation.parameters.clone();
+        let tape =
+            tokio::task::spawn_blocking(move || FactorTape::build(&parameters, &parameters.method))
+                .await
+                .map_err(|e| {
+                    ChainError::Internal(format!("the factor tape build did not finish: {e}"))
+                })??;
+
         self.cache_tape(simulation.id, tape.clone());
         Ok(tape)
     }

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -517,6 +517,15 @@ impl SimulationManager {
     ///
     /// Takes the map rather than `&self` so the builder can file its result
     /// from inside the blocking task, where no caller can drop it.
+    ///
+    /// One race that follows from filing there, recorded because it is benign
+    /// only under the current routes: a build already running when the
+    /// simulation is deleted, completed or reaped will file afterwards, leaving
+    /// a tape for an id the store no longer knows. Nothing can serve it — every
+    /// path reads the store before the cache — so it costs memory until the LRU
+    /// pushes it out. It would stop being benign the day v2 gains a route that
+    /// changes a simulation's parameters in place, because the stale tape would
+    /// then be a tape of the *old* parameters under a live id.
     fn cache_tape(
         tapes: &Mutex<HashMap<Uuid, TapeEntry>>,
         max_cached_tapes: usize,
@@ -961,6 +970,31 @@ mod tests {
             Ok(_) => assert_eq!(manager.cached_tapes(), 1),
             Err(error) => panic!("the peek must succeed: {error}"),
         }
+    }
+
+    /// The tape cache still honours the configured capacity now that the build
+    /// files its own result from inside the blocking task and the cap travels
+    /// as a parameter rather than through `&self`.
+    #[tokio::test]
+    async fn test_the_tape_cache_still_honours_its_capacity() {
+        let config = SimulationV2Config {
+            max_cached_tapes: 2,
+            ..SimulationV2Config::default()
+        };
+        let manager = SimulationManager::new(Arc::new(InMemorySimulationStore::new()), config);
+
+        for _ in 0..4 {
+            let created = created(&manager, 5).await;
+            if let Err(error) = manager.peek(created.id).await {
+                panic!("the peek must succeed: {error}");
+            }
+        }
+
+        assert_eq!(
+            manager.cached_tapes(),
+            2,
+            "four tapes were built under a cap of two"
+        );
     }
 
     /// A peek is repeatable and changes nothing.

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -48,7 +48,7 @@ struct TapeEntry {
 pub struct SimulationManager {
     store: Arc<dyn SimulationStore>,
     config: SimulationV2Config,
-    tapes: Mutex<HashMap<Uuid, TapeEntry>>,
+    tapes: Arc<Mutex<HashMap<Uuid, TapeEntry>>>,
     snapshots: Mutex<SnapshotCache>,
     /// Where served snapshots are queued for filing, when the operator turned
     /// persistence on. `None` is the default and the whole feature is then
@@ -101,7 +101,7 @@ impl SimulationManager {
         Self {
             store,
             config,
-            tapes: Mutex::new(HashMap::new()),
+            tapes: Arc::new(Mutex::new(HashMap::new())),
             snapshots: Mutex::new(SnapshotCache::with_bounds(
                 config.max_cached_snapshots,
                 config.max_cached_snapshot_contracts,
@@ -475,21 +475,31 @@ impl SimulationManager {
     /// worker that would stall every other request the worker holds, so it goes
     /// to the blocking pool, exactly as the export path already does with the
     /// same call.
+    ///
+    /// The result is filed **inside** the blocking task rather than after the
+    /// await. A `spawn_blocking` task cannot be cancelled, but awaiting it can:
+    /// a client that disconnects or times out mid-build drops this future, and
+    /// filing afterwards would throw away a build that ran to completion
+    /// anyway. At three seconds a caller retrying under a shorter timeout would
+    /// then never warm the cache and would pin a blocking thread on every
+    /// attempt.
     async fn tape_for(&self, simulation: &SessionV2) -> Result<FactorTape, ChainError> {
         if let Some(tape) = self.cached_tape(simulation.id) {
             return Ok(tape);
         }
 
         let parameters = simulation.parameters.clone();
-        let tape =
-            tokio::task::spawn_blocking(move || FactorTape::build(&parameters, &parameters.method))
-                .await
-                .map_err(|e| {
-                    ChainError::Internal(format!("the factor tape build did not finish: {e}"))
-                })??;
+        let id = simulation.id;
+        let tapes = Arc::clone(&self.tapes);
+        let max_cached_tapes = self.config.max_cached_tapes;
 
-        self.cache_tape(simulation.id, tape.clone());
-        Ok(tape)
+        tokio::task::spawn_blocking(move || {
+            let tape = FactorTape::build(&parameters, &parameters.method)?;
+            Self::cache_tape(&tapes, max_cached_tapes, id, tape.clone());
+            Ok(tape)
+        })
+        .await
+        .map_err(|e| ChainError::Internal(format!("the factor tape build did not finish: {e}")))?
     }
 
     /// Reads a cached tape, refreshing its recency.
@@ -504,8 +514,16 @@ impl SimulationManager {
     }
 
     /// Stores a built tape, evicting the least recently used first.
-    fn cache_tape(&self, id: Uuid, tape: FactorTape) {
-        let mut tapes = match self.tapes.lock() {
+    ///
+    /// Takes the map rather than `&self` so the builder can file its result
+    /// from inside the blocking task, where no caller can drop it.
+    fn cache_tape(
+        tapes: &Mutex<HashMap<Uuid, TapeEntry>>,
+        max_cached_tapes: usize,
+        id: Uuid,
+        tape: FactorTape,
+    ) {
+        let mut tapes = match tapes.lock() {
             Ok(tapes) => tapes,
             Err(poisoned) => poisoned.into_inner(),
         };
@@ -514,7 +532,7 @@ impl SimulationManager {
         // The capacity is validated `>= 1` when the configuration loads, so
         // `- 1` cannot underflow. Evicting before the insert keeps the id being
         // inserted out of the running for victim.
-        let max = self.config.max_cached_tapes;
+        let max = max_cached_tapes;
         debug_assert!(
             max >= 1,
             "the configured capacity is validated >= 1 at load"

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -726,7 +726,7 @@ impl SessionV2 {
     /// Creates a simulation from resolved parameters.
     ///
     /// The id is **random** (`Uuid::new_v4`), for the reason v1 already
-    /// documents: [`UuidGenerator`] derives from a process-local counter that
+    /// documents: [`crate::utils::UuidGenerator`] derives from a process-local counter that
     /// starts at zero, so a restarted service or a second replica would reissue
     /// the same id sequence. That was survivable while an id only had to be
     /// unique among live sessions; it is not now that persisted snapshots are

--- a/src/session/snapshot_record.rs
+++ b/src/session/snapshot_record.rs
@@ -1,7 +1,7 @@
 //! The domain snapshot, in the shape the warehouse stores.
 //!
 //! The conversion lives here rather than in `infrastructure` because
-//! [`SeriesSnapshot`] is `pub(crate)` inside the private `domain` module: the
+//! `SeriesSnapshot` is `pub(crate)` inside the private `domain` module: the
 //! persistence layer cannot name it, and must not, or the layering would run
 //! backwards. The session layer sees both sides, so it owns the translation —
 //! the same place the f64 ↔ typed conversion already happens for the REST


### PR DESCRIPTION
## What

A `Historical` v2 walk carries no volatility of its own, and the factor tape priced every step of one at the constant `volatility` the request happened to send. v1 does not: its walk driver estimates the realized volatility over an **expanding window**, so step `i` is priced by what had been observed by step `i` and nothing later. Same series, same seed, two different volatility paths — and the v2 one is not causal, which is what makes it wrong rather than merely different: a backtest at step 3 was priced by the turbulence of step 900.

## How

The issue frames this as port-or-nothing, because upstream's `expanding_window_vols` is private to its driver. It is not. All three of its ingredients are public, and upstream's own comment records that its prefix-sum variance is *"algebraically identical to the two-pass form in `constant_volatility`"*:

| upstream function | path |
|---|---|
| `calculate_log_returns` | `utils/others.rs:250` |
| `constant_volatility` | `volatility/utils.rs:49` |
| `adjust_volatility` | `volatility/utils.rs:605` |

So `expanding_window_volatilities` writes an **indexing policy over upstream mathematics** — the window, the `>= 2` guard, the backfill of points 0 and 1 — and no mathematics of its own. There is no second copy of an upstream kernel in this repo, so nothing new has to be re-synced on an optionstratlib bump, and `CLAUDE.md` needs no new Key Decision. Upstream's own whole-series fallback (`walk_volatility`) composes the same three functions, so this matches its idiom rather than working around it.

Everything read stays inside the horizon, the seeding chain's volatility included — a historical walk replays `prices[..steps]`, and every reduction is taken over that prefix. That is a deliberate divergence from v1, whose fallback reduces the whole embedded series.

## Contract

`Historical` requests behave differently, with no schema change:

- **The request's `volatility` prices nothing.** The series prices itself. Not silently swallowed — the values that did price the chains are each snapshot's `base_volatility`, which the snapshot and export surfaces already report. Documented in the request DTO, the response DTO, `lib.rs` and ADR 0001 §8.1.
- **Two series are now refused that used to be served**: one whose realized volatility is zero or above the `1.0` a chain can be priced at, and a horizon of fewer than three steps, which has no dispersion to estimate from. Issue #63 lists refusing as an accepted answer, and the alternative was pricing from data the horizon could not have seen. Both arrive as a `400` naming `method.prices` at the **first peek**, not at creation, because creation deliberately does not build a tape — recorded in ADR §8.1 and the §11 error table.
- v1 and v2 agree on the volatility path **from step 1 on**, to a documented tolerance. Step 0 differs by construction: v1 never asks its estimator about step 0 and prices its first chain at the request's constant, while v2 serves step 0 as a snapshot.

No `pub` signature, DTO field, OpenAPI shape, stored-session field or dependency changed. IronCondor speaks only `/api/v1/chain`, which is untouched.

## Numbers

| | |
|---|---|
| max v1 ↔ v2 deviation | `3.4e-23` annualised (tolerance pinned at `1e-18`) |
| 10 000-step estimate, release | `3.33 s` |

Composing costs quadratic time where upstream's recurrence is linear, because that recurrence is not reachable from outside it. Only `Historical` pays it, once per tape build — and it was running inline on an actix worker, so the build moved to the blocking pool, where the export path already runs the identical call. It files its result from **inside** the blocking task: `spawn_blocking` cannot be cancelled but awaiting it can, and filing afterwards threw away a completed three-second build whenever a client disconnected.

## Tests

Eleven new, in `src/domain/factors.rs`:

- **no look-ahead** — for every cut of a series, the estimates over the prefix equal the first *k* of the estimates over the whole thing;
- **v1 parity** — drives `walk_steps_par`, the exact driver `generator_optionchain` uses, records the volatility it hands the chain builder, and compares it against the tape;
- backfill of points 0 and 1, the `< 3` guard, the zero-dispersion degenerate case;
- per-step variation and rebuild reproducibility on the tape;
- the four new refusals: short horizon, no dispersion, above `1.0`, and a zero price in the resolved series.

## Review

Audited before opening by `reproducibility-reviewer` and `architect`. Their findings — a non-causal fallback, a panic behind a false `# Errors` section, a zero volatility surfacing as a `500`, an uncancellable-but-discarded build, and five doc claims stronger than the code — are all addressed in the second commit rather than deferred.

## Checklist

- [x] Reproducibility intact, with a tape test — same parameters ⇒ identical rows, and the walk path itself is unchanged
- [x] Stored-session shape untouched; the v1 golden contract suite is green
- [x] DTO contract additive — text only, no schema change
- [x] Errors converge on `ChainError`; no upstream error type in any signature
- [x] utoipa descriptions updated on both the request and the response field
- [x] `make pre-push` clean — 711 + 16 + 3 tests, zero clippy/fmt/doc warnings
- [x] `README.md` regenerated via `make readme`

Also included, and called out because it is not this issue: a small commit fixing three broken intra-doc links that survived the v0.2.0 cleanup, so the gate is warning-free again.

Closes #63
