### PR TITLE
Upgrade optionstratlib 0.18 to 0.20 and positive 0.5 to 0.6 (#76)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ members = [
 
 [workspace.dependencies]
 optionchain_simulator = { path = "." }
-optionstratlib = "0.18"
-positive = "0.5"
+optionstratlib = "0.20"
+positive = "0.6"
 tracing = "0.1"
 rust_decimal = { version = "1.42", features = ["maths", "serde"] }
 rust_decimal_macros = "1.40"

--- a/examples/clickhouse/src/bin/clickhouse_optionchain.rs
+++ b/examples/clickhouse/src/bin/clickhouse_optionchain.rs
@@ -211,11 +211,9 @@ async fn run_simulation_steps(
 fn calculate_historical_volatility(
     prices: &[Positive],
 ) -> Result<Positive, Box<dyn std::error::Error>> {
-    let log_return = calculate_log_returns(prices).unwrap_or_default();
-    let log_return_dec = log_return
-        .iter()
-        .map(|r| r.to_dec())
-        .collect::<Vec<Decimal>>();
+    // `calculate_log_returns` returns the returns as `Decimal` since
+    // optionstratlib 0.20, so they feed `constant_volatility` directly.
+    let log_return_dec: Vec<Decimal> = calculate_log_returns(prices)?;
 
     let volatility = constant_volatility(&log_return_dec)?;
     let annualized_volatility = annualized_volatility(volatility, TimeFrame::Day)?.round_to(3);

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -538,18 +538,21 @@ fn historical_constant_volatility(
 ///
 /// # Why it composes rather than copies
 ///
-/// Upstream's estimator is private to its driver, but its three ingredients are
-/// public, and upstream's own comment records that its prefix-sum variance is
-/// *algebraically identical to the two-pass form in `constant_volatility`*. So
-/// the window below writes the indexing policy and the backfill and **no
-/// mathematics**: there is no second copy of an upstream kernel in this repo to
-/// drift out of sync, which is the property the module docs above claim.
+/// Upstream's three ingredients are public, and upstream's own comment records
+/// that its prefix-sum variance is *algebraically identical to the two-pass
+/// form in `constant_volatility`*. So the window below writes the indexing
+/// policy and the backfill and **no mathematics**: there is no second copy of
+/// an upstream kernel in this repo to drift out of sync, which is the property
+/// the module docs above claim.
 ///
 /// The cost of composing is quadratic time — `constant_volatility` reduces a
-/// whole slice and upstream's prefix-sum recurrence is not reachable from
-/// outside — where upstream is linear. It runs once per tape and only for
-/// `Historical`; the nine synthetic models never reach it. optionstratlib#423
-/// asks for the estimator to be exposed, which would make this a single call.
+/// whole slice, where upstream's prefix-sum recurrence is linear. It runs once
+/// per tape and only for `Historical`; the nine synthetic models never reach
+/// it. optionstratlib#423 asked for the estimator itself to be exposed, and
+/// 0.20 did expose it as `simulation::expanding_window_vols`, which would
+/// collapse this to a single call and erase the quadratic term. Making that
+/// swap is a change to the priced tape's provenance, so it belongs to its own
+/// issue with its own same-seed comparison, not to a dependency bump.
 ///
 /// # Indexing
 ///
@@ -637,9 +640,11 @@ fn expanding_window_volatilities(
 /// division is checked and an unrepresentable ratio is a rejection naming the
 /// field.
 ///
-/// The log itself is taken on the `Decimal`, which is what recovers the true
-/// sign: `Positive::ln` builds its result without revalidating, so a falling
-/// price would otherwise yield a negative value wearing a `Positive`.
+/// The log itself is taken on the `Decimal` rather than on the ratio's
+/// `Positive`. Since `positive` 0.6 `Positive::ln` returns a `Decimal` and so
+/// carries the sign correctly on its own, but taking it here keeps the checked
+/// division and the checked log in one expression, each with its own
+/// rejection.
 ///
 /// # Errors
 ///

--- a/src/domain/simulator.rs
+++ b/src/domain/simulator.rs
@@ -659,6 +659,76 @@ mod tests {
         tape
     }
 
+    /// A session whose dividend yield is non-zero, at a fixed seed, with its
+    /// greek columns pinned to literals.
+    ///
+    /// TAPE-BREAKING for the greek columns relative to any release pinned to
+    /// optionstratlib 0.18: upstream #426 made `d1` / `d2` carry the cost of
+    /// carry `b = r - q` rather than the bare risk-free rate, so `delta_call`,
+    /// `delta_put` and `gamma` moved for every session with a non-zero
+    /// `dividend_yield`. Bid, ask and mid are unaffected — the pricing kernels
+    /// already discounted the yield — and so are the seeded price path and any
+    /// session whose yield is zero.
+    ///
+    /// Every other reproducibility test in this crate compares two runs of the
+    /// SAME binary, which is exactly why none of them caught that shift. This
+    /// one holds the numbers themselves, so the next upstream bump has to
+    /// declare what it moved instead of moving it silently.
+    #[tokio::test]
+    async fn test_greek_columns_are_pinned_at_a_non_zero_dividend_yield() {
+        let mut session = create_test_session(Some(Uuid::new_v4()));
+        session.parameters.dividend_yield = pos_or_panic!(0.015);
+        session.parameters.risk_free_rate = dec!(0.04);
+        session.parameters.seed = Some(20260713);
+
+        let simulator = Simulator {
+            simulation_cache: Arc::new(Mutex::new(HashMap::new())),
+            database_repo: None,
+        };
+
+        let chain = match simulator.simulate_next_step(&mut session).await {
+            Ok(chain) => chain,
+            Err(error) => panic!("the first step must produce a chain: {error}"),
+        };
+        assert_eq!(chain.underlying_price, pos_or_panic!(100.0));
+
+        // The money, where the carry term bites hardest.
+        let atm = match chain
+            .iter()
+            .find(|contract| contract.strike_price == pos_or_panic!(100.0))
+        {
+            Some(contract) => contract,
+            None => panic!("the chain must carry the at-the-money strike"),
+        };
+        assert_eq!(atm.delta_call, Some(dec!(0.5250683903310066130344888912)));
+        assert_eq!(atm.delta_put, Some(dec!(-0.4736994926369290798684617156)));
+        assert_eq!(atm.gamma, Some(dec!(0.0693468762175267532729472986)));
+
+        // A wing, so the pin is not a single point on the curve.
+        let wing = match chain
+            .iter()
+            .find(|contract| contract.strike_price == pos_or_panic!(110.0))
+        {
+            Some(contract) => contract,
+            None => panic!("the chain must carry the 110 strike"),
+        };
+        assert_eq!(wing.delta_call, Some(dec!(0.0523243367419569481464854646)));
+        assert_eq!(wing.delta_put, Some(dec!(-0.9464435462259787447564651422)));
+        assert_eq!(wing.gamma, Some(dec!(0.0189194837294070818706825884)));
+
+        // The call and put deltas sum to `e^{-qT}`, not to 1: the dividend
+        // yield is genuinely in the numbers, which is what makes this a test
+        // of the carry term rather than of an arbitrary chain.
+        let parity = match (atm.delta_call, atm.delta_put) {
+            (Some(call), Some(put)) => call - put,
+            _ => panic!("the at-the-money strike must carry both deltas"),
+        };
+        assert!(
+            parity < Decimal::ONE,
+            "call - put must fall short of 1 by the dividend discount, got {parity}"
+        );
+    }
+
     #[tokio::test]
     async fn test_same_seed_produces_identical_tape() {
         // Complete-tape test: two sessions with identical parameters and the

--- a/src/domain/walker.rs
+++ b/src/domain/walker.rs
@@ -85,7 +85,15 @@ impl Walker {
 
         for _ in 1..steps {
             let dw = self.normal_sample() * sqrt_dt.to_dec();
-            let drift = (theta * mu.sub_or_zero(&x) * dt).to_dec();
+            // `mu - x` floored at zero. This mirrors upstream's
+            // `sub_floor_zero`, which 0.20 substituted for the deprecated
+            // `sub_or_zero` in `generate_ou_process`: same three branches, and
+            // identical on every input including `Decimal` overflow, where
+            // `sub_or_zero` panicked and both of these floor. Flooring is also
+            // the only option here, since `ou_process` returns a
+            // `Vec<Positive>` with no error channel.
+            let gap = mu.checked_sub_dec(x).unwrap_or(Positive::ZERO);
+            let drift = (theta * gap * dt).to_dec();
             let diffusion = volatility.to_dec() * dw;
             x += drift + diffusion;
             x = x.max(Decimal::ZERO);

--- a/src/infrastructure/clickhouse/utils.rs
+++ b/src/infrastructure/clickhouse/utils.rs
@@ -48,7 +48,16 @@ pub fn calculate_required_duration(timeframe: &TimeFrame, steps: usize) -> Durat
         TimeFrame::Month => Duration::days(steps as i64 * 30), // Approximation
         TimeFrame::Quarter => Duration::days(steps as i64 * 90), // Approximation
         TimeFrame::Year => Duration::days(steps as i64 * 365),
-        TimeFrame::Custom(p) => Duration::days(p.to_i64()),
+        // Upstream's `Custom` carries periods per year; this arm has always
+        // read it as a day count, and that reading is left as it stands. What
+        // changes is the failure mode: `Positive::to_i64` panicked above
+        // `i64::MAX` and is deprecated in `positive` 0.6, so a value that does
+        // not fit an `i64` — or a day count `chrono` cannot represent — now
+        // clamps to the widest representable duration.
+        TimeFrame::Custom(p) => p
+            .to_i64_checked()
+            .and_then(Duration::try_days)
+            .unwrap_or(Duration::MAX),
     }
 }
 
@@ -93,11 +102,77 @@ mod tests {
     use chrono::{Datelike, TimeZone, Utc};
     use mockall::predicate::*;
     use mockall::*;
+    use positive::pos_or_panic;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     mock! {
         pub Row<'a> {
             fn get<T: 'static>(&self, field_name: &str) -> Result<T, ChainError>;
         }
+    }
+
+    /// `TimeFrame::Custom` carries a value straight off the REST surface
+    /// (`ApiTimeFrame::Custom(f64)`), validated only as finite, strictly
+    /// positive and within `Decimal`. A value too large for an `i64` used to
+    /// abort the process inside the deprecated `Positive::to_i64`; it now
+    /// clamps to the widest duration `chrono` can hold.
+    #[test]
+    fn test_calculate_required_duration_custom_beyond_i64_clamps() {
+        let timeframe = TimeFrame::Custom(pos_or_panic!(1e20));
+
+        assert_eq!(calculate_required_duration(&timeframe, 1), Duration::MAX);
+    }
+
+    /// The second clamp leg: the day count fits an `i64` but not a
+    /// `chrono::Duration`, which tops out near 1.07e11 days. This one used to
+    /// panic one layer lower, inside `Duration::days`.
+    #[test]
+    fn test_calculate_required_duration_custom_beyond_chrono_clamps() {
+        let timeframe = TimeFrame::Custom(pos_or_panic!(5e11));
+
+        assert_eq!(calculate_required_duration(&timeframe, 1), Duration::MAX);
+    }
+
+    /// A custom timeframe small enough to represent is still read as a day
+    /// count, unchanged by the clamp.
+    #[test]
+    fn test_calculate_required_duration_custom_within_range_is_days() {
+        let timeframe = TimeFrame::Custom(pos_or_panic!(7.0));
+
+        assert_eq!(
+            calculate_required_duration(&timeframe, 1),
+            Duration::days(7)
+        );
+    }
+
+    /// The clamp routes into the error channel that already existed: no real
+    /// date range can cover `Duration::MAX`, so the request is rejected by
+    /// name instead of aborting the process.
+    #[test]
+    fn test_select_random_date_with_an_unrepresentable_custom_is_rejected() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let min_date = match Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).single() {
+            Some(date) => date,
+            None => panic!("the fixture date must resolve"),
+        };
+        let max_date = match Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).single() {
+            Some(date) => date,
+            None => panic!("the fixture date must resolve"),
+        };
+
+        let result = select_random_date(
+            &mut rng,
+            min_date,
+            max_date,
+            &TimeFrame::Custom(pos_or_panic!(1e20)),
+            1,
+        );
+
+        assert!(
+            matches!(result, Err(ChainError::NotEnoughData(_))),
+            "an unrepresentable custom timeframe must be rejected, got {result:?}"
+        );
     }
 
     #[test]

--- a/src/session/model.rs
+++ b/src/session/model.rs
@@ -745,18 +745,22 @@ mod tests_simulation_parameters_serialization {
         // Verify JSON contains all expected fields
         let value: Value = serde_json::from_str(&json).unwrap();
 
+        // Since `positive` 0.6 a `Positive` serialises as its exact decimal in
+        // a string, so every `Positive` field below is quoted; `Decimal` was
+        // already written that way. Trailing zeros do not survive the exact
+        // representation, which is why `45.0` is written `"45"`.
         assert_eq!(value["symbol"], "AAPL");
         assert_eq!(value["steps"], 30);
-        assert_eq!(value["initial_price"], 150.75);
-        assert_eq!(value["days_to_expiration"], 45.0);
-        assert_eq!(value["volatility"], 0.25);
+        assert_eq!(value["initial_price"], "150.75");
+        assert_eq!(value["days_to_expiration"], "45");
+        assert_eq!(value["volatility"], "0.25");
         assert_eq!(value["risk_free_rate"], "0.04");
-        assert_eq!(value["dividend_yield"], 0.015);
+        assert_eq!(value["dividend_yield"], "0.015");
         assert_eq!(value["time_frame"], "Day");
         assert_eq!(value["chain_size"], 15);
-        assert_eq!(value["strike_interval"], 5.0);
+        assert_eq!(value["strike_interval"], "5");
         assert_eq!(value["smile_curve"], "0.5");
-        assert_eq!(value["spread"], 0.02);
+        assert_eq!(value["spread"], "0.02");
 
         // Check the method field specifically
         assert!(value["method"].is_object());
@@ -766,9 +770,9 @@ mod tests_simulation_parameters_serialization {
                 .unwrap()
                 .contains_key("GeometricBrownian")
         );
-        assert_eq!(value["method"]["GeometricBrownian"]["dt"], 0.0027);
+        assert_eq!(value["method"]["GeometricBrownian"]["dt"], "0.0027");
         assert_eq!(value["method"]["GeometricBrownian"]["drift"], "0.05");
-        assert_eq!(value["method"]["GeometricBrownian"]["volatility"], 0.25);
+        assert_eq!(value["method"]["GeometricBrownian"]["volatility"], "0.25");
 
         // Deserialize back to verify round-trip
         let deserialized: SimulationParameters = from_str(&json).unwrap();
@@ -1080,6 +1084,147 @@ mod tests_simulation_parameters_serialization {
                 assert_eq!(jump_mean, dec!(-0.05));
             }
             _ => panic!("Wrong simulation method variant deserialized"),
+        }
+    }
+
+    /// The same wire change, on the largest stored payload there is.
+    ///
+    /// A `Historical` method carries `prices: Vec<Positive>` — hundreds of bare
+    /// JSON numbers in a document written before `positive` 0.6, and the one
+    /// variant this crate special-cases everywhere. The visitor is shared with
+    /// every scalar `Positive`, so a break here is unlikely; "unlikely" is
+    /// precisely what a stored-session test exists to remove.
+    #[test]
+    fn test_a_stored_historical_price_series_still_loads() {
+        const STORED_BY_AN_OLDER_BINARY: &str = concat!(
+            r#"{"id":"6ba7b812-9dad-11d1-80b4-00c04fd430c8","#,
+            r#""created_at":{"secs_since_epoch":1735689600,"nanos_since_epoch":0},"#,
+            r#""updated_at":{"secs_since_epoch":1735689660,"nanos_since_epoch":0},"#,
+            r#""parameters":{"symbol":"AAPL","steps":5,"initial_price":75,"#,
+            r#""days_to_expiration":30,"volatility":0.2,"risk_free_rate":"0.02","#,
+            r#""dividend_yield":0,"method":{"Historical":{"timeframe":"Day","#,
+            r#""prices":[75,76.2,74.8,77.5,78.1],"symbol":"AAPL"}},"#,
+            r#""time_frame":"Day","chain_size":10,"strike_interval":5,"#,
+            r#""skew_slope":"-0.2","smile_curve":"0.5","spread":0.01,"seed":7},"#,
+            r#""current_step":0,"total_steps":5,"state":"Initialized","version":0}"#,
+        );
+
+        let session: Session = match from_str(STORED_BY_AN_OLDER_BINARY) {
+            Ok(session) => session,
+            Err(error) => panic!("a stored historical series must load: {error}"),
+        };
+
+        match session.parameters.method {
+            SimulationMethod::Historical {
+                ref timeframe,
+                ref prices,
+                ..
+            } => {
+                assert_eq!(*timeframe, TimeFrame::Day);
+                assert_eq!(prices.len(), 5);
+                // Every element, at full decimal precision: a series that came
+                // back through an f64 detour would not compare equal here.
+                assert_eq!(prices[0], pos_or_panic!(75.0));
+                assert_eq!(prices[1], pos_or_panic!(76.2));
+                assert_eq!(prices[2], pos_or_panic!(74.8));
+                assert_eq!(prices[3], pos_or_panic!(77.5));
+                assert_eq!(prices[4], pos_or_panic!(78.1));
+            }
+            ref other => panic!("the stored method must survive the load, got {other:?}"),
+        }
+        assert_eq!(session.parameters.seed, Some(7));
+
+        // The rewritten series is the 0.6 string form, and reloads identically.
+        let rewritten = match to_string(&session) {
+            Ok(rewritten) => rewritten,
+            Err(error) => panic!("must re-serialize: {error}"),
+        };
+        assert!(
+            rewritten.contains(r#""prices":["75","76.2","74.8","77.5","78.1"]"#),
+            "a rewritten series must carry the 0.6 string form, got {rewritten}"
+        );
+        match from_str::<Session>(&rewritten) {
+            Ok(reloaded) => assert_eq!(reloaded.parameters.method, session.parameters.method),
+            Err(error) => panic!("the rewritten session must load: {error}"),
+        }
+    }
+
+    /// Stored-session compatibility across the `positive` 0.6 wire change.
+    ///
+    /// Up to `positive` 0.5 a `Positive` serialised as a JSON number; since 0.6
+    /// it serialises as its exact decimal in a string. Sessions written by an
+    /// earlier binary are still in Redis in the numeric form, and the upgrade
+    /// must not strand them: `SessionStore` reads them back through this very
+    /// `Deserialize`. The document below is the numeric form, value for value
+    /// as `positive` 0.5.1 emitted it — integers where the decimal has no
+    /// fractional digits, JSON floats otherwise, and `Decimal` fields quoted
+    /// because `rust_decimal` always wrote them that way.
+    #[test]
+    fn test_a_session_written_before_positive_0_6_still_loads() {
+        const STORED_BY_AN_OLDER_BINARY: &str = concat!(
+            r#"{"id":"6ba7b810-9dad-11d1-80b4-00c04fd430c8","#,
+            r#""created_at":{"secs_since_epoch":1735689600,"nanos_since_epoch":0},"#,
+            r#""updated_at":{"secs_since_epoch":1735689660,"nanos_since_epoch":0},"#,
+            r#""parameters":{"symbol":"AAPL","steps":30,"initial_price":150.75,"#,
+            r#""days_to_expiration":45,"volatility":0.25,"risk_free_rate":"0.04","#,
+            r#""dividend_yield":0.015,"method":{"GeometricBrownian":{"dt":0.0027,"#,
+            r#""drift":"0.05","volatility":0.25}},"time_frame":"Day","chain_size":15,"#,
+            r#""strike_interval":5,"skew_slope":"-0.2","smile_curve":"0.5","#,
+            r#""spread":0.02,"seed":42},"#,
+            r#""current_step":3,"total_steps":30,"state":"InProgress","version":4}"#,
+        );
+
+        let session: Session = match from_str(STORED_BY_AN_OLDER_BINARY) {
+            Ok(session) => session,
+            Err(error) => panic!("a session stored by an older binary must load: {error}"),
+        };
+
+        // Every `Positive` carries the value the old document held, at full
+        // decimal precision rather than through a lossy float detour.
+        assert_eq!(session.parameters.initial_price, pos_or_panic!(150.75));
+        assert_eq!(session.parameters.days_to_expiration, pos_or_panic!(45.0));
+        assert_eq!(session.parameters.volatility, pos_or_panic!(0.25));
+        assert_eq!(session.parameters.dividend_yield, pos_or_panic!(0.015));
+        assert_eq!(session.parameters.strike_interval, Some(pos_or_panic!(5.0)));
+        assert_eq!(session.parameters.spread, Some(pos_or_panic!(0.02)));
+        assert_eq!(session.parameters.risk_free_rate, dec!(0.04));
+        match session.parameters.method {
+            SimulationMethod::GeometricBrownian {
+                dt,
+                drift,
+                volatility,
+            } => {
+                assert_eq!(dt, pos_or_panic!(0.0027));
+                assert_eq!(drift, dec!(0.05));
+                assert_eq!(volatility, pos_or_panic!(0.25));
+            }
+            ref other => panic!("the stored method must survive the load, got {other:?}"),
+        }
+
+        // The session's own state is untouched by the wire change, and the seed
+        // — the reproducibility contract — comes back intact.
+        assert_eq!(session.parameters.seed, Some(42));
+        assert_eq!(session.current_step, 3);
+        assert_eq!(session.total_steps, 30);
+        assert_eq!(session.state, SessionState::InProgress);
+        assert_eq!(session.version, 4);
+
+        // Rewriting it stores the 0.6 shape, which the same reader accepts:
+        // the store converges on one form without a migration step.
+        let rewritten = match to_string(&session) {
+            Ok(rewritten) => rewritten,
+            Err(error) => panic!("must re-serialize: {error}"),
+        };
+        assert!(
+            rewritten.contains(r#""initial_price":"150.75""#),
+            "a rewritten session must carry the 0.6 string form, got {rewritten}"
+        );
+        match from_str::<Session>(&rewritten) {
+            Ok(reloaded) => assert_eq!(
+                reloaded.parameters.initial_price,
+                session.parameters.initial_price
+            ),
+            Err(error) => panic!("the rewritten session must load: {error}"),
         }
     }
 }

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -893,6 +893,7 @@ mod tests {
     use crate::domain::expiry::{ExpiryRule, ExpiryRuleKind, MAX_TARGET_COUNT};
     use chrono::{TimeZone, Weekday};
     use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
 
     /// The reference configuration from ADR 0001 §14.1, as a request.
     /// Two rules at the per-rule cap: the most expirations a schedule can keep
@@ -1419,33 +1420,34 @@ mod tests {
             // `Positive` admits zero, so these three survive the type and have
             // to be rejected by the validator: a zero price or volatility is a
             // chain of worthless options, and a zero interval collapses every
-            // strike onto one.
+            // strike onto one. Every `Positive` is quoted since `positive` 0.6
+            // writes the exact decimal as a string.
             (
-                r#""initial_price":5000"#,
-                r#""initial_price":0"#,
+                r#""initial_price":"5000""#,
+                r#""initial_price":"0""#,
                 "initial_price",
             ),
             (
-                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.18"#,
-                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0"#,
+                r#""tzdb_version":"2025b","initial_price":"5000","volatility":"0.18""#,
+                r#""tzdb_version":"2025b","initial_price":"5000","volatility":"0""#,
                 "volatility",
             ),
             (
-                r#""strike_interval":25"#,
-                r#""strike_interval":0"#,
+                r#""strike_interval":"25""#,
+                r#""strike_interval":"0""#,
                 "strike_interval",
             ),
             // The walk's own invariants are not re-derived here: the stored
             // method round-trips through the same mirror the request path
             // validates with, so a `dt` of zero is caught by that check.
-            (r#""dt":0.004"#, r#""dt":0.0"#, "dt"),
+            (r#""dt":"0.004""#, r#""dt":"0.0""#, "dt"),
             // A simulation has exactly one base volatility, and the check that
             // enforces it has to hold on the stored path too — otherwise a
             // document can carry a top-level value the walk never uses. The
             // anchor is needed because "volatility":0.18 appears twice.
             (
-                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.18"#,
-                r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.25"#,
+                r#""tzdb_version":"2025b","initial_price":"5000","volatility":"0.18""#,
+                r#""tzdb_version":"2025b","initial_price":"5000","volatility":"0.25""#,
                 "volatility",
             ),
         ];
@@ -1730,6 +1732,150 @@ mod tests {
         match simulation.simulated_at() {
             Ok(at) => assert_eq!(at, instant(2026, 1, 7, 14, 30)),
             Err(error) => panic!("must resolve: {error}"),
+        }
+    }
+
+    /// The same wire change on v2's largest stored payload: a `Historical`
+    /// method's `prices: Vec<Positive>`, written as bare JSON numbers.
+    ///
+    /// `Historical` carries no model volatility, so it is also the variant
+    /// that skips the "one base volatility" cross-check — the load has to
+    /// succeed for a different reason than the synthetic models do.
+    #[test]
+    fn test_a_stored_historical_price_series_still_loads() {
+        const STORED_BY_AN_OLDER_BINARY: &str = concat!(
+            r#"{"id":"6ba7b813-9dad-11d1-80b4-00c04fd430c8","schema_version":1,"#,
+            r#""created_at":{"secs_since_epoch":1735689600,"nanos_since_epoch":0},"#,
+            r#""updated_at":{"secs_since_epoch":1735689660,"nanos_since_epoch":0},"#,
+            r#""parameters":{"symbol":"SPX","steps":4,"#,
+            r#""effective_start":"2026-01-05T14:30:00Z","step_interval_seconds":86400,"#,
+            r#""time_frame":"Day","schedule":{"calendar":"weekdays_v1","#,
+            r#""timezone":"America/New_York","expiration_time":"17:00:00","rules":["#,
+            r#"{"rule_id":"zero_dte","kind":"daily","target_count":1}]},"#,
+            r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.18,"#,
+            r#""risk_free_rate":"0.04","dividend_yield":0.012,"#,
+            r#""method":{"Historical":{"timeframe":"Day","#,
+            r#""prices":[5000,5012.5,4987.25,5030],"symbol":"SPX"}},"#,
+            r#""chain_size":15,"strike_interval":25,"skew_slope":"-0.2","#,
+            r#""smile_curve":"0.4","spread":0.02,"seed":42},"#,
+            r#""current_step":0,"total_steps":4,"state":"Initialized","version":0}"#,
+        );
+
+        let simulation: SessionV2 = match serde_json::from_str(STORED_BY_AN_OLDER_BINARY) {
+            Ok(simulation) => simulation,
+            Err(error) => panic!("a stored historical series must load: {error}"),
+        };
+
+        match simulation.parameters.method {
+            SimulationMethod::Historical {
+                ref timeframe,
+                ref prices,
+                ..
+            } => {
+                assert_eq!(*timeframe, TimeFrame::Day);
+                assert_eq!(prices.len(), 4);
+                assert_eq!(prices[0], pos_or_panic!(5000.0));
+                assert_eq!(prices[1], pos_or_panic!(5012.5));
+                assert_eq!(prices[2], pos_or_panic!(4987.25));
+                assert_eq!(prices[3], pos_or_panic!(5030.0));
+            }
+            ref other => panic!("the stored method must survive the load, got {other:?}"),
+        }
+        assert_eq!(simulation.parameters.seed, 42);
+
+        let rewritten = match serde_json::to_string(&simulation) {
+            Ok(rewritten) => rewritten,
+            Err(error) => panic!("must re-serialize: {error}"),
+        };
+        assert!(
+            rewritten.contains(r#""prices":["5000","5012.5","4987.25","5030"]"#),
+            "a rewritten series must carry the 0.6 string form, got {rewritten}"
+        );
+        match serde_json::from_str::<SessionV2>(&rewritten) {
+            Ok(reloaded) => assert_eq!(reloaded.parameters.method, simulation.parameters.method),
+            Err(error) => panic!("the rewritten simulation must load: {error}"),
+        }
+    }
+
+    /// Stored-simulation compatibility across the `positive` 0.6 wire change.
+    ///
+    /// Up to `positive` 0.5 a `Positive` serialised as a JSON number; since 0.6
+    /// it serialises as its exact decimal in a string. Simulations written by
+    /// an earlier binary sit in Redis in the numeric form and must keep
+    /// loading, validation and all — the v2 store reads them back through this
+    /// same `Deserialize`. The document below is that numeric form, value for
+    /// value as `positive` 0.5.1 emitted it.
+    #[test]
+    fn test_a_simulation_written_before_positive_0_6_still_loads() {
+        const STORED_BY_AN_OLDER_BINARY: &str = concat!(
+            r#"{"id":"6ba7b811-9dad-11d1-80b4-00c04fd430c8","schema_version":1,"#,
+            r#""created_at":{"secs_since_epoch":1735689600,"nanos_since_epoch":0},"#,
+            r#""updated_at":{"secs_since_epoch":1735689660,"nanos_since_epoch":0},"#,
+            r#""parameters":{"symbol":"SPX","steps":500,"#,
+            r#""effective_start":"2026-01-05T14:30:00Z","step_interval_seconds":86400,"#,
+            r#""time_frame":"Day","schedule":{"calendar":"weekdays_v1","#,
+            r#""timezone":"America/New_York","expiration_time":"17:00:00","rules":["#,
+            r#"{"rule_id":"monthlies","kind":"monthly","target_count":12,"weekday":"Fri"},"#,
+            r#"{"rule_id":"weeklies","kind":"weekly","target_count":3,"#,
+            r#""weekdays":["Mon","Wed","Fri"]},"#,
+            r#"{"rule_id":"zero_dte","kind":"daily","target_count":1}]},"#,
+            r#""tzdb_version":"2025b","initial_price":5000,"volatility":0.18,"#,
+            r#""risk_free_rate":"0.04","dividend_yield":0.012,"#,
+            r#""method":{"GeometricBrownian":{"dt":0.004,"drift":"0.05","volatility":0.18}},"#,
+            r#""chain_size":15,"strike_interval":25,"skew_slope":"-0.2","#,
+            r#""smile_curve":"0.4","spread":0.02,"seed":42},"#,
+            r#""current_step":7,"total_steps":500,"state":"InProgress","version":9}"#,
+        );
+
+        let simulation: SessionV2 = match serde_json::from_str(STORED_BY_AN_OLDER_BINARY) {
+            Ok(simulation) => simulation,
+            Err(error) => panic!("a simulation stored by an older binary must load: {error}"),
+        };
+
+        assert_eq!(simulation.parameters.initial_price, pos_or_panic!(5000.0));
+        assert_eq!(simulation.parameters.volatility, pos_or_panic!(0.18));
+        assert_eq!(simulation.parameters.dividend_yield, pos_or_panic!(0.012));
+        assert_eq!(
+            simulation.parameters.strike_interval,
+            Some(pos_or_panic!(25.0))
+        );
+        assert_eq!(simulation.parameters.spread, Some(pos_or_panic!(0.02)));
+        match simulation.parameters.method {
+            SimulationMethod::GeometricBrownian {
+                dt,
+                drift,
+                volatility,
+            } => {
+                assert_eq!(dt, pos_or_panic!(0.004));
+                assert_eq!(drift, dec!(0.05));
+                assert_eq!(volatility, pos_or_panic!(0.18));
+            }
+            ref other => panic!("the stored method must survive the load, got {other:?}"),
+        }
+
+        // The seed is the reproducibility contract; a stored simulation that
+        // came back with a different one would serve a different tape.
+        assert_eq!(simulation.parameters.seed, 42);
+        assert_eq!(simulation.current_step, 7);
+        assert_eq!(simulation.state, SessionState::InProgress);
+        assert_eq!(simulation.version, 9);
+
+        // Rewriting it stores the 0.6 shape, which the same reader accepts, so
+        // the store converges on one form with no migration step.
+        let rewritten = match serde_json::to_string(&simulation) {
+            Ok(rewritten) => rewritten,
+            Err(error) => panic!("must re-serialize: {error}"),
+        };
+        assert!(
+            rewritten.contains(r#""initial_price":"5000""#),
+            "a rewritten simulation must carry the 0.6 string form, got {rewritten}"
+        );
+        match serde_json::from_str::<SessionV2>(&rewritten) {
+            Ok(reloaded) => assert_eq!(
+                reloaded.parameters.initial_price,
+                simulation.parameters.initial_price
+            ),
+            Err(error) => panic!("the rewritten simulation must load: {error}"),
         }
     }
 }

--- a/tests/v1_contract.rs
+++ b/tests/v1_contract.rs
@@ -44,8 +44,11 @@ const V1_CREATE_REQUEST: &str = r#"{
   "spread": 0.02
 }"#;
 
-/// A stored v1 `SimulationParameters` document, in the shape the current
-/// binary writes it.
+/// A stored v1 `SimulationParameters` document, in the numeric shape binaries
+/// built against `positive` 0.5 wrote it. Since `positive` 0.6 a `Positive`
+/// serialises as a decimal string, so this fixture is now a second
+/// stored-compatibility case: the contract below asserts the key set, and the
+/// document still has to load.
 const V1_STORED_PARAMETERS: &str = r#"{
   "symbol": "AAPL",
   "steps": 20,


### PR DESCRIPTION
## What

Moves the workspace pins to `optionstratlib = "0.20"` and `positive = "0.6"`,
crossing the deliberately breaking 0.19.0 release that bumped `positive` 0.5 to
0.6, `expiration_date` 0.2 to 0.3 and `option_type` 0.1 to 0.3.

Neither `expiration_date` nor `option_type` becomes a direct dependency: every
type this crate names is re-exported by `optionstratlib` (`ExpirationDate` is
the only one it reaches for), so `[workspace.dependencies]` gains nothing.

Closes #76.

## Why it is more than a pin bump

0.20.0 carries `OptionData::greeks_call` / `greeks_put` — the twelve-greek
snapshots #73 needs — and four upstream correctness fixes, one of which changes
values this service already serves.

Reviewed before opening by `architect` (layering, dependency policy, semver)
and `reproducibility-reviewer` (walk path, seed plumbing, stored shape); their
findings are folded in below.

## Code changes: three call sites

| File | Change |
|---|---|
| `src/domain/walker.rs` | `Positive::sub_or_zero` is deprecated in `positive` 0.6. The Ornstein-Uhlenbeck drift now floors the mean gap with `checked_sub_dec(...).unwrap_or(Positive::ZERO)` |
| `src/infrastructure/clickhouse/utils.rs` | `Positive::to_i64` is deprecated because it panics above `i64::MAX`; the custom-timeframe arm clamps through `to_i64_checked` and `Duration::try_days`. This closes two reachable request-path panics — `ApiTimeFrame::Custom(f64)` only has to be finite and positive to be accepted — and routes into the `ChainError::NotEnoughData` the caller already raises. Four new tests cover both clamp legs, the unclamped path and the rejection |
| `examples/clickhouse` | `calculate_log_returns` returns `Vec<Decimal>` upstream now, so the `to_dec` mapping is redundant |

The walker replacement is what upstream itself substituted: 0.20's
`generate_ou_process` calls `sub_floor_zero`, the same three branches, identical
on every input **including** the `Decimal` overflow where `sub_or_zero` panicked
and both of these floor. **The seeded tape is unchanged**, and the RNG draw
order is untouched.

## The mirrored kernels need no re-sync

`optionstratlib/src/simulation/traits.rs` — the `WalkTypeAble` kernels
`src/domain/walker.rs` mirrors — is byte-identical between `v0.18.0` and
`v0.20.0`. The walk driver's only change is that same `calculate_log_returns`
return type plus documentation and a newly-public `expanding_window_vols`.
`ApiWalkType` still matches `WalkType` exhaustively; no variant was added.

Two doc blocks in `src/domain/factors.rs` that this upgrade made false are
corrected: upstream's expanding-window estimator is public as of 0.20, and
`Positive::ln` now returns a `Decimal` rather than wrapping a possibly-negative
result in a `Positive`.

## The wire change

`positive` 0.6 serialises a `Positive` as its exact decimal in a **string**
(`"5000"`) instead of a JSON number (`5000`). Upstream states deserialisation
still accepts the numeric form; this PR proves it here rather than trusting it.

Four new tests load documents in the pre-upgrade shape — value for value as
`positive` 0.5.1 emitted it, verified against the 0.5.1 serialiser itself
(integers where the decimal has no fractional digits, JSON floats otherwise,
`Decimal` fields already quoted) — and assert every field comes back intact,
including the seed:

- `test_a_session_written_before_positive_0_6_still_loads` (v1 `Session`)
- `test_a_simulation_written_before_positive_0_6_still_loads` (v2 `SessionV2`)
- `test_a_stored_historical_price_series_still_loads`, one per version — a
  `Historical` method's `prices: Vec<Positive>` is the largest old-shape
  payload in Redis, and the variant that skips the base-volatility cross-check

All four also assert that rewriting the document stores the 0.6 shape and that
the same reader accepts it, so the Redis store converges on one form with no
migration step. Verified against live Redis too: the 18 `#[ignore]`d
live-service tests pass against Redis 7, ClickHouse 26.3 and MongoDB 7.

### The cut is one-way

`positive` 0.5.1's deserializer hard-errors on **any** string, so a session
written after this deploys cannot be read by 0.2.0: `in_redis.rs` turns that
into a `ChainError::Internal` and an HTTP 500 for that session id. Rolling back
the binary therefore means flushing the session keyspace, or accepting that
sessions created in the meantime are unreadable. Worth deciding before the
deploy, not during it.

### Everywhere else a `Positive` could reach a serialised document

| Surface | Verdict |
|---|---|
| v2 ClickHouse quote / metadata rows | Unaffected — decimals are scaled into `i128` (`snapshots/model.rs`) |
| OHLCV `Row` | Unaffected — reads `f32` |
| MongoDB event documents | Unaffected — carry no `Positive` |
| REST DTOs | Unaffected — this crate's own `f64` types, so the HTTP surface is byte-identical |

Two tests that assert on serialised text were re-baselined for the string form:
the v1 parameters serialisation test and the v2 stored-document tamper table.

## Served values that changed

Measured by building the same chain with 0.18.0 and 0.20.0 side by side (SPX,
5000 spot, 30 days, 18% volatility, 4% rate, 11 strikes at 25 wide):

- **`dividend_yield = 0`** — every served value is identical: implied
  volatility, bid, ask, mid, `delta_call`, `delta_put`, `gamma`.
- **`dividend_yield > 0`** — prices are identical; `delta_call`, `delta_put`
  and `gamma` move.

The cause is upstream #426: `d1` / `d2` now carry the cost of carry
`b = r - q` instead of `r`, so the analytic greeks stop diverging from the
discounted terms whenever the yield is non-zero. At a 1.2% yield:

| Strike | delta_call 0.18 | delta_call 0.20 | gamma 0.18 | gamma 0.20 |
|---|---|---|---|---|
| 4875 | 0.7174333049 | 0.7109844485 | 0.0013005999 | 0.0013147162 |
| 5000 | 0.5351341609 | 0.5275412219 | 0.0015384563 | 0.0015408091 |
| 5125 | 0.3475318371 | 0.3404689321 | 0.0014376727 | 0.0014266538 |

**No golden or tape test needed re-baselining**, because none existed to
re-baseline: every reproducibility test compares two runs of the *same* binary,
and no fixture held an absolute greek — which is exactly why the suite stayed
green through a real value shift. `test_greek_columns_are_pinned_at_a_non_zero_dividend_yield`
(`src/domain/simulator.rs`) now pins them at a fixed seed, on the money and on a
wing, and asserts that call minus put deltas fall short of 1 by the dividend
discount, so the carry term is genuinely in the numbers. The next upstream bump
has to declare what it moved instead of moving it silently.

Upstream #429 (`vomma` / `veta` applying quantity twice), #435 and #437 (the
`Side` sign in every greek, not only `delta`) move nothing served today — only
per-one-long-contract `delta` and `gamma` are on the wire. They matter for #73,
which puts the full set there.

## The next release is 0.3.0, not 0.2.1

`positive` is a public dependency: `SimulationParameters.initial_price`,
`SimulationParametersV2` and the re-exported `OHLCVData` all expose `Positive`
in their public signatures. Under cargo's 0.x rules `positive` 0.5 → 0.6 is a
major bump, so a downstream pinned to `positive = "0.5"` no longer type-checks
against this crate; the serde shape of those `pub` types changed too. The
version stays at 0.2.0 in this PR — bumping it here would fire
`docker-publish.yml`, which triggers on the `[package] version` diff, before CI
has run on the release commit. The bump belongs to its own commit at release
time, exactly as a7d8d80 did.

## Known, pre-existing, and out of scope

- `make check-spanish` cannot run: the Makefile calls `scripts/spanish.py`,
  which does not exist. A mandatory pre-submission item that has been
  unexecutable for some time; worth its own issue.
- `TimeFrame::Custom` carries *periods per year* upstream, while
  `calculate_required_duration` has always read it as a day count. The new
  comment records the mismatch; fixing the reading is a behaviour change and
  belongs to its own issue.
- optionstratlib 0.20 exposes `expanding_window_vols`, which
  `src/domain/factors.rs` could collapse into a single call, erasing its
  quadratic term. The stale docs claiming it is private are corrected here;
  adopting it changes the priced tape's provenance and needs its own same-seed
  comparison.

## Consumer coordination

IronCondor pins `optionstratlib` 0.18 and consumes this service's REST DTOs.
The DTOs are this crate's own types, so this bump does not force one there. Flag
it anyway when this merges: the greek values it materialises from a simulator
tape change whenever the simulation carries a non-zero dividend yield.

## Checks

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `LOGLEVEL=WARN cargo test --workspace` clean — 728 lib tests, 16 contract
  tests, 3 doctests, 0 failures
- `cargo test --workspace -- --ignored` clean — 18 live-service tests against
  Redis, ClickHouse and MongoDB containers
- `cargo build --release` clean, zero warnings
- `make readme` produced no diff: the upgrade changes no documented surface

## Stack

- **Base branch: `main`** — this is the bottom of the stack.
- **Stack: #76 → #73 → #74 → #75.** This one is #76.
- Nothing below it; the diff reads against `main` directly.
