### PR TITLE
Emit the full greek set in the v1 and v2 chain responses (#73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ OCS_MAX_CHAIN_SIZE=500
 # Range: >= 1.  Default: 100000
 OCS_MAX_HISTORICAL_PRICES=100000
 
+# How many `?greeks=first|all` requests may price and serialise at once, across
+# v1 and v2 together. One job is up to OCS_MAX_SNAPSHOT_CONTRACTS contracts of
+# pricing plus the encoding of the result, so this is the bound that stops a
+# burst of greek requests from taking every core and starving the requests that
+# never asked for them. Requests above the bound WAIT rather than fail, and they
+# wait in async code, so a client that disconnects while queued costs nothing.
+# `greeks=none` never takes a permit.
+# Range: >= 1.  Default: 4
+OCS_MAX_CONCURRENT_GREEK_RENDERS=4
+
 
 # ---------------------------------------------------------------------------
 # v1 domain cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,8 +73,12 @@ actix-web = { version = "4.14", features = ["rustls"] }
 actix-files = "0.6"
 redis = { version = "1.3", features = ["tokio-comp", "connection-manager"] }
 # actix_extras is unavailable: optionstratlib enables utoipa/axum_extras,
-# and utoipa's framework extras are mutually exclusive
-utoipa = "5.5"
+# and utoipa's framework extras are mutually exclusive.
+# `decimal` is declared here rather than inherited: the greek DTOs derive
+# `ToSchema` over `rust_decimal::Decimal` (issue #73), so the schema for
+# `Decimal` is now a first-party requirement, not a side effect of what
+# optionstratlib happens to enable.
+utoipa = { version = "5.5", features = ["decimal"] }
 utoipa-swagger-ui = { version = "9.0", features = ["actix-web"] }
 rand = "0.10"
 rand_distr = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,12 +73,8 @@ actix-web = { version = "4.14", features = ["rustls"] }
 actix-files = "0.6"
 redis = { version = "1.3", features = ["tokio-comp", "connection-manager"] }
 # actix_extras is unavailable: optionstratlib enables utoipa/axum_extras,
-# and utoipa's framework extras are mutually exclusive.
-# `decimal` is declared here rather than inherited: the greek DTOs derive
-# `ToSchema` over `rust_decimal::Decimal` (issue #73), so the schema for
-# `Decimal` is now a first-party requirement, not a side effect of what
-# optionstratlib happens to enable.
-utoipa = { version = "5.5", features = ["decimal"] }
+# and utoipa's framework extras are mutually exclusive
+utoipa = "5.5"
 utoipa-swagger-ui = { version = "9.0", features = ["actix-web"] }
 rand = "0.10"
 rand_distr = "0.6"

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ Every environment variable the service reads is documented in
 deliberately different failure behaviour:
 
 - **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
-  `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CACHED_WALKS` — warn and fall back
+  `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CONCURRENT_GREEK_RENDERS`,
+  `OCS_MAX_CACHED_WALKS` — warn and fall back
   to their defaults when set to something invalid. A bad value there
   degrades one request.
 - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
@@ -661,27 +662,28 @@ strike:
     "mid": 0.67164031192058,
     "delta": 0.21342098496717668,
     "greeks": {
-        "delta": "0.2134209849671766791739391948",
-        "gamma": "0.0511531622872449408680866469",
-        "theta": "-0.0289390751520225679360302935",
-        "vega": "0.083366946728269604768867711",
-        "rho": "0.0169894176861345909734753825",
-        "rho_d": "-0.0175414508192199992738499204",
-        "alpha": "-1.7676156552525424476306277983",
-        "vanna": "1.2473442995808183501801769442",
-        "vomma": "0.2838300607436393803867085535",
-        "veta": "0.0000348161009099551782779877",
-        "charm": "-0.0044637844401925672319270818",
-        "color": "-0.0002301924225239124326433752"
+        "delta": 0.21342098496717668,
+        "gamma": 0.051153162287244945,
+        "theta": -0.028939075152022566,
+        "vega": 0.0833669467282696,
+        "rho": 0.016989417686134593,
+        "rho_d": -0.01754145081922,
+        "alpha": -1.7676156552525426,
+        "vanna": 1.2473442995808184,
+        "vomma": 0.28383006074363937,
+        "veta": 0.00003481610090995518,
+        "charm": -0.0044637844401925674,
+        "color": -0.00023019242252391244
     }
 }
 ```
 
-The put of the same strike carries `"rho": "-0.069028687541464627650228228"`
-and `"charm": "-0.0045048296956570029453340524"`: the sign flips on `rho`
-and the value differs on `charm`, so the two sides are genuinely computed
-rather than one copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and
-`color` are style-independent and do agree.
+The put of the same strike carries `"rho": -0.06902868754146463` and
+`"charm": -0.004504829695657003`: the sign flips on `rho` and the value
+differs on `charm`, so the two sides are genuinely computed rather than one
+copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and `color` are
+style-independent and do agree. `alpha` differs too — it is a ratio, and the
+two sides have different thetas.
 
 Three things a client has to know about those numbers:
 
@@ -689,9 +691,10 @@ Three things a client has to know about those numbers:
   sign and size, exactly once. Upstream builds the snapshot as a long
   position and applies the side sign inside every greek, so a consumer that
   applies it again double-counts.
-- **They are decimals, so they arrive as JSON strings**, not numbers. That
-  is deliberate: they are the values upstream computed, not a lossy `f64`
-  view of them. Everything else on the wire stays `f64`.
+- **They are `f64`, like every other number on this surface.** The DTOs are
+  this crate's own twelve- and four-field types, converted from upstream's
+  `Decimal` exactly once at the boundary, so upstream's serialisation never
+  becomes part of this service's contract by accident.
 - **`null` means not meaningful for these inputs**, never zero. Only `rho`,
   `rho_d` and `alpha` can be null. Distinct from that: a strike whose option
   cannot be built carries **no `greeks` key at all**, which on the wire looks

--- a/README.md
+++ b/README.md
@@ -629,6 +629,80 @@ parameter and returns the same body shown below.
 }
 ```
 
+##### The `greeks` query parameter
+
+Both chain-serving endpoints on each version — `GET /api/v1/chain`,
+`POST /api/v1/chain/step`, `GET /api/v2/simulations/{id}/snapshot` and
+`POST /api/v2/simulations/{id}/step` — accept an optional `greeks` level.
+It is opt-in, and its default is the response shown above: the full set is
+twelve values per option style, and a chain can be a thousand strikes wide
+across many expirations, so a play-loop client that does not need them must
+not be made to download them.
+
+| `greeks` | The `greeks` key on each quoted side |
+|----------|--------------------------------------|
+| absent, or `none` | Not present at all. `implied_volatility`, `gamma` and the per-side `delta` as before |
+| `first` | `theta`, `vega`, `rho`, `rho_d` |
+| `all` | The full twelve-value snapshot: `delta`, `gamma`, `theta`, `vega`, `rho`, `rho_d`, `alpha`, `vanna`, `vomma`, `veta`, `charm`, `color` |
+
+Any other value is a `400` naming `greeks`, never a silent fall back to the
+default: a client that asked for `all` and quietly received nothing would
+price a position against greeks it never got.
+
+One quoted side at `greeks=all`: the 105 strike of a chain built on a 100
+underlying, 30 days to expiration, a 4% rate and a 1.5% dividend yield, with
+a base volatility of 20% that the skew and smile shape to 0.1983 at this
+strike:
+
+```json
+"call": {
+    "bid": 0.66,
+    "ask": 0.68,
+    "mid": 0.67164031192058,
+    "delta": 0.21342098496717668,
+    "greeks": {
+        "delta": "0.2134209849671766791739391948",
+        "gamma": "0.0511531622872449408680866469",
+        "theta": "-0.0289390751520225679360302935",
+        "vega": "0.083366946728269604768867711",
+        "rho": "0.0169894176861345909734753825",
+        "rho_d": "-0.0175414508192199992738499204",
+        "alpha": "-1.7676156552525424476306277983",
+        "vanna": "1.2473442995808183501801769442",
+        "vomma": "0.2838300607436393803867085535",
+        "veta": "0.0000348161009099551782779877",
+        "charm": "-0.0044637844401925672319270818",
+        "color": "-0.0002301924225239124326433752"
+    }
+}
+```
+
+The put of the same strike carries `"rho": "-0.069028687541464627650228228"`
+and `"charm": "-0.0045048296956570029453340524"`: the sign flips on `rho`
+and the value differs on `charm`, so the two sides are genuinely computed
+rather than one copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and
+`color` are style-independent and do agree.
+
+Three things a client has to know about those numbers:
+
+- **Every value is per ONE LONG CONTRACT.** The client applies position
+  sign and size, exactly once. Upstream builds the snapshot as a long
+  position and applies the side sign inside every greek, so a consumer that
+  applies it again double-counts.
+- **They are decimals, so they arrive as JSON strings**, not numbers. That
+  is deliberate: they are the values upstream computed, not a lossy `f64`
+  view of them. Everything else on the wire stays `f64`.
+- **`null` means not meaningful for these inputs**, never zero. Only `rho`,
+  `rho_d` and `alpha` can be null. Distinct from that: a strike whose option
+  cannot be built carries **no `greeks` key at all**, which on the wire looks
+  like the default level. Its `implied_volatility`, `gamma` and `delta` are
+  still there — they are defined where the full set is not.
+
+`delta` and `gamma` keep their existing places on the quote and the
+contract. They are computed independently of the snapshot and stay defined
+at expiry and at zero volatility, where the full set is not, so the default
+response is unchanged at every strike — degenerate ones included.
+
 #### 3. Update Session Parameters (PATCH /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
 
 **Request Body:**

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -419,6 +419,9 @@ The example below is cursor `1` of the reference configuration in §14
           "gamma": 0.0031,
           "call": { "bid": 21.4,  "ask": 22.1,  "mid": 21.75, "delta":  0.55 },
           "put":  { "bid":  9.05, "ask":  9.55, "mid":  9.30, "delta": -0.45 }
+          // Each side additionally carries an optional `greeks` object when the
+          // `greeks` query parameter is `first` or `all` (issue #73). Absent at
+          // the default level, which is the shape shown here.
         }
       ]
     }
@@ -439,7 +442,12 @@ Invariants a reviewer can check:
   `base_volatility` by the configured skew and smile — the base is the input to
   the ladder, not a copy of it.
 - All numeric fields are `f64` **at the REST boundary only**; the domain works
-  in `Positive`/`Decimal`.
+  in `Positive`/`Decimal`. The one documented exception is the optional `greeks`
+  object each quoted side carries when the `greeks` query parameter asks for it
+  (issue #73): its values are upstream `Decimal`s carried verbatim, so they
+  render as JSON strings rather than numbers. Nothing shown above changes — the
+  key is absent at the default level, which is what every existing client
+  receives.
 - `expires_at` is the **only** expiration a client sees. Upstream's
   `OptionChain` also carries a `YYYY-MM-DD` string that it stamps from the host
   clock — `get_date_string()` reads `Utc::now()` for a relative expiration and

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,5 +8,5 @@ pub use rest::requests_v2::CreateSimulationRequest;
 // The greek payload the response DTOs carry. Re-exported beside them: a
 // consumer that can see `OptionPriceResponse.greeks` must be able to name its
 // type to match on it or build one.
-pub use rest::greeks::{FirstOrderGreeks, GreeksResponse};
+pub use rest::greeks::{FirstOrderGreeks, FullGreeks, GreeksResponse};
 pub use rest::responses::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,4 +5,8 @@ pub use rest::models::ListenOn;
 pub use rest::patch::Patch;
 pub use rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 pub use rest::requests_v2::CreateSimulationRequest;
+// The greek payload the response DTOs carry. Re-exported beside them: a
+// consumer that can see `OptionPriceResponse.greeks` must be able to name its
+// type to match on it or build one.
+pub use rest::greeks::{FirstOrderGreeks, GreeksResponse};
 pub use rest::responses::*;

--- a/src/api/rest/greeks.rs
+++ b/src/api/rest/greeks.rs
@@ -1,0 +1,415 @@
+//! The `greeks` query parameter and the payload it selects.
+//!
+//! A chain response carries implied volatility, gamma and per-side delta by
+//! default and nothing else. The full set is twelve values per option style,
+//! and a chain can be 1 001 strikes wide across 512 expirations, so emitting it
+//! unconditionally would multiply the payload a play-loop client pulls every
+//! few hundred milliseconds. It is therefore opt-in, and the default is exactly
+//! what clients get today.
+//!
+//! # Levels
+//!
+//! | `greeks` | What the quote carries |
+//! |---|---|
+//! | absent or `none` | Today's fields only. No `greeks` key at all |
+//! | `first` | `theta`, `vega`, `rho`, `rho_d` |
+//! | `all` | The full twelve-value [`GreeksSnapshot`] |
+//!
+//! # Sign and size
+//!
+//! Every emitted greek is **per one long contract**. Upstream builds the
+//! snapshot through `get_option(Side::Long, style)`, and since optionstratlib
+//! 0.20 the `Greeks` trait applies the `Side` sign in *every* greek rather than
+//! only in `delta` — so a consumer that applies the position sign again would
+//! double-count it. The client applies position sign and size exactly once, to
+//! these values.
+//!
+//! An absent `rho`, `rho_d` or `alpha` means **not meaningful for these
+//! inputs**, never zero; upstream normalises `alpha` to `None` where it would
+//! otherwise be `Decimal::MAX`.
+
+use crate::utils::ChainError;
+use optionstratlib::chains::OptionData;
+use optionstratlib::greeks::GreeksSnapshot;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// How much of the greek set a chain response should carry.
+///
+/// Parsed from the `greeks` query parameter by [`GreekLevel::parse`]; the
+/// default is [`GreekLevel::None`], which is the pre-existing response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GreekLevel {
+    /// Implied volatility, gamma and per-side delta only: the default, and
+    /// byte-identical to the response before the parameter existed.
+    None,
+    /// Adds the remaining first-order greeks: `theta`, `vega`, `rho`, `rho_d`.
+    First,
+    /// The full twelve-value snapshot per option style.
+    All,
+}
+
+impl GreekLevel {
+    /// Parses the raw `greeks` query value.
+    ///
+    /// An absent parameter is [`GreekLevel::None`], so a client that has never
+    /// heard of it keeps its current payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming `greeks` for any other value.
+    /// An unrecognised level is rejected rather than silently downgraded: a
+    /// client that asked for `all` and quietly received the default would
+    /// price a position against greeks it never got.
+    pub(crate) fn parse(raw: Option<&str>) -> Result<Self, ChainError> {
+        match raw {
+            None => Ok(Self::None),
+            Some(value) => match value.trim() {
+                "none" => Ok(Self::None),
+                "first" => Ok(Self::First),
+                "all" => Ok(Self::All),
+                other => Err(ChainError::Validation {
+                    field: "greeks".to_string(),
+                    reason: format!("unknown greek level '{other}'; expected none, first or all"),
+                }),
+            },
+        }
+    }
+
+    /// Whether this level needs the option's greek snapshots at all.
+    #[must_use]
+    #[inline]
+    pub(crate) fn wants_greeks(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// The first-order greeks the default response does not already carry.
+///
+/// `delta` is deliberately absent: it is already on the quote, and repeating it
+/// under a second key would let the two drift. `gamma` is likewise already on
+/// the contract.
+///
+/// Closed with `deny_unknown_fields`, which does two jobs at once: it makes
+/// serde's untagged resolution independent of variant order, and utoipa derives
+/// `additionalProperties: false` from it. That is what keeps the published
+/// `oneOf` satisfiable — without it a full twelve-value payload would satisfy
+/// this four-field shape as well, and "exactly one branch" would fail for
+/// every `greeks=all` response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FirstOrderGreeks {
+    /// Sensitivity to the passage of time, per one long contract.
+    pub theta: Decimal,
+    /// Sensitivity to implied volatility, per one long contract.
+    pub vega: Decimal,
+    /// Sensitivity to the risk-free rate. `null` means not meaningful for
+    /// these inputs, never zero.
+    pub rho: Option<Decimal>,
+    /// Sensitivity to the dividend yield. `null` means not meaningful for
+    /// these inputs, never zero.
+    pub rho_d: Option<Decimal>,
+}
+
+impl From<&GreeksSnapshot> for FirstOrderGreeks {
+    fn from(snapshot: &GreeksSnapshot) -> Self {
+        Self {
+            theta: snapshot.theta,
+            vega: snapshot.vega,
+            rho: snapshot.rho,
+            rho_d: snapshot.rho_d,
+        }
+    }
+}
+
+/// The greek payload one quoted side carries, shaped by the requested level.
+///
+/// Serialised untagged, so the `greeks` key is a plain object at both levels
+/// and a client parses it by the fields it finds rather than by a discriminant.
+/// The full variant is the upstream [`GreeksSnapshot`] itself rather than a
+/// local mirror, so a value cannot drift between what upstream computed and
+/// what this service serves.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum GreeksResponse {
+    /// `greeks=all`: the full twelve-value snapshot.
+    ///
+    /// Listed first so deserialisation prefers it — an untagged enum takes the
+    /// first variant that matches, and the four-field variant would otherwise
+    /// swallow a complete snapshot by ignoring the rest.
+    Full(GreeksSnapshot),
+    /// `greeks=first`: the remaining first-order greeks.
+    FirstOrder(FirstOrderGreeks),
+}
+
+impl GreeksResponse {
+    /// Shapes an upstream snapshot to the requested level.
+    ///
+    /// Returns `None` at [`GreekLevel::None`], which is what keeps the default
+    /// response free of the key entirely.
+    #[must_use]
+    fn from_snapshot(snapshot: &GreeksSnapshot, level: GreekLevel) -> Option<Self> {
+        match level {
+            GreekLevel::None => None,
+            GreekLevel::First => Some(Self::FirstOrder(FirstOrderGreeks::from(snapshot))),
+            GreekLevel::All => Some(Self::Full(snapshot.clone())),
+        }
+    }
+}
+
+/// The greek payloads for both sides of one strike, at the requested level.
+///
+/// Upstream can compute the snapshots at chain build time, but only when the
+/// build asks for them, and nothing in this crate does: `with_greek_snapshots`
+/// is off by default, and turning it on globally would charge every client for
+/// a payload most never request. So in practice **this function computes
+/// them**, through upstream's own `calculate_greeks`; the `is_some` branch is
+/// the guard for a chain that already carries them, not the normal path. No
+/// greek mathematics lives in this crate either way.
+///
+/// # An absent payload is not a zero
+///
+/// Upstream returns no snapshot for a strike whose option cannot be built, and
+/// only logs it at `debug`. Such a strike arrives with **no `greeks` key at
+/// all**, which on the wire is indistinguishable from the default level. A
+/// client that asked for a level and found the key missing on some strikes is
+/// looking at degenerate strikes, not at a downgraded response — the existing
+/// `implied_volatility`, `gamma` and `delta` mirrors are still there, because
+/// they are defined where the full set is not.
+///
+/// # Cost
+///
+/// Roughly 40 µs per contract in a release build. `first` and `all` cost the
+/// same: upstream builds the snapshot whole and the level only decides what is
+/// written out. Computing here rather than at build time is measurably more
+/// expensive per contract, because `calculate_greeks` recomputes delta and
+/// gamma that this response then reads from the mirrors instead; asking the
+/// builder for snapshots costs about 1.5x a plain chain build. The trade is
+/// deliberate — every client would pay the build-time cost, and only some ask
+/// for the payload.
+///
+/// Callers must keep this off the async runtime. Both versions render above the
+/// default level inside `spawn_blocking`, because
+/// `DEFAULT_MAX_SNAPSHOT_CONTRACTS` is 200 000 and seconds of uninterrupted CPU
+/// on a worker would stall every other request that worker holds.
+///
+/// # Why a clone
+///
+/// `calculate_greeks` takes `&mut self` and this function only has `&OptionData`
+/// — the DTO layer has no business mutating the snapshot it was handed to
+/// render. The clone is one option, not the chain, and is unmeasurable next to
+/// the pricing itself.
+#[must_use]
+pub(crate) fn greeks_for(
+    data: &OptionData,
+    level: GreekLevel,
+) -> (Option<GreeksResponse>, Option<GreeksResponse>) {
+    if !level.wants_greeks() {
+        return (None, None);
+    }
+
+    if data.greeks_call.is_some() || data.greeks_put.is_some() {
+        return (
+            data.greeks_call
+                .as_ref()
+                .and_then(|snapshot| GreeksResponse::from_snapshot(snapshot, level)),
+            data.greeks_put
+                .as_ref()
+                .and_then(|snapshot| GreeksResponse::from_snapshot(snapshot, level)),
+        );
+    }
+
+    let mut priced = data.clone();
+    priced.calculate_greeks();
+    (
+        priced
+            .greeks_call
+            .as_ref()
+            .and_then(|snapshot| GreeksResponse::from_snapshot(snapshot, level)),
+        priced
+            .greeks_put
+            .as_ref()
+            .and_then(|snapshot| GreeksResponse::from_snapshot(snapshot, level)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use optionstratlib::ExpirationDate;
+    use optionstratlib::chains::chain::OptionChain;
+    use optionstratlib::chains::{OptionChainBuildParams, utils::OptionDataPriceParams};
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    /// A one-strike chain, optionally built with the greek snapshots already
+    /// populated. `with_greek_snapshots(true)` is the path no handler takes
+    /// today, which is exactly why the branch that reads it needs a test.
+    fn fixture_chain(prepopulated: bool) -> OptionChain {
+        let price_params = OptionDataPriceParams::new(
+            Some(Box::new(pos_or_panic!(100.0))),
+            Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+            Some(dec!(0.04)),
+            Some(pos_or_panic!(0.015)),
+            Some("AAPL".to_string()),
+        );
+        let build_params = OptionChainBuildParams::new(
+            "AAPL".to_string(),
+            Some(Positive::ONE),
+            1,
+            Some(pos_or_panic!(5.0)),
+            dec!(-0.2),
+            dec!(0.5),
+            pos_or_panic!(0.02),
+            2,
+            price_params,
+            pos_or_panic!(0.2),
+        )
+        .with_greek_snapshots(prepopulated);
+
+        match OptionChain::build_chain(&build_params) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the fixture chain must build: {error}"),
+        }
+    }
+
+    /// The first strike of a fixture chain.
+    fn fixture_option(prepopulated: bool) -> optionstratlib::chains::OptionData {
+        let chain = fixture_chain(prepopulated);
+        match chain.iter().next() {
+            Some(data) => data.clone(),
+            None => panic!("the fixture chain must carry a strike"),
+        }
+    }
+
+    /// The default level does no work at all: no clone, no pricing, no key.
+    #[test]
+    fn test_greeks_for_returns_nothing_at_the_default_level() {
+        let data = fixture_option(false);
+
+        assert_eq!(greeks_for(&data, GreekLevel::None), (None, None));
+    }
+
+    /// The path every request actually takes: the chain carries no snapshots,
+    /// so this function prices them.
+    #[test]
+    fn test_greeks_for_prices_an_option_that_carries_no_snapshots() {
+        let data = fixture_option(false);
+        assert!(
+            data.greeks_call.is_none() && data.greeks_put.is_none(),
+            "the fixture must start without snapshots, or this tests nothing"
+        );
+
+        let (call, put) = greeks_for(&data, GreekLevel::All);
+
+        assert!(matches!(call, Some(GreeksResponse::Full(_))));
+        assert!(matches!(put, Some(GreeksResponse::Full(_))));
+        // Pricing happens on a clone: the caller's option is untouched, which
+        // is what lets a shared snapshot be rendered at different levels by
+        // different clients.
+        assert!(data.greeks_call.is_none() && data.greeks_put.is_none());
+    }
+
+    /// The other branch: a chain built WITH snapshots is read rather than
+    /// repriced, and yields the same values.
+    #[test]
+    fn test_greeks_for_reads_snapshots_a_chain_already_carries() {
+        let prepopulated = fixture_option(true);
+        assert!(
+            prepopulated.greeks_call.is_some(),
+            "with_greek_snapshots must populate the call snapshot"
+        );
+
+        let (read_call, read_put) = greeks_for(&prepopulated, GreekLevel::All);
+        let (priced_call, priced_put) = greeks_for(&fixture_option(false), GreekLevel::All);
+
+        assert_eq!(read_call, priced_call, "reading must equal pricing");
+        assert_eq!(read_put, priced_put, "reading must equal pricing");
+    }
+
+    /// The level selects the shape, not the computation: `first` projects the
+    /// same snapshot the `all` payload carries in full.
+    #[test]
+    fn test_greeks_for_projects_the_first_order_subset() {
+        let data = fixture_option(false);
+
+        let (first, _) = greeks_for(&data, GreekLevel::First);
+        let (all, _) = greeks_for(&data, GreekLevel::All);
+
+        match (first, all) {
+            (Some(GreeksResponse::FirstOrder(subset)), Some(GreeksResponse::Full(full))) => {
+                assert_eq!(subset.theta, full.theta);
+                assert_eq!(subset.vega, full.vega);
+                assert_eq!(subset.rho, full.rho);
+                assert_eq!(subset.rho_d, full.rho_d);
+            }
+            other => panic!("each level must yield its own variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_absent_parameter_is_none() {
+        match GreekLevel::parse(None) {
+            Ok(level) => assert_eq!(level, GreekLevel::None),
+            Err(error) => panic!("an absent parameter must parse: {error}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_accepts_the_three_documented_levels() {
+        for (raw, expected) in [
+            ("none", GreekLevel::None),
+            ("first", GreekLevel::First),
+            ("all", GreekLevel::All),
+        ] {
+            match GreekLevel::parse(Some(raw)) {
+                Ok(level) => assert_eq!(level, expected, "for {raw}"),
+                Err(error) => panic!("{raw} must parse: {error}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_trims_surrounding_whitespace() {
+        match GreekLevel::parse(Some("  all  ")) {
+            Ok(level) => assert_eq!(level, GreekLevel::All),
+            Err(error) => panic!("a padded value must parse: {error}"),
+        }
+    }
+
+    /// An unknown level is a rejection, not a silent downgrade: a client that
+    /// asked for `all` and got the default would price against greeks it never
+    /// received.
+    #[test]
+    fn test_parse_rejects_an_unknown_level_naming_the_field() {
+        match GreekLevel::parse(Some("second")) {
+            Ok(level) => panic!("an unknown level must be rejected, got {level:?}"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "greeks");
+                assert!(
+                    reason.contains("second"),
+                    "the reason must quote the offending value, got {reason}"
+                );
+            }
+            Err(other) => panic!("expected a validation failure, got {other:?}"),
+        }
+    }
+
+    /// Case matters: the parameter is a fixed vocabulary, not a free-form
+    /// string, and accepting `ALL` here would leave `All` and `all` to diverge
+    /// the day the set grows.
+    #[test]
+    fn test_parse_rejects_a_differently_cased_level() {
+        assert!(GreekLevel::parse(Some("ALL")).is_err());
+        assert!(GreekLevel::parse(Some("First")).is_err());
+    }
+
+    #[test]
+    fn test_wants_greeks_is_false_only_for_none() {
+        assert!(!GreekLevel::None.wants_greeks());
+        assert!(GreekLevel::First.wants_greeks());
+        assert!(GreekLevel::All.wants_greeks());
+    }
+}

--- a/src/api/rest/greeks.rs
+++ b/src/api/rest/greeks.rs
@@ -17,12 +17,17 @@
 //!
 //! # Sign and size
 //!
-//! Every emitted greek is **per one long contract**. Upstream builds the
-//! snapshot through `get_option(Side::Long, style)`, and since optionstratlib
-//! 0.20 the `Greeks` trait applies the `Side` sign in *every* greek rather than
-//! only in `delta` — so a consumer that applies the position sign again would
-//! double-count it. The client applies position sign and size exactly once, to
-//! these values.
+//! Every emitted greek is **per one long contract**, with one exception. For
+//! the eleven that scale, upstream builds the snapshot through
+//! `get_option(Side::Long, style)`, and since optionstratlib 0.20 the `Greeks`
+//! trait applies the `Side` sign in *every* greek rather than only in `delta` —
+//! so a consumer that applies the position sign again would double-count it.
+//! The client applies position sign and size exactly once, to those values.
+//!
+//! **`alpha` is not one of them.** It is the ratio `gamma / theta`, so a short
+//! position negates both and the ratio is unchanged; upstream says so in as many
+//! words. Scaling it by quantity, or flipping it with the position sign, gives a
+//! client a number that means nothing. Carry it through as it arrives.
 //!
 //! An absent `rho`, `rho_d` or `alpha` means **not meaningful for these
 //! inputs**, never zero; upstream normalises `alpha` to `None` where it would
@@ -33,14 +38,23 @@ use optionstratlib::chains::OptionData;
 use optionstratlib::greeks::GreeksSnapshot;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use tokio::sync::Semaphore;
 use utoipa::ToSchema;
 
 /// How much of the greek set a chain response should carry.
 ///
 /// Parsed from the `greeks` query parameter by [`GreekLevel::parse`]; the
 /// default is [`GreekLevel::None`], which is the pre-existing response.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum GreekLevel {
+/// Serialised and schema-bearing so the OpenAPI document can publish the
+/// parameter as a closed enum rather than an unconstrained string: a generated
+/// client then cannot send `?greeks=second` at all, and a reader of the document
+/// sees the three values without reading prose. The wire form is still parsed by
+/// [`GreekLevel::parse`] from a raw string, so an unknown value stays a typed
+/// `400` naming the field rather than actix's untyped rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GreekLevel {
     /// Implied volatility, gamma and per-side delta only: the default, and
     /// byte-identical to the response before the parameter existed.
     None,
@@ -97,48 +111,137 @@ impl GreekLevel {
 /// `oneOf` satisfiable — without it a full twelve-value payload would satisfy
 /// this four-field shape as well, and "exactly one branch" would fail for
 /// every `greeks=all` response.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FirstOrderGreeks {
     /// Sensitivity to the passage of time, per one long contract.
-    pub theta: Decimal,
+    pub theta: Option<f64>,
     /// Sensitivity to implied volatility, per one long contract.
-    pub vega: Decimal,
+    pub vega: Option<f64>,
     /// Sensitivity to the risk-free rate. `null` means not meaningful for
     /// these inputs, never zero.
-    pub rho: Option<Decimal>,
+    pub rho: Option<f64>,
     /// Sensitivity to the dividend yield. `null` means not meaningful for
     /// these inputs, never zero.
-    pub rho_d: Option<Decimal>,
+    pub rho_d: Option<f64>,
 }
 
 impl From<&GreeksSnapshot> for FirstOrderGreeks {
     fn from(snapshot: &GreeksSnapshot) -> Self {
         Self {
-            theta: snapshot.theta,
-            vega: snapshot.vega,
-            rho: snapshot.rho,
-            rho_d: snapshot.rho_d,
+            theta: to_f64(snapshot.theta),
+            vega: to_f64(snapshot.vega),
+            rho: snapshot.rho.and_then(to_f64),
+            rho_d: snapshot.rho_d.and_then(to_f64),
         }
     }
+}
+
+/// The full twelve-value greek set of one option style.
+///
+/// A LOCAL type, not upstream's `GreeksSnapshot`. `CLAUDE.md` is binding that
+/// the REST DTOs speak `f64` with the conversion happening exactly once at the
+/// boundary; carrying the upstream struct would have made its `Decimal`
+/// serialisation — JSON strings, and whatever field set the next release
+/// carries — part of this service's public contract by accident rather than by
+/// decision.
+///
+/// The cost is a twelve-field mirror that has to track upstream. That cost is
+/// paid deliberately, and [`FullGreeks::from`] destructures the snapshot so a
+/// thirteenth greek is a compile error here rather than a field the API
+/// silently stops carrying.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FullGreeks {
+    /// Sensitivity to the underlying price, per one long contract.
+    pub delta: Option<f64>,
+    /// Rate of change of delta, per one long contract.
+    pub gamma: Option<f64>,
+    /// Sensitivity to the passage of time, per one long contract.
+    pub theta: Option<f64>,
+    /// Sensitivity to implied volatility, per one long contract.
+    pub vega: Option<f64>,
+    /// Sensitivity to the risk-free rate. `null` means not meaningful.
+    pub rho: Option<f64>,
+    /// Sensitivity to the dividend yield. `null` means not meaningful.
+    pub rho_d: Option<f64>,
+    /// The ratio `gamma / theta`. **Does not scale with position sign or
+    /// size** — a short position negates both terms and leaves the ratio
+    /// unchanged. `null` means not meaningful. See the module docs.
+    pub alpha: Option<f64>,
+    /// Rate of change of delta with volatility, per one long contract.
+    pub vanna: Option<f64>,
+    /// Rate of change of vega with volatility, per one long contract.
+    pub vomma: Option<f64>,
+    /// Rate of change of vega with time, per one long contract.
+    pub veta: Option<f64>,
+    /// Rate of change of delta with time, per one long contract.
+    pub charm: Option<f64>,
+    /// Rate of change of gamma with time, per one long contract.
+    pub color: Option<f64>,
+}
+
+impl From<&GreeksSnapshot> for FullGreeks {
+    fn from(snapshot: &GreeksSnapshot) -> Self {
+        // Destructured, not field-accessed: a thirteenth upstream greek is then
+        // a COMPILE ERROR rather than a value this DTO silently stops carrying.
+        // Same discipline `ApiWalkType` uses for a new `WalkType` variant.
+        let GreeksSnapshot {
+            delta,
+            gamma,
+            theta,
+            vega,
+            rho,
+            rho_d,
+            alpha,
+            vanna,
+            vomma,
+            veta,
+            charm,
+            color,
+        } = snapshot;
+        Self {
+            delta: to_f64(*delta),
+            gamma: to_f64(*gamma),
+            theta: to_f64(*theta),
+            vega: to_f64(*vega),
+            rho: rho.and_then(to_f64),
+            rho_d: rho_d.and_then(to_f64),
+            alpha: alpha.and_then(to_f64),
+            vanna: to_f64(*vanna),
+            vomma: to_f64(*vomma),
+            veta: to_f64(*veta),
+            charm: to_f64(*charm),
+            color: to_f64(*color),
+        }
+    }
+}
+
+/// The one `Decimal` to `f64` conversion on this boundary.
+///
+/// `None` only if a value were outside `f64`'s range, which no `Decimal` is —
+/// its maximum is about `7.9e28`. Written as an `Option` rather than an
+/// `unwrap` because `rules/global_rules.md` allows neither on a request path.
+#[must_use]
+#[inline]
+fn to_f64(value: Decimal) -> Option<f64> {
+    use rust_decimal::prelude::ToPrimitive;
+    value.to_f64()
 }
 
 /// The greek payload one quoted side carries, shaped by the requested level.
 ///
 /// Serialised untagged, so the `greeks` key is a plain object at both levels
 /// and a client parses it by the fields it finds rather than by a discriminant.
-/// The full variant is the upstream [`GreeksSnapshot`] itself rather than a
-/// local mirror, so a value cannot drift between what upstream computed and
-/// what this service serves.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 pub enum GreeksResponse {
-    /// `greeks=all`: the full twelve-value snapshot.
+    /// `greeks=all`: the full twelve-value set.
     ///
     /// Listed first so deserialisation prefers it — an untagged enum takes the
     /// first variant that matches, and the four-field variant would otherwise
-    /// swallow a complete snapshot by ignoring the rest.
-    Full(GreeksSnapshot),
+    /// swallow a complete payload by ignoring the rest.
+    Full(FullGreeks),
     /// `greeks=first`: the remaining first-order greeks.
     FirstOrder(FirstOrderGreeks),
 }
@@ -153,9 +256,97 @@ impl GreeksResponse {
         match level {
             GreekLevel::None => None,
             GreekLevel::First => Some(Self::FirstOrder(FirstOrderGreeks::from(snapshot))),
-            GreekLevel::All => Some(Self::Full(snapshot.clone())),
+            GreekLevel::All => Some(Self::Full(FullGreeks::from(snapshot))),
         }
     }
+}
+
+/// Default number of greek-pricing jobs allowed to run at once.
+///
+/// Small on purpose. One job is up to `OCS_MAX_SNAPSHOT_CONTRACTS` contracts of
+/// pricing plus the serialisation of the result, which is seconds of CPU at the
+/// cap; letting every concurrent request start one turns a handful of peeks
+/// into a machine with no cores left for anything else, including the requests
+/// that never asked for greeks.
+pub(crate) const DEFAULT_MAX_CONCURRENT_GREEK_RENDERS: usize = 4;
+
+/// How many greek-pricing jobs may run at once
+/// (`OCS_MAX_CONCURRENT_GREEK_RENDERS`).
+///
+/// The admission bound the whole service shares — v1 and v2, peek and step —
+/// because they contend for the same cores. Requests above the bound WAIT on
+/// the semaphore rather than being rejected, and they wait in async code, so a
+/// client that disconnects while queued drops its future and never occupies a
+/// thread at all. That is the part a bare `spawn_blocking` cannot do: its task
+/// is not cancellable once started, so without admission a burst of peeks
+/// commits the machine to every job in it.
+static GREEK_RENDER_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
+    Semaphore::new(crate::api::rest::limits::parse_limit(
+        std::env::var("OCS_MAX_CONCURRENT_GREEK_RENDERS").ok(),
+        DEFAULT_MAX_CONCURRENT_GREEK_RENDERS,
+    ))
+});
+
+/// Runs a rendering job off the runtime and under admission when the level
+/// makes it expensive.
+///
+/// At [`GreekLevel::None`] there is nothing to price, so the work stays inline
+/// and takes no permit — the default request must not queue behind a burst of
+/// greek requests.
+///
+/// The job is the WHOLE unit of work, pricing and serialisation together.
+/// Serialising afterwards on the worker would put a large document back on the
+/// thread the job was moved off, which at `greeks=all` on a capped snapshot is
+/// a stall on its own.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] if the blocking task panics or is dropped,
+/// and whatever the job itself returns.
+pub(crate) async fn admit_blocking<T, F>(level: GreekLevel, job: F) -> Result<T, ChainError>
+where
+    F: FnOnce() -> Result<T, ChainError> + Send + 'static,
+    T: Send + 'static,
+{
+    if !level.wants_greeks() {
+        return job();
+    }
+
+    let permit = GREEK_RENDER_PERMITS.acquire().await.map_err(|error| {
+        ChainError::Internal(format!("the greek admission gate is closed: {error}"))
+    })?;
+
+    let outcome = tokio::task::spawn_blocking(job)
+        .await
+        .map_err(|error| ChainError::Internal(format!("greek rendering failed: {error}")))?;
+
+    drop(permit);
+    outcome
+}
+
+/// Renders one response body under [`admit_blocking`].
+///
+/// # Errors
+///
+/// As [`admit_blocking`], plus [`ChainError::Internal`] when the response
+/// cannot be serialised.
+pub(crate) async fn render_body<T, F>(level: GreekLevel, render: F) -> Result<Vec<u8>, ChainError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: serde::Serialize + Send + 'static,
+{
+    admit_blocking(level, move || serialize_body(&render())).await
+}
+
+/// Serialises a response body, reporting a failure as an internal error rather
+/// than panicking on a request path.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when the value cannot be serialised.
+pub(crate) fn serialize_body<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, ChainError> {
+    serde_json::to_vec(value)
+        .map_err(|error| ChainError::Internal(format!("failed to encode the response: {error}")))
 }
 
 /// The greek payloads for both sides of one strike, at the requested level.
@@ -346,6 +537,41 @@ mod tests {
                 assert_eq!(subset.rho_d, full.rho_d);
             }
             other => panic!("each level must yield its own variant, got {other:?}"),
+        }
+    }
+
+    /// The admission bound is what the documentation says it is.
+    ///
+    /// The number itself is a judgement call, but `.env.example` and the crate
+    /// docs quote it, so it may not drift from them silently. It also may not
+    /// be zero, which `parse_limit` already enforces for the configured value:
+    /// a bound of zero would deadlock every greek request.
+    #[test]
+    fn test_the_greek_admission_default_matches_the_documentation() {
+        assert_eq!(DEFAULT_MAX_CONCURRENT_GREEK_RENDERS, 4);
+    }
+
+    /// The default level never queues.
+    ///
+    /// `admit_blocking` runs it inline and takes no permit, so a burst of
+    /// `greeks=all` requests cannot make a plain peek wait behind them. Proven
+    /// by exhausting the permits first: this call still completes.
+    #[tokio::test]
+    async fn test_the_default_level_takes_no_permit() {
+        let held = match GREEK_RENDER_PERMITS
+            .acquire_many(u32::try_from(DEFAULT_MAX_CONCURRENT_GREEK_RENDERS).unwrap_or(1))
+            .await
+        {
+            Ok(permits) => permits,
+            Err(error) => panic!("the semaphore must hand out its permits: {error}"),
+        };
+
+        let outcome = admit_blocking(GreekLevel::None, || Ok(7_usize)).await;
+
+        drop(held);
+        match outcome {
+            Ok(value) => assert_eq!(value, 7),
+            Err(error) => panic!("the default level must not wait for a permit: {error}"),
         }
     }
 

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -1,5 +1,5 @@
 use crate::api::rest::error::map_error;
-use crate::api::rest::greeks::{GreekLevel, greeks_for};
+use crate::api::rest::greeks::{GreekLevel, admit_blocking, greeks_for, serialize_body};
 use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
 use crate::api::rest::models::SessionId;
 use crate::api::rest::patch::Patch;
@@ -211,42 +211,47 @@ pub(crate) fn apply_update(
     Ok(())
 }
 
-/// Renders the v1 chain DTOs, off the runtime whenever greeks have to be priced.
+/// Renders the v1 chain bodies, under the shared greek admission bound.
 ///
-/// Returns the response to serve and the one to persist. They differ only above
-/// the default greek level, where the served payload carries the greeks and the
-/// persisted one deliberately does not: the event log records the chain at step
-/// N, not what the client who happened to advance it asked for.
+/// Returns the serialised bytes to write and the DTO to persist. They differ
+/// only above the default greek level, where the served payload carries the
+/// greeks and the persisted one deliberately does not: the event log records
+/// the chain at step N, not what the client who happened to advance it asked
+/// for.
 ///
-/// At the default level the conversion is a field-by-field copy and stays
-/// inline. Above it, upstream's `calculate_greeks` runs per strike per style at
-/// roughly 40 µs a contract, so a chain at the `OCS_MAX_CHAIN_SIZE` cap is tens
-/// of milliseconds of uninterrupted CPU. Left on a worker that stalls every
-/// other request the worker holds, so it goes to the blocking pool — the same
-/// treatment the v2 tape build and the export path already give their heavy
-/// synchronous work.
+/// Both are produced inside one admitted blocking job, serialisation included.
+/// `HttpResponse::json` would otherwise encode a large document on the Actix
+/// worker after the job returned, which is the stall the job exists to avoid.
+/// See [`crate::api::rest::greeks::admit_blocking`] for the bound v1 and v2
+/// share.
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Internal`] if the blocking task panics or is dropped.
+/// Returns [`ChainError::Internal`] if the blocking task panics or is dropped,
+/// or if the response cannot be serialised.
 async fn render_chain_responses(
     session: Session,
     option_chain: OptionChain,
     level: GreekLevel,
-) -> Result<(ChainResponse, ChainResponse), ChainError> {
-    if !level.wants_greeks() {
-        let response = build_chain_response(&session, &option_chain, level);
-        let persisted = response.clone();
-        return Ok((response, persisted));
-    }
-
-    tokio::task::spawn_blocking(move || {
+) -> Result<(Vec<u8>, ChainResponse), ChainError> {
+    admit_blocking(level, move || {
         let served = build_chain_response(&session, &option_chain, level);
-        let persisted = build_chain_response(&session, &option_chain, GreekLevel::None);
-        (served, persisted)
+        let persisted = if level.wants_greeks() {
+            build_chain_response(&session, &option_chain, GreekLevel::None)
+        } else {
+            served.clone()
+        };
+        Ok((serialize_body(&served)?, persisted))
     })
     .await
-    .map_err(|error| ChainError::Internal(format!("greek pricing failed: {error}")))
+}
+
+/// Writes an already-serialised JSON body.
+#[must_use]
+fn json_body(bytes: Vec<u8>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body(bytes)
 }
 
 #[utoipa::path(
@@ -357,6 +362,7 @@ pub(crate) async fn create_session(
 /// Query parameters for the advance-step command: the session id plus an
 /// optional expected-cursor precondition for safe retries.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AdvanceStepQuery {
     /// ID of the session to advance one step.
     #[serde(rename = "sessionid")]
@@ -382,6 +388,7 @@ pub(crate) struct AdvanceStepQuery {
 /// take the parameter; PUT, PATCH and DELETE return no chain and must not
 /// advertise it.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ChainQuery {
     /// ID of the session to read the current snapshot for.
     #[serde(rename = "sessionid")]
@@ -405,7 +412,7 @@ pub(crate) struct ChainQuery {
     params(
         ("sessionid" = String, Query, description = "ID of the session to advance one step"),
         ("expected_step" = Option<usize>, Query, description = "Expected current cursor; mismatch returns 412 without advancing"),
-        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
+        ("greeks" = Option<GreekLevel>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. The one exception is `alpha`, the ratio gamma/theta, which a short position leaves unchanged and which must NOT be scaled or sign-flipped. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
@@ -474,11 +481,11 @@ pub(crate) async fn advance_step(
             // shape it would mean two clients advancing the same session wrote
             // differently-shaped documents, with a `greeks=all` advance writing
             // roughly five times the BSON for no gain.
-            let (response, persisted) =
-                match render_chain_responses(session, option_chain, level).await {
-                    Ok(rendered) => rendered,
-                    Err(error) => return map_error(error),
-                };
+            let (body, persisted) = match render_chain_responses(session, option_chain, level).await
+            {
+                Ok(rendered) => rendered,
+                Err(error) => return map_error(error),
+            };
             let duration = start_time.elapsed();
             metrics_collector.record_simulation_step(&method);
             metrics_collector.record_simulation_duration(duration);
@@ -494,7 +501,7 @@ pub(crate) async fn advance_step(
                 error!(session_id = %session_id, "Failed to save chain step to MongoDB: {}", e);
                 // Continue as this is not critical for the main flow
             }
-            HttpResponse::Ok().json(response)
+            json_body(body)
         }
         Err(error) => map_error(error),
     }
@@ -509,7 +516,7 @@ pub(crate) async fn advance_step(
         not mutate session state or record a simulation step.",
     params(
         ("sessionid" = String, Query, description = "ID of the session to read the current snapshot for"),
-        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
+        ("greeks" = Option<GreekLevel>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. The one exception is `alpha`, the ratio gamma/theta, which a short position leaves unchanged and which must NOT be scaled or sign-flipped. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Current snapshot returned (read-only; repeatable)", body = ChainResponse),
@@ -552,7 +559,7 @@ pub(crate) async fn get_current_step(
     match session_manager.peek_current_step(session_id).await {
         Ok((session, option_chain)) => {
             match render_chain_responses(session, option_chain, level).await {
-                Ok((response, _)) => HttpResponse::Ok().json(response),
+                Ok((body, _)) => json_body(body),
                 Err(error) => map_error(error),
             }
         }
@@ -1260,12 +1267,9 @@ mod tests_chain_response_greeks {
                 .get(side)
                 .and_then(|quote| quote.get("greeks"))
                 .and_then(|greeks| greeks.get(name))
-                .and_then(Value::as_str);
+                .and_then(Value::as_f64);
             match raw {
-                Some(value) => match value.parse::<f64>() {
-                    Ok(parsed) => parsed,
-                    Err(error) => panic!("{side}.{name} must be numeric: {value} ({error})"),
-                },
+                Some(value) => value,
                 None => panic!("{side}.{name} must be present: {contract}"),
             }
         };

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -1,4 +1,5 @@
 use crate::api::rest::error::map_error;
+use crate::api::rest::greeks::{GreekLevel, greeks_for};
 use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS};
 use crate::api::rest::models::SessionId;
 use crate::api::rest::patch::Patch;
@@ -25,7 +26,18 @@ use uuid::Uuid;
 /// Builds the `ChainResponse` DTO shared by the advance (`POST /api/v1/chain/step`) and
 /// peek (`GET /api/v1/chain`) endpoints from a session and its current option-chain
 /// snapshot. Kept as a single place so both surfaces emit an identical response shape.
-fn build_chain_response(session: &Session, option_chain: &OptionChain) -> ChainResponse {
+///
+/// `level` is the resolved `greeks` query parameter. At [`GreekLevel::None`] —
+/// the default, and what every existing client sends — the response is
+/// byte-identical to the one before the parameter existed: `implied_volatility`,
+/// `gamma` and the per-side `delta` still come from the convenience mirrors on
+/// `OptionData`, which are defined at expiry and at zero volatility where the
+/// full greek set is not.
+fn build_chain_response(
+    session: &Session,
+    option_chain: &OptionChain,
+    level: GreekLevel,
+) -> ChainResponse {
     let expiration = option_chain.get_expiration_date();
     ChainResponse {
         underlying: option_chain.symbol.clone(),
@@ -40,6 +52,7 @@ fn build_chain_response(session: &Session, option_chain: &OptionChain) -> ChainR
                 let call_bid = contract.get_call_sell_price();
                 let put_bid = contract.get_put_sell_price();
                 let volatility = contract.get_volatility();
+                let (call_greeks, put_greeks) = greeks_for(contract, level);
                 OptionContractResponse {
                     strike: contract.strike().into(),
                     expiration: expiration.clone(),
@@ -48,12 +61,14 @@ fn build_chain_response(session: &Session, option_chain: &OptionChain) -> ChainR
                         ask: call_ask.map(|a| a.into()),
                         mid: contract.call_middle.map(|m| m.into()),
                         delta: call_delta.map(|d| d.to_f64().unwrap_or(0.0)),
+                        greeks: call_greeks,
                     },
                     put: OptionPriceResponse {
                         bid: put_bid.map(|b| b.into()),
                         ask: put_ask.map(|a| a.into()),
                         mid: contract.put_middle.map(|m| m.into()),
                         delta: put_delta.map(|d| d.to_f64().unwrap_or(0.0)),
+                        greeks: put_greeks,
                     },
                     implied_volatility: Some(volatility.into()),
                     gamma: contract.current_gamma().map(|g| g.to_f64().unwrap_or(0.0)),
@@ -196,6 +211,44 @@ pub(crate) fn apply_update(
     Ok(())
 }
 
+/// Renders the v1 chain DTOs, off the runtime whenever greeks have to be priced.
+///
+/// Returns the response to serve and the one to persist. They differ only above
+/// the default greek level, where the served payload carries the greeks and the
+/// persisted one deliberately does not: the event log records the chain at step
+/// N, not what the client who happened to advance it asked for.
+///
+/// At the default level the conversion is a field-by-field copy and stays
+/// inline. Above it, upstream's `calculate_greeks` runs per strike per style at
+/// roughly 40 µs a contract, so a chain at the `OCS_MAX_CHAIN_SIZE` cap is tens
+/// of milliseconds of uninterrupted CPU. Left on a worker that stalls every
+/// other request the worker holds, so it goes to the blocking pool — the same
+/// treatment the v2 tape build and the export path already give their heavy
+/// synchronous work.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] if the blocking task panics or is dropped.
+async fn render_chain_responses(
+    session: Session,
+    option_chain: OptionChain,
+    level: GreekLevel,
+) -> Result<(ChainResponse, ChainResponse), ChainError> {
+    if !level.wants_greeks() {
+        let response = build_chain_response(&session, &option_chain, level);
+        let persisted = response.clone();
+        return Ok((response, persisted));
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let served = build_chain_response(&session, &option_chain, level);
+        let persisted = build_chain_response(&session, &option_chain, GreekLevel::None);
+        (served, persisted)
+    })
+    .await
+    .map_err(|error| ChainError::Internal(format!("greek pricing failed: {error}")))
+}
+
 #[utoipa::path(
     post,
     path = "/api/v1/chain",
@@ -314,6 +367,28 @@ pub(crate) struct AdvanceStepQuery {
     /// (response lost after the save) without consuming another step.
     #[serde(default)]
     pub(crate) expected_step: Option<usize>,
+    /// How much of the greek set the served chain should carry: `none` (the
+    /// default), `first` or `all`. Kept as a raw string so an unknown value is
+    /// a typed `400` naming the field rather than actix's untyped query
+    /// rejection.
+    #[serde(default)]
+    pub(crate) greeks: Option<String>,
+}
+
+/// The query of the v1 chain peek: the session, plus how much of the greek set
+/// to carry.
+///
+/// Separate from [`SessionId`] because only the two chain-serving endpoints
+/// take the parameter; PUT, PATCH and DELETE return no chain and must not
+/// advertise it.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ChainQuery {
+    /// ID of the session to read the current snapshot for.
+    #[serde(rename = "sessionid")]
+    pub(crate) session_id: String,
+    /// How much of the greek set to carry. See [`AdvanceStepQuery::greeks`].
+    #[serde(default)]
+    pub(crate) greeks: Option<String>,
 }
 
 #[utoipa::path(
@@ -329,10 +404,12 @@ pub(crate) struct AdvanceStepQuery {
         of consuming another one.",
     params(
         ("sessionid" = String, Query, description = "ID of the session to advance one step"),
-        ("expected_step" = Option<usize>, Query, description = "Expected current cursor; mismatch returns 412 without advancing")
+        ("expected_step" = Option<usize>, Query, description = "Expected current cursor; mismatch returns 412 without advancing"),
+        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
+        (status = 400, description = "Malformed session id, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` of ValidationErrorResponse with `field` = `greeks`; a malformed id carries `error` alone."),
         (status = 404, description = "Session not found"),
         (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 410, description = "Simulation completed. No more steps available"),
@@ -364,6 +441,12 @@ pub(crate) async fn advance_step(
             ));
         }
     };
+    // Rejected before the step is consumed: an unknown level must not advance
+    // the cursor on its way to a 400.
+    let level = match GreekLevel::parse(query.greeks.as_deref()) {
+        Ok(level) => level,
+        Err(error) => return map_error(error),
+    };
 
     // Expected-cursor precondition: a transport-level check (412) so an
     // ambiguous retry can be resolved without consuming another step.
@@ -384,22 +467,28 @@ pub(crate) async fn advance_step(
     // Advance the session one step (mutates state and persists it).
     match session_manager.get_next_step(session_id).await {
         Ok((session, option_chain)) => {
-            let response = build_chain_response(&session, &option_chain);
+            // Read before the session moves into the renderer.
+            let method = session.parameters.method.to_string();
+            // `persisted` is the response at the DEFAULT level: the event log is
+            // a record of the chain at step N, and letting a query parameter
+            // shape it would mean two clients advancing the same session wrote
+            // differently-shaped documents, with a `greeks=all` advance writing
+            // roughly five times the BSON for no gain.
+            let (response, persisted) =
+                match render_chain_responses(session, option_chain, level).await {
+                    Ok(rendered) => rendered,
+                    Err(error) => return map_error(error),
+                };
             let duration = start_time.elapsed();
-            metrics_collector.record_simulation_step(&session.parameters.method.to_string());
+            metrics_collector.record_simulation_step(&method);
             metrics_collector.record_simulation_duration(duration);
             // Publish the current simulation-cache occupancy: an advance may have
             // populated a fresh walk or evicted a completed one (issue #9).
             metrics_collector
                 .set_simulation_cache_size(session_manager.simulation_cache_len().await as i64);
 
-            // Save to MongoDB
             if let Err(e) = mongodb_repo
-                .save_chain_step(
-                    session_id,
-                    response.clone(),
-                    metrics_collector.get_ref().clone(),
-                )
+                .save_chain_step(session_id, persisted, metrics_collector.get_ref().clone())
                 .await
             {
                 error!(session_id = %session_id, "Failed to save chain step to MongoDB: {}", e);
@@ -419,10 +508,12 @@ pub(crate) async fn advance_step(
         explicit advance via POST /api/v1/chain/step moves the cursor. This endpoint does \
         not mutate session state or record a simulation step.",
     params(
-        ("sessionid" = String, Query, description = "ID of the session to read the current snapshot for")
+        ("sessionid" = String, Query, description = "ID of the session to read the current snapshot for"),
+        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Current snapshot returned (read-only; repeatable)", body = ChainResponse),
+        (status = 400, description = "Malformed session id, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` of ValidationErrorResponse with `field` = `greeks`; a malformed id carries `error` alone."),
         (status = 404, description = "Session not found"),
         (status = 410, description = "Session completed; no current step available"),
         (status = 500, description = "Internal server error")
@@ -431,7 +522,7 @@ pub(crate) async fn advance_step(
 pub(crate) async fn get_current_step(
     req: HttpRequest,
     session_manager: web::Data<Arc<SessionManager>>,
-    query: web::Query<SessionId>,
+    query: web::Query<ChainQuery>,
 ) -> impl Responder {
     info!(
         "{} {}: session_id={}",
@@ -450,13 +541,20 @@ pub(crate) async fn get_current_step(
         }
     };
 
+    let level = match GreekLevel::parse(query.greeks.as_deref()) {
+        Ok(level) => level,
+        Err(error) => return map_error(error),
+    };
+
     // Peek the current snapshot: read-only, repeatable, no state change and no persistence.
     // No simulation-step metric is recorded and no chain-step event is written, because the
     // same step is served repeatedly.
     match session_manager.peek_current_step(session_id).await {
         Ok((session, option_chain)) => {
-            let response = build_chain_response(&session, &option_chain);
-            HttpResponse::Ok().json(response)
+            match render_chain_responses(session, option_chain, level).await {
+                Ok((response, _)) => HttpResponse::Ok().json(response),
+                Err(error) => map_error(error),
+            }
         }
         Err(error) => map_error(error),
     }
@@ -985,5 +1083,389 @@ mod tests_apply_update {
             changed,
             "seed null should produce a fresh seed different from the previous one"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_chain_response_greeks {
+    use super::*;
+    use crate::api::rest::greeks::GreekLevel;
+    use crate::session::{SimulationMethod, SimulationParameters};
+    use crate::utils::UuidGenerator;
+    use optionstratlib::ExpirationDate;
+    use optionstratlib::chains::OptionChainBuildParams;
+    use optionstratlib::chains::utils::OptionDataPriceParams;
+    use optionstratlib::utils::TimeFrame;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+    use serde_json::Value;
+
+    /// The twelve values of an upstream `GreeksSnapshot`.
+    const FULL_SET: [&str; 12] = [
+        "delta", "gamma", "theta", "vega", "rho", "rho_d", "alpha", "vanna", "vomma", "veta",
+        "charm", "color",
+    ];
+
+    /// A session and a chain built from the same parameters, with a non-zero
+    /// dividend yield so `rho_d` is a meaningful number rather than a null.
+    fn session_and_chain() -> (Session, OptionChain) {
+        let parameters = SimulationParameters {
+            symbol: "AAPL".to_string(),
+            steps: 10,
+            initial_price: pos_or_panic!(100.0),
+            days_to_expiration: pos_or_panic!(30.0),
+            volatility: pos_or_panic!(0.2),
+            risk_free_rate: dec!(0.04),
+            dividend_yield: pos_or_panic!(0.015),
+            method: SimulationMethod::GeometricBrownian {
+                dt: pos_or_panic!(0.004),
+                drift: dec!(0.0),
+                volatility: pos_or_panic!(0.2),
+            },
+            time_frame: TimeFrame::Day,
+            chain_size: Some(3),
+            strike_interval: Some(pos_or_panic!(5.0)),
+            skew_slope: Some(dec!(-0.2)),
+            smile_curve: Some(dec!(0.5)),
+            spread: Some(pos_or_panic!(0.02)),
+            seed: Some(42),
+        };
+
+        let price_params = OptionDataPriceParams::new(
+            Some(Box::new(parameters.initial_price)),
+            Some(ExpirationDate::Days(parameters.days_to_expiration)),
+            Some(parameters.risk_free_rate),
+            Some(parameters.dividend_yield),
+            Some(parameters.symbol.clone()),
+        );
+        let build_params = OptionChainBuildParams::new(
+            parameters.symbol.clone(),
+            Some(Positive::ONE),
+            3,
+            Some(pos_or_panic!(5.0)),
+            dec!(-0.2),
+            dec!(0.5),
+            pos_or_panic!(0.02),
+            2,
+            price_params,
+            parameters.volatility,
+        );
+        let chain = match OptionChain::build_chain(&build_params) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the fixture chain must build: {error}"),
+        };
+
+        let namespace = match Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8") {
+            Ok(namespace) => namespace,
+            Err(error) => panic!("the fixture namespace must parse: {error}"),
+        };
+        let session = Session::new(parameters, &UuidGenerator::new(namespace));
+        (session, chain)
+    }
+
+    /// Renders a chain response at one level and returns its quotes, both
+    /// sides of every strike.
+    fn quotes_at(level: GreekLevel) -> Vec<Value> {
+        let (session, chain) = session_and_chain();
+        let response = build_chain_response(&session, &chain, level);
+        let value = match serde_json::to_value(&response) {
+            Ok(value) => value,
+            Err(error) => panic!("the response must serialize: {error}"),
+        };
+        let contracts = match value.get("contracts").and_then(Value::as_array) {
+            Some(contracts) => contracts.clone(),
+            None => panic!("the response must carry contracts: {value}"),
+        };
+        let mut quotes = Vec::new();
+        for contract in &contracts {
+            for side in ["call", "put"] {
+                match contract.get(side) {
+                    Some(quote) => quotes.push(quote.clone()),
+                    None => panic!("every contract must carry a {side}: {contract}"),
+                }
+            }
+        }
+        assert!(!quotes.is_empty(), "the fixture chain must quote something");
+        quotes
+    }
+
+    /// The regression that protects every existing v1 client: at the default
+    /// level the response carries no `greeks` key at all, so the payload is
+    /// what it has always been.
+    #[test]
+    fn test_the_default_v1_chain_carries_no_greeks_key() {
+        for quote in quotes_at(GreekLevel::None) {
+            assert!(
+                quote.get("greeks").is_none(),
+                "the default quote must carry no greeks key: {quote}"
+            );
+        }
+    }
+
+    /// `greeks=all` carries all twelve values for both styles on every strike.
+    #[test]
+    fn test_the_v1_chain_carries_the_twelve_values_per_style() {
+        for quote in quotes_at(GreekLevel::All) {
+            let greeks = match quote.get("greeks").and_then(Value::as_object) {
+                Some(greeks) => greeks,
+                None => panic!("greeks=all must carry a greeks object: {quote}"),
+            };
+            for key in FULL_SET {
+                assert!(
+                    greeks.contains_key(key),
+                    "greeks=all must carry {key}: {quote}"
+                );
+            }
+            assert_eq!(
+                greeks.len(),
+                FULL_SET.len(),
+                "greeks=all must carry exactly the twelve values: {quote}"
+            );
+        }
+    }
+
+    /// `greeks=first` adds the four the default response lacks, and nothing
+    /// else; `delta` stays on the quote itself.
+    #[test]
+    fn test_the_v1_chain_first_level_carries_only_the_remaining_first_order_set() {
+        for quote in quotes_at(GreekLevel::First) {
+            let greeks = match quote.get("greeks").and_then(Value::as_object) {
+                Some(greeks) => greeks,
+                None => panic!("greeks=first must carry a greeks object: {quote}"),
+            };
+            let mut keys: Vec<&str> = greeks.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            assert_eq!(keys, vec!["rho", "rho_d", "theta", "vega"], "{quote}");
+            assert!(quote.get("delta").is_some(), "{quote}");
+        }
+    }
+
+    /// The per-style split is real: `charm` differs between the call and the
+    /// put, and `rho` carries opposite signs.
+    #[test]
+    fn test_the_v1_call_and_put_greeks_are_genuinely_different() {
+        let (session, chain) = session_and_chain();
+        let response = build_chain_response(&session, &chain, GreekLevel::All);
+        let value = match serde_json::to_value(&response) {
+            Ok(value) => value,
+            Err(error) => panic!("the response must serialize: {error}"),
+        };
+        let contracts = match value.get("contracts").and_then(Value::as_array) {
+            Some(contracts) => contracts,
+            None => panic!("the response must carry contracts: {value}"),
+        };
+
+        let greek = |contract: &Value, side: &str, name: &str| -> f64 {
+            let raw = contract
+                .get(side)
+                .and_then(|quote| quote.get("greeks"))
+                .and_then(|greeks| greeks.get(name))
+                .and_then(Value::as_str);
+            match raw {
+                Some(value) => match value.parse::<f64>() {
+                    Ok(parsed) => parsed,
+                    Err(error) => panic!("{side}.{name} must be numeric: {value} ({error})"),
+                },
+                None => panic!("{side}.{name} must be present: {contract}"),
+            }
+        };
+
+        for contract in contracts {
+            assert_ne!(
+                greek(contract, "call", "charm"),
+                greek(contract, "put", "charm"),
+                "charm must differ between the styles: {contract}"
+            );
+            let call_rho = greek(contract, "call", "rho");
+            let put_rho = greek(contract, "put", "rho");
+            assert!(
+                call_rho * put_rho < 0.0,
+                "rho must carry opposite signs, got {call_rho} and {put_rho}"
+            );
+        }
+    }
+
+    /// The level changes only what is added: prices, delta and gamma are the
+    /// same numbers at all three levels, because the greeks are read off the
+    /// option and never fed back into it.
+    #[test]
+    fn test_the_v1_greek_level_does_not_move_the_quoted_market() {
+        let strip = |level: GreekLevel| -> Vec<Value> {
+            quotes_at(level)
+                .into_iter()
+                .map(|quote| {
+                    let mut quote = quote;
+                    if let Some(object) = quote.as_object_mut() {
+                        object.remove("greeks");
+                    }
+                    quote
+                })
+                .collect()
+        };
+
+        let none = strip(GreekLevel::None);
+        assert_eq!(strip(GreekLevel::First), none);
+        assert_eq!(strip(GreekLevel::All), none);
+    }
+}
+
+/// HTTP-level coverage of the `greeks` parameter on the v1 surface.
+///
+/// The conversion tests above call `build_chain_response` directly, which
+/// cannot exercise the query extractor, `map_error`, or the ordering of the
+/// level parse against the store call. v1 is the surface IronCondor is on, so
+/// its rejection path is worth proving through the real routes.
+#[cfg(test)]
+mod tests_v1_greeks_over_http {
+    use super::*;
+    use crate::session::InMemorySessionStore;
+    use actix_web::App;
+    use actix_web::http::StatusCode;
+    use actix_web::test as actix_test;
+    use serde_json::Value;
+
+    /// Mounts the real peek route over an in-memory store.
+    macro_rules! peek_service {
+        () => {{
+            let manager = Arc::new(SessionManager::new(Arc::new(InMemorySessionStore::new())));
+            actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(manager))
+                    .service(web::resource("/api/v1/chain").route(web::get().to(get_current_step))),
+            )
+            .await
+        }};
+    }
+
+    /// An unknown level is a typed 400 naming the field.
+    ///
+    /// The id below is well formed but belongs to no session, and the response
+    /// is still a `400` rather than a `404`: the level is resolved before the
+    /// store is touched, which is the ordering the step endpoint depends on.
+    #[actix_web::test]
+    async fn test_an_unknown_greek_level_is_a_typed_400_on_v1() {
+        let app = peek_service!();
+
+        for level in ["second", "ALL", ""] {
+            let uri = format!(
+                "/api/v1/chain?sessionid=6ba7b810-9dad-11d1-80b4-00c04fd430c8&greeks={level}"
+            );
+            let request = actix_test::TestRequest::get().uri(&uri).to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "greeks={level} must be rejected before the store is read"
+            );
+            let body: Value = actix_test::read_body_json(response).await;
+            assert_eq!(
+                body.get("field").and_then(Value::as_str),
+                Some("greeks"),
+                "the 400 must name the field: {body}"
+            );
+        }
+    }
+
+    /// A rejected level must not consume a step.
+    ///
+    /// The v2 half of this is hermetic; v1's advance handler extracts a
+    /// `MongoDBRepository`, and actix resolves every extractor before the
+    /// handler runs, so this one needs the live service CI provides.
+    #[actix_web::test]
+    #[ignore = "requires live MongoDB on localhost:27017; run with -- --ignored"]
+    async fn test_an_unknown_greek_level_on_v1_step_does_not_advance() {
+        use crate::infrastructure::{MetricsCollector, init_mongodb};
+        use crate::session::{SimulationMethod, SimulationParameters};
+        use optionstratlib::utils::TimeFrame;
+        use positive::pos_or_panic;
+        use rust_decimal_macros::dec;
+
+        let store = Arc::new(InMemorySessionStore::new());
+        let manager = Arc::new(SessionManager::new(store));
+        let parameters = SimulationParameters {
+            symbol: "AAPL".to_string(),
+            steps: 10,
+            initial_price: pos_or_panic!(100.0),
+            days_to_expiration: pos_or_panic!(30.0),
+            volatility: pos_or_panic!(0.2),
+            risk_free_rate: dec!(0.04),
+            dividend_yield: pos_or_panic!(0.015),
+            method: SimulationMethod::GeometricBrownian {
+                dt: pos_or_panic!(0.004),
+                drift: dec!(0.0),
+                volatility: pos_or_panic!(0.2),
+            },
+            time_frame: TimeFrame::Day,
+            chain_size: Some(3),
+            strike_interval: Some(pos_or_panic!(5.0)),
+            skew_slope: Some(dec!(-0.2)),
+            smile_curve: Some(dec!(0.5)),
+            spread: Some(pos_or_panic!(0.02)),
+            seed: Some(42),
+        };
+        let session = match manager.create_session(parameters).await {
+            Ok(session) => session,
+            Err(error) => panic!("the fixture session must be created: {error}"),
+        };
+        let session_id = session.id;
+
+        let metrics = match MetricsCollector::new() {
+            Ok(metrics) => Arc::new(metrics),
+            Err(error) => panic!("the metrics collector must build: {error}"),
+        };
+        let mongo = match init_mongodb().await {
+            Ok(repository) => repository,
+            Err(error) => panic!("this test needs a live MongoDB: {error}"),
+        };
+
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(manager.clone()))
+                .app_data(web::Data::new(metrics))
+                .app_data(web::Data::new(mongo))
+                .service(web::resource("/api/v1/chain/step").route(web::post().to(advance_step))),
+        )
+        .await;
+
+        let request = actix_test::TestRequest::post()
+            .uri(&format!(
+                "/api/v1/chain/step?sessionid={session_id}&greeks=second"
+            ))
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(body.get("field").and_then(Value::as_str), Some("greeks"));
+
+        match manager.get_session(session_id).await {
+            Ok(session) => assert_eq!(
+                session.current_step, 0,
+                "a rejected level must not consume a step"
+            ),
+            Err(error) => panic!("the session must still exist: {error}"),
+        }
+    }
+
+    /// A known level reaches the store, so the parameter is not swallowing
+    /// well-formed requests: an unknown session is a `404`, not a `400`.
+    #[actix_web::test]
+    async fn test_a_known_greek_level_reaches_the_store_on_v1() {
+        let app = peek_service!();
+
+        for level in ["", "?", "&greeks=none", "&greeks=first", "&greeks=all"] {
+            let query = match level {
+                "" | "?" => String::new(),
+                other => other.to_string(),
+            };
+            let uri =
+                format!("/api/v1/chain?sessionid=6ba7b810-9dad-11d1-80b4-00c04fd430c8{query}");
+            let request = actix_test::TestRequest::get().uri(&uri).to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "a valid level must reach the store, for {uri}"
+            );
+        }
     }
 }

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -20,8 +20,10 @@
 //! first".
 
 use crate::api::rest::error::map_error;
+use crate::api::rest::greeks::GreekLevel;
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::responses_v2::{SimulationResponse, SnapshotResponse, snapshot_response};
+use crate::domain::series::SeriesSnapshot;
 use crate::session::{SessionV2, SimulationManager, SimulationParametersV2};
 use crate::utils::ChainError;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
@@ -46,6 +48,49 @@ pub(crate) struct AdvanceQuery {
     /// the actual cursor and nothing is consumed.
     #[serde(default)]
     pub(crate) expected_step: Option<usize>,
+    /// How much of the greek set the snapshot should carry: `none` (the
+    /// default), `first` or `all`. Kept as a raw string so an unknown value is
+    /// a typed `400` naming the field rather than actix's untyped query
+    /// rejection.
+    #[serde(default)]
+    pub(crate) greeks: Option<String>,
+}
+
+/// The query of a snapshot peek.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SnapshotQuery {
+    /// How much of the greek set to carry. See [`AdvanceQuery::greeks`].
+    #[serde(default)]
+    pub(crate) greeks: Option<String>,
+}
+
+/// Renders a snapshot DTO, off the runtime whenever greeks have to be priced.
+///
+/// At the default level the conversion is a field-by-field copy of numbers the
+/// snapshot already holds, and stays inline. Above it, upstream's
+/// `calculate_greeks` runs per strike per style at roughly 40 µs a contract.
+/// `DEFAULT_MAX_SNAPSHOT_CONTRACTS` is 200 000, so a single `?greeks=all` call
+/// can be seconds of uninterrupted CPU — which, left on a worker, stalls every
+/// other request that worker is holding. It goes to the blocking pool, for the
+/// same reason and in the same way as the tape build in
+/// [`crate::session::SimulationManager`] and the export path.
+///
+/// The simulation and the snapshot are moved rather than borrowed: both are
+/// already owned clones handed back by the manager, and moving them keeps the
+/// blocking task `'static` without a second copy of a snapshot that may hold
+/// hundreds of thousands of contracts.
+async fn render_snapshot(
+    simulation: SessionV2,
+    snapshot: SeriesSnapshot,
+    level: GreekLevel,
+) -> Result<SnapshotResponse, ChainError> {
+    if !level.wants_greeks() {
+        return Ok(snapshot_response(&simulation, &snapshot, level));
+    }
+
+    tokio::task::spawn_blocking(move || snapshot_response(&simulation, &snapshot, level))
+        .await
+        .map_err(|error| ChainError::Internal(format!("greek pricing failed: {error}")))
 }
 
 /// Parses a path id, reporting a malformed one as a validation failure naming
@@ -127,10 +172,13 @@ pub(crate) async fn get_simulation(
     description = "Peek the snapshot at the current cursor. Safe and repeatable: it never \
         advances the cursor and never persists anything, so calling it twice returns the \
         same market. To advance, use POST /api/v2/simulations/{id}/step.",
-    params(("id" = String, Path, description = "The simulation's identifier")),
+    params(
+        ("id" = String, Path, description = "The simulation's identifier"),
+        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
+    ),
     responses(
         (status = 200, description = "The snapshot at the current cursor", body = SnapshotResponse),
-        (status = 400, description = "Malformed id, or the simulation is in a terminal error state"),
+        (status = 400, description = "Malformed id, an unknown `greeks` level, or a simulation in a terminal error state. The malformed-id and unknown-level bodies are the typed `{error, field}` of ValidationErrorResponse, with `field` = `id` or `greeks`; a terminal state carries `error` alone."),
         (status = 404, description = "Simulation not found"),
         (status = 410, description = "Simulation completed; there is no current step"),
         (status = 500, description = "Internal server error")
@@ -140,6 +188,7 @@ pub(crate) async fn peek_snapshot(
     req: HttpRequest,
     manager: web::Data<Arc<SimulationManager>>,
     path: web::Path<SimulationPath>,
+    query: web::Query<SnapshotQuery>,
 ) -> impl Responder {
     info!("{} {}", req.method(), req.path());
 
@@ -147,11 +196,17 @@ pub(crate) async fn peek_snapshot(
         Ok(id) => id,
         Err(error) => return map_error(error),
     };
+    // Resolved before the snapshot is built: an unknown level costs nothing.
+    let level = match GreekLevel::parse(query.greeks.as_deref()) {
+        Ok(level) => level,
+        Err(error) => return map_error(error),
+    };
 
     match manager.peek(id).await {
-        Ok((simulation, snapshot)) => {
-            HttpResponse::Ok().json(snapshot_response(&simulation, &snapshot))
-        }
+        Ok((simulation, snapshot)) => match render_snapshot(simulation, snapshot, level).await {
+            Ok(response) => HttpResponse::Ok().json(response),
+            Err(error) => map_error(error),
+        },
         Err(error) => map_error(error),
     }
 }
@@ -166,11 +221,12 @@ pub(crate) async fn peek_snapshot(
         the step, the call returns 412 with the actual cursor instead of consuming another.",
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
-        ("expected_step" = Option<usize>, Query, description = "Expected current cursor; a mismatch returns 412 without advancing")
+        ("expected_step" = Option<usize>, Query, description = "Expected current cursor; a mismatch returns 412 without advancing"),
+        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Served the snapshot and advanced once", body = SnapshotResponse),
-        (status = 400, description = "Malformed id, or the simulation is in a terminal error state"),
+        (status = 400, description = "Malformed id, an unknown `greeks` level, or a simulation in a terminal error state. The malformed-id and unknown-level bodies are the typed `{error, field}` of ValidationErrorResponse, with `field` = `id` or `greeks`; a terminal state carries `error` alone."),
         (status = 404, description = "Simulation not found"),
         (status = 409, description = "Another request advanced the simulation first; re-read and retry"),
         (status = 410, description = "Simulation completed; no further steps"),
@@ -190,6 +246,12 @@ pub(crate) async fn advance_simulation(
         Ok(id) => id,
         Err(error) => return map_error(error),
     };
+    // Rejected before the step is consumed: an unknown level must not advance
+    // the cursor on its way to a 400.
+    let level = match GreekLevel::parse(query.greeks.as_deref()) {
+        Ok(level) => level,
+        Err(error) => return map_error(error),
+    };
 
     // The precondition is a transport-level check, resolved before anything is
     // built or persisted, so a mismatch costs nothing.
@@ -204,9 +266,10 @@ pub(crate) async fn advance_simulation(
     }
 
     match manager.advance(id).await {
-        Ok((simulation, snapshot)) => {
-            HttpResponse::Ok().json(snapshot_response(&simulation, &snapshot))
-        }
+        Ok((simulation, snapshot)) => match render_snapshot(simulation, snapshot, level).await {
+            Ok(response) => HttpResponse::Ok().json(response),
+            Err(error) => map_error(error),
+        },
         Err(error) => map_error(error),
     }
 }
@@ -376,6 +439,289 @@ mod tests {
             Some(id) => id.to_string(),
             None => panic!("the response must carry an id: {body}"),
         }
+    }
+
+    /// Every quote in a snapshot body, call and put alike.
+    fn quotes(body: &Value) -> Vec<&Value> {
+        let chains = match body.get("chains").and_then(Value::as_array) {
+            Some(chains) => chains,
+            None => panic!("the snapshot must carry chains: {body}"),
+        };
+        let mut quotes = Vec::new();
+        for chain in chains {
+            let contracts = match chain.get("contracts").and_then(Value::as_array) {
+                Some(contracts) => contracts,
+                None => panic!("every chain must carry contracts: {chain}"),
+            };
+            for contract in contracts {
+                for side in ["call", "put"] {
+                    match contract.get(side) {
+                        Some(quote) => quotes.push(quote),
+                        None => panic!("every contract must carry a {side}: {contract}"),
+                    }
+                }
+            }
+        }
+        assert!(!quotes.is_empty(), "the snapshot must quote something");
+        quotes
+    }
+
+    /// Fetches the current snapshot at a greek level, or with no parameter at
+    /// all when `query` is empty.
+    macro_rules! snapshot {
+        ($app:expr, $id:expr, $query:expr) => {{
+            let uri = format!("/api/v2/simulations/{}/snapshot{}", $id, $query);
+            let request = actix_test::TestRequest::get().uri(&uri).to_request();
+            let response = actix_test::call_service(&$app, request).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let body: Value = actix_test::read_body_json(response).await;
+            body
+        }};
+    }
+
+    /// The regression that protects every existing client: with no `greeks`
+    /// parameter the snapshot is byte-identical to `greeks=none`, and neither
+    /// carries the key at all. A client that ignores unknown fields is
+    /// unaffected either way, but one that compares payloads is not, and the
+    /// tape is meant to be comparable.
+    #[actix_web::test]
+    async fn test_the_default_snapshot_is_identical_to_greeks_none() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        let default = snapshot!(app, id, "");
+        let explicit = snapshot!(app, id, "?greeks=none");
+
+        assert_eq!(default, explicit);
+        for quote in quotes(&default) {
+            assert!(
+                quote.get("greeks").is_none(),
+                "the default quote must carry no greeks key: {quote}"
+            );
+        }
+    }
+
+    /// `greeks=all` carries all twelve values for both styles on every strike.
+    #[actix_web::test]
+    async fn test_greeks_all_carries_the_twelve_values_per_style() {
+        const EXPECTED: [&str; 12] = [
+            "delta", "gamma", "theta", "vega", "rho", "rho_d", "alpha", "vanna", "vomma", "veta",
+            "charm", "color",
+        ];
+
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+        let body = snapshot!(app, id, "?greeks=all");
+
+        for quote in quotes(&body) {
+            let greeks = match quote.get("greeks").and_then(Value::as_object) {
+                Some(greeks) => greeks,
+                None => panic!("greeks=all must carry a greeks object: {quote}"),
+            };
+            for key in EXPECTED {
+                assert!(
+                    greeks.contains_key(key),
+                    "greeks=all must carry {key}: {quote}"
+                );
+            }
+            assert_eq!(
+                greeks.len(),
+                EXPECTED.len(),
+                "greeks=all must carry exactly the twelve values: {quote}"
+            );
+        }
+    }
+
+    /// `greeks=first` carries the four first-order values the default response
+    /// does not already have, and nothing beyond them. `delta` stays where it
+    /// is, on the quote itself, so the two cannot drift.
+    #[actix_web::test]
+    async fn test_greeks_first_carries_only_the_remaining_first_order_set() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+        let body = snapshot!(app, id, "?greeks=first");
+
+        for quote in quotes(&body) {
+            let greeks = match quote.get("greeks").and_then(Value::as_object) {
+                Some(greeks) => greeks,
+                None => panic!("greeks=first must carry a greeks object: {quote}"),
+            };
+            let mut keys: Vec<&str> = greeks.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            assert_eq!(keys, vec!["rho", "rho_d", "theta", "vega"], "{quote}");
+            assert!(
+                quote.get("delta").is_some(),
+                "delta stays on the quote itself: {quote}"
+            );
+        }
+    }
+
+    /// The per-style split is real, not one value copied twice: `charm`
+    /// differs between the call and the put, and `rho` carries opposite signs.
+    #[actix_web::test]
+    async fn test_the_call_and_put_greeks_are_genuinely_different() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+        let body = snapshot!(app, id, "?greeks=all");
+
+        let chains = match body.get("chains").and_then(Value::as_array) {
+            Some(chains) => chains,
+            None => panic!("the snapshot must carry chains: {body}"),
+        };
+        let contracts = match chains
+            .first()
+            .and_then(|chain| chain.get("contracts"))
+            .and_then(Value::as_array)
+        {
+            Some(contracts) => contracts,
+            None => panic!("the first chain must carry contracts: {body}"),
+        };
+
+        // Decimal-valued greeks arrive as strings; parsing keeps the assertion
+        // about the numbers rather than about their rendering.
+        let greek = |contract: &Value, side: &str, name: &str| -> f64 {
+            let raw = contract
+                .get(side)
+                .and_then(|quote| quote.get("greeks"))
+                .and_then(|greeks| greeks.get(name))
+                .and_then(Value::as_str);
+            match raw {
+                Some(value) => match value.parse::<f64>() {
+                    Ok(parsed) => parsed,
+                    Err(error) => panic!("{side}.{name} must be numeric: {value} ({error})"),
+                },
+                None => panic!("{side}.{name} must be present: {contract}"),
+            }
+        };
+
+        for contract in contracts {
+            assert_ne!(
+                greek(contract, "call", "charm"),
+                greek(contract, "put", "charm"),
+                "charm must differ between the styles: {contract}"
+            );
+            let call_rho = greek(contract, "call", "rho");
+            let put_rho = greek(contract, "put", "rho");
+            assert!(
+                call_rho * put_rho < 0.0,
+                "rho must carry opposite signs, got {call_rho} and {put_rho}"
+            );
+        }
+    }
+
+    /// An unknown level is a typed `400` naming the field, not a silent
+    /// downgrade to the default.
+    #[actix_web::test]
+    async fn test_an_unknown_greek_level_is_a_typed_400() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        for uri in [
+            format!("/api/v2/simulations/{id}/snapshot?greeks=second"),
+            format!("/api/v2/simulations/{id}/snapshot?greeks=ALL"),
+        ] {
+            let request = actix_test::TestRequest::get().uri(&uri).to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "for {uri}");
+            let body: Value = actix_test::read_body_json(response).await;
+            assert_eq!(
+                body.get("field").and_then(Value::as_str),
+                Some("greeks"),
+                "the 400 must name the field: {body}"
+            );
+        }
+    }
+
+    /// The step endpoint takes the same parameter, and rejects an unknown one
+    /// WITHOUT consuming a step — a 400 that advanced the cursor would make an
+    /// error unrepeatable.
+    #[actix_web::test]
+    async fn test_an_unknown_greek_level_on_step_does_not_advance() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        let request = actix_test::TestRequest::post()
+            .uri(&format!("/api/v2/simulations/{id}/step?greeks=second"))
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let request = actix_test::TestRequest::get()
+            .uri(&format!("/api/v2/simulations/{id}"))
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(
+            body.get("cursor")
+                .and_then(|cursor| cursor.get("current_step"))
+                .and_then(Value::as_u64),
+            Some(0),
+            "a rejected level must not consume a step: {body}"
+        );
+    }
+
+    /// The step endpoint serves the greeks too, so a stepping client does not
+    /// have to peek separately to get them.
+    #[actix_web::test]
+    async fn test_the_step_endpoint_serves_the_requested_greeks() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        let request = actix_test::TestRequest::post()
+            .uri(&format!("/api/v2/simulations/{id}/step?greeks=all"))
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = actix_test::read_body_json(response).await;
+
+        for quote in quotes(&body) {
+            assert!(
+                quote
+                    .get("greeks")
+                    .and_then(|greeks| greeks.get("vomma"))
+                    .is_some(),
+                "a stepped snapshot must carry the full set: {quote}"
+            );
+        }
+    }
+
+    /// Asking for greeks changes nothing about the market itself: the prices,
+    /// the delta and the gamma a snapshot serves are identical at all three
+    /// levels. The greeks are read off the same option, never fed back into it.
+    #[actix_web::test]
+    async fn test_the_greek_level_does_not_move_the_quoted_market() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        let strip = |body: &Value| -> Value {
+            let mut stripped = body.clone();
+            if let Some(chains) = stripped.get_mut("chains").and_then(Value::as_array_mut) {
+                for chain in chains {
+                    if let Some(contracts) =
+                        chain.get_mut("contracts").and_then(Value::as_array_mut)
+                    {
+                        for contract in contracts {
+                            for side in ["call", "put"] {
+                                if let Some(quote) =
+                                    contract.get_mut(side).and_then(Value::as_object_mut)
+                                {
+                                    quote.remove("greeks");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            stripped
+        };
+
+        let none = snapshot!(app, id, "?greeks=none");
+        let first = snapshot!(app, id, "?greeks=first");
+        let all = snapshot!(app, id, "?greeks=all");
+
+        assert_eq!(strip(&first), none);
+        assert_eq!(strip(&all), none);
     }
 
     /// Creating returns 201 and echoes every replay input.
@@ -802,6 +1148,153 @@ mod tests {
         };
 
         assert_eq!(snapshot_of(&first).await, snapshot_of(&second).await);
+    }
+
+    /// Reproducibility holds at the new level too: two simulations built from
+    /// the same body — hence the same seed — serve identical `greeks=all`
+    /// snapshots, greek for greek.
+    ///
+    /// The domain tape test compares two walks and never sees a greek level,
+    /// so it cannot cover this. IronCondor gates on the served bytes, and the
+    /// greeks are now part of them.
+    #[actix_web::test]
+    async fn test_the_same_seed_serves_the_same_greeks() {
+        let app = v2_service!();
+        let first = id_of(&create!(app));
+        let second = id_of(&create!(app));
+        assert_ne!(first, second, "two creations must be distinct simulations");
+
+        let mut left = snapshot!(app, first, "?greeks=all");
+        let mut right = snapshot!(app, second, "?greeks=all");
+        // The id is the one thing that legitimately differs.
+        for body in [&mut left, &mut right] {
+            if let Some(object) = body.as_object_mut() {
+                object.remove("id");
+            }
+        }
+
+        assert_eq!(left, right);
+    }
+
+    /// The style-independent greeks really are shared, and the style-dependent
+    /// ones really are not.
+    ///
+    /// The crate docs make this claim to clients deciding what to store per
+    /// side; without a test it is just a sentence. `gamma`, `vega`, `vanna`,
+    /// `vomma`, `veta` and `color` do not depend on the option style, so a
+    /// call and a put on the same strike must agree on them exactly.
+    #[actix_web::test]
+    async fn test_the_style_independent_greeks_agree_across_the_two_sides() {
+        const SHARED: [&str; 6] = ["gamma", "vega", "vanna", "vomma", "veta", "color"];
+        const PER_STYLE: [&str; 4] = ["delta", "theta", "rho", "rho_d"];
+
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+        let body = snapshot!(app, id, "?greeks=all");
+
+        let chains = match body.get("chains").and_then(Value::as_array) {
+            Some(chains) => chains,
+            None => panic!("the snapshot must carry chains: {body}"),
+        };
+        for chain in chains {
+            let contracts = match chain.get("contracts").and_then(Value::as_array) {
+                Some(contracts) => contracts,
+                None => panic!("every chain must carry contracts: {chain}"),
+            };
+            for contract in contracts {
+                let side = |name: &str, greek: &str| -> Value {
+                    contract
+                        .get(name)
+                        .and_then(|quote| quote.get("greeks"))
+                        .and_then(|greeks| greeks.get(greek))
+                        .cloned()
+                        .unwrap_or(Value::Null)
+                };
+                for greek in SHARED {
+                    assert_eq!(
+                        side("call", greek),
+                        side("put", greek),
+                        "{greek} does not depend on the style: {contract}"
+                    );
+                }
+                for greek in PER_STYLE {
+                    assert_ne!(
+                        side("call", greek),
+                        side("put", greek),
+                        "{greek} depends on the style: {contract}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The snapshot's `delta` and `gamma` agree with the `f64` mirrors the
+    /// quote and the contract already carried.
+    ///
+    /// At `greeks=all` a response carries each of those numbers twice, from
+    /// two independent upstream computations. If they ever disagreed a client
+    /// would have to know which one to believe, so the agreement is pinned
+    /// rather than assumed.
+    #[actix_web::test]
+    async fn test_the_snapshot_agrees_with_the_mirrors_it_duplicates() {
+        // The mirrors are rendered as `f64`, the snapshot at full decimal
+        // precision, so they agree to within the `f64` round-trip and no more.
+        const TOLERANCE: f64 = 1e-12;
+
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+        let body = snapshot!(app, id, "?greeks=all");
+
+        let parse = |value: Option<&Value>, what: &str| -> f64 {
+            match value.and_then(Value::as_str) {
+                Some(raw) => match raw.parse::<f64>() {
+                    Ok(parsed) => parsed,
+                    Err(error) => panic!("{what} must be numeric: {raw} ({error})"),
+                },
+                None => panic!("{what} must be present"),
+            }
+        };
+
+        let chains = match body.get("chains").and_then(Value::as_array) {
+            Some(chains) => chains,
+            None => panic!("the snapshot must carry chains: {body}"),
+        };
+        for chain in chains {
+            let contracts = match chain.get("contracts").and_then(Value::as_array) {
+                Some(contracts) => contracts,
+                None => panic!("every chain must carry contracts: {chain}"),
+            };
+            for contract in contracts {
+                let mirror_gamma = match contract.get("gamma").and_then(Value::as_f64) {
+                    Some(gamma) => gamma,
+                    None => continue,
+                };
+                for side in ["call", "put"] {
+                    let quote = match contract.get(side) {
+                        Some(quote) => quote,
+                        None => panic!("every contract must carry a {side}: {contract}"),
+                    };
+                    let greeks = match quote.get("greeks") {
+                        Some(greeks) => greeks,
+                        None => panic!("greeks=all must carry a greeks object: {quote}"),
+                    };
+                    let snapshot_gamma = parse(greeks.get("gamma"), "the snapshot gamma");
+                    assert!(
+                        (snapshot_gamma - mirror_gamma).abs() < TOLERANCE,
+                        "gamma disagrees with its mirror: {snapshot_gamma} vs {mirror_gamma}"
+                    );
+
+                    if let Some(mirror_delta) = quote.get("delta").and_then(Value::as_f64) {
+                        let snapshot_delta = parse(greeks.get("delta"), "the snapshot delta");
+                        assert!(
+                            (snapshot_delta - mirror_delta).abs() < TOLERANCE,
+                            "{side} delta disagrees with its mirror: \
+                             {snapshot_delta} vs {mirror_delta}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// A malformed id is a validation failure naming the field, not an opaque

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -20,7 +20,7 @@
 //! first".
 
 use crate::api::rest::error::map_error;
-use crate::api::rest::greeks::GreekLevel;
+use crate::api::rest::greeks::{GreekLevel, render_body};
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::responses_v2::{SimulationResponse, SnapshotResponse, snapshot_response};
 use crate::domain::series::SeriesSnapshot;
@@ -42,6 +42,7 @@ pub(crate) struct SimulationPath {
 
 /// Query parameters for the advance command.
 #[derive(Debug, Default, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AdvanceQuery {
     /// Optional expected cursor. When supplied, the advance proceeds only if
     /// the simulation is at exactly this step; otherwise `412` is returned with
@@ -58,39 +59,38 @@ pub(crate) struct AdvanceQuery {
 
 /// The query of a snapshot peek.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SnapshotQuery {
     /// How much of the greek set to carry. See [`AdvanceQuery::greeks`].
     #[serde(default)]
     pub(crate) greeks: Option<String>,
 }
 
-/// Renders a snapshot DTO, off the runtime whenever greeks have to be priced.
+/// Renders a snapshot body, under the shared greek admission bound.
 ///
-/// At the default level the conversion is a field-by-field copy of numbers the
-/// snapshot already holds, and stays inline. Above it, upstream's
-/// `calculate_greeks` runs per strike per style at roughly 40 µs a contract.
-/// `DEFAULT_MAX_SNAPSHOT_CONTRACTS` is 200 000, so a single `?greeks=all` call
-/// can be seconds of uninterrupted CPU — which, left on a worker, stalls every
-/// other request that worker is holding. It goes to the blocking pool, for the
-/// same reason and in the same way as the tape build in
-/// [`crate::session::SimulationManager`] and the export path.
-///
-/// The simulation and the snapshot are moved rather than borrowed: both are
-/// already owned clones handed back by the manager, and moving them keeps the
-/// blocking task `'static` without a second copy of a snapshot that may hold
-/// hundreds of thousands of contracts.
+/// See [`crate::api::rest::greeks::render_body`]: above the default level the
+/// pricing AND the serialisation happen together in one admitted blocking job,
+/// and the handler writes the bytes it returns. The simulation and the snapshot
+/// are moved rather than borrowed — both are already owned clones from the
+/// manager, and moving them keeps the job `'static` without a second copy of a
+/// snapshot that may hold hundreds of thousands of contracts.
 async fn render_snapshot(
     simulation: SessionV2,
     snapshot: SeriesSnapshot,
     level: GreekLevel,
-) -> Result<SnapshotResponse, ChainError> {
-    if !level.wants_greeks() {
-        return Ok(snapshot_response(&simulation, &snapshot, level));
-    }
+) -> Result<Vec<u8>, ChainError> {
+    render_body(level, move || {
+        snapshot_response(&simulation, &snapshot, level)
+    })
+    .await
+}
 
-    tokio::task::spawn_blocking(move || snapshot_response(&simulation, &snapshot, level))
-        .await
-        .map_err(|error| ChainError::Internal(format!("greek pricing failed: {error}")))
+/// Writes an already-serialised JSON body.
+#[must_use]
+fn json_body(bytes: Vec<u8>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body(bytes)
 }
 
 /// Parses a path id, reporting a malformed one as a validation failure naming
@@ -174,7 +174,7 @@ pub(crate) async fn get_simulation(
         same market. To advance, use POST /api/v2/simulations/{id}/step.",
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
-        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
+        ("greeks" = Option<GreekLevel>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. The one exception is `alpha`, the ratio gamma/theta, which a short position leaves unchanged and which must NOT be scaled or sign-flipped. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "The snapshot at the current cursor", body = SnapshotResponse),
@@ -204,7 +204,7 @@ pub(crate) async fn peek_snapshot(
 
     match manager.peek(id).await {
         Ok((simulation, snapshot)) => match render_snapshot(simulation, snapshot, level).await {
-            Ok(response) => HttpResponse::Ok().json(response),
+            Ok(bytes) => json_body(bytes),
             Err(error) => map_error(error),
         },
         Err(error) => map_error(error),
@@ -222,7 +222,7 @@ pub(crate) async fn peek_snapshot(
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
         ("expected_step" = Option<usize>, Query, description = "Expected current cursor; a mismatch returns 412 without advancing"),
-        ("greeks" = Option<String>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. An unknown value is a 400")
+        ("greeks" = Option<GreekLevel>, Query, description = "How much of the greek set to carry: `none` (default), `first` (adds theta, vega, rho, rho_d) or `all` (the full twelve-value snapshot per style). Every value is per ONE LONG CONTRACT: the client applies position sign and size. The one exception is `alpha`, the ratio gamma/theta, which a short position leaves unchanged and which must NOT be scaled or sign-flipped. An unknown value is a 400")
     ),
     responses(
         (status = 200, description = "Served the snapshot and advanced once", body = SnapshotResponse),
@@ -267,7 +267,7 @@ pub(crate) async fn advance_simulation(
 
     match manager.advance(id).await {
         Ok((simulation, snapshot)) => match render_snapshot(simulation, snapshot, level).await {
-            Ok(response) => HttpResponse::Ok().json(response),
+            Ok(bytes) => json_body(bytes),
             Err(error) => map_error(error),
         },
         Err(error) => map_error(error),
@@ -332,6 +332,28 @@ pub(crate) async fn delete_simulation(
 /// surfaced verbatim rather than guessed at.
 pub(crate) fn json_error_handler(
     error: actix_web::error::JsonPayloadError,
+    _req: &HttpRequest,
+) -> actix_web::Error {
+    let message = error.to_string();
+    let response =
+        HttpResponse::BadRequest().json(crate::api::rest::responses::ValidationErrorResponse {
+            error: message.clone(),
+            field: field_from_serde_message(&message),
+        });
+    actix_web::error::InternalError::from_response(error, response).into()
+}
+
+/// Renders a rejected QUERY string in the documented `{error, field}` shape.
+///
+/// Without it actix answers a query that fails to deserialize with an untyped
+/// plaintext `400`, which is the one outcome the greek level was built not to
+/// have: `?greek=all` is a misspelling, and a client that gets the default
+/// payload back with a `200` prices a position against greeks it never
+/// received. The query DTOs carry `deny_unknown_fields` so the misspelling is
+/// an error at all, and this turns that error into something a client can act
+/// on — the same treatment [`json_error_handler`] gives a rejected body.
+pub(crate) fn query_error_handler(
+    error: actix_web::error::QueryPayloadError,
     _req: &HttpRequest,
 ) -> actix_web::Error {
     let message = error.to_string();
@@ -584,12 +606,9 @@ mod tests {
                 .get(side)
                 .and_then(|quote| quote.get("greeks"))
                 .and_then(|greeks| greeks.get(name))
-                .and_then(Value::as_str);
+                .and_then(Value::as_f64);
             match raw {
-                Some(value) => match value.parse::<f64>() {
-                    Ok(parsed) => parsed,
-                    Err(error) => panic!("{side}.{name} must be numeric: {value} ({error})"),
-                },
+                Some(value) => value,
                 None => panic!("{side}.{name} must be present: {contract}"),
             }
         };
@@ -628,6 +647,37 @@ mod tests {
                 body.get("field").and_then(Value::as_str),
                 Some("greeks"),
                 "the 400 must name the field: {body}"
+            );
+        }
+    }
+
+    /// A MISSPELLED parameter is a typed 400, not a silent downgrade.
+    ///
+    /// `?greek=all` used to be accepted and ignored, so a client that fat
+    /// fingered the key got a `200` carrying the default payload and priced a
+    /// position against greeks it never received — exactly the failure the
+    /// unknown-VALUE rejection exists to prevent, reached through the key
+    /// instead. The query DTOs reject unknown keys, and the rejection is
+    /// rendered in the documented shape rather than actix's plaintext.
+    #[actix_web::test]
+    async fn test_a_misspelled_query_key_is_a_typed_400() {
+        let app = v2_service!();
+        let id = id_of(&create!(app));
+
+        for key in ["greek", "Greeks", "greeks_level"] {
+            let uri = format!("/api/v2/simulations/{id}/snapshot?{key}=all");
+            let request = actix_test::TestRequest::get().uri(&uri).to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "?{key}=all must be rejected, not ignored"
+            );
+            let body: Value = actix_test::read_body_json(response).await;
+            assert_eq!(
+                body.get("field").and_then(Value::as_str),
+                Some(key),
+                "the 400 must name the offending key: {body}"
             );
         }
     }
@@ -1246,11 +1296,8 @@ mod tests {
         let body = snapshot!(app, id, "?greeks=all");
 
         let parse = |value: Option<&Value>, what: &str| -> f64 {
-            match value.and_then(Value::as_str) {
-                Some(raw) => match raw.parse::<f64>() {
-                    Ok(parsed) => parsed,
-                    Err(error) => panic!("{what} must be numeric: {raw} ({error})"),
-                },
+            match value.and_then(Value::as_f64) {
+                Some(number) => number,
                 None => panic!("{what} must be present"),
             }
         };

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod controller;
 mod error;
 pub(crate) mod export;
 mod favicon;
+pub(crate) mod greeks;
 pub(crate) mod handlers;
 pub(crate) mod handlers_v2;
 pub(crate) mod limits;

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -607,6 +607,7 @@ impl fmt::Display for ApiWalkType {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SessionId {
     #[serde(rename = "sessionid")]
     pub(crate) session_id: String,

--- a/src/api/rest/responses.rs
+++ b/src/api/rest/responses.rs
@@ -1,3 +1,4 @@
+use crate::api::rest::greeks::GreeksResponse;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::ToSchema;
@@ -92,6 +93,15 @@ pub struct OptionPriceResponse {
     pub mid: Option<f64>,
     /// The delta of the option
     pub delta: Option<f64>,
+    /// The greeks selected by the `greeks` query parameter, per one long
+    /// contract. Absent entirely at the default level, so a client that does
+    /// not ask sees the response it has always seen; `first` carries the
+    /// remaining first-order greeks and `all` the full twelve-value snapshot.
+    ///
+    /// Decimal-valued, so these arrive as JSON strings rather than numbers:
+    /// they are the upstream values verbatim, not a lossy `f64` view of them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub greeks: Option<GreeksResponse>,
 }
 
 /// Simplified session information for inclusion in chain responses.

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -17,6 +17,7 @@
 //! is deterministic. Surfacing the stamp would put a value in the contract that
 //! changes between two otherwise-identical replays.
 
+use crate::api::rest::greeks::{GreekLevel, GreeksResponse, greeks_for};
 use crate::domain::series::SeriesSnapshot;
 use crate::session::{ExpiryRule, ExpiryRuleKind, SessionV2};
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -183,6 +184,15 @@ pub struct OptionQuoteResponse {
     pub mid: Option<f64>,
     /// Delta.
     pub delta: Option<f64>,
+    /// The greeks selected by the `greeks` query parameter, per one long
+    /// contract. Absent entirely at the default level, so a client that does
+    /// not ask sees the response it has always seen; `first` carries the
+    /// remaining first-order greeks and `all` the full twelve-value snapshot.
+    ///
+    /// Decimal-valued, so these arrive as JSON strings rather than numbers:
+    /// they are the upstream values verbatim, not a lossy `f64` view of them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub greeks: Option<GreeksResponse>,
 }
 
 /// One strike of one expiration.
@@ -236,25 +246,36 @@ pub struct SnapshotResponse {
     pub chains: Vec<ExpiryChainResponse>,
 }
 
-impl From<&OptionData> for ContractResponse {
-    fn from(data: &OptionData) -> Self {
-        Self {
-            strike: data.strike_price.to_f64(),
-            implied_volatility: data.implied_volatility.to_f64(),
-            gamma: decimal_to_f64(data.gamma),
-            call: OptionQuoteResponse {
-                bid: data.call_bid.map(|value| value.to_f64()),
-                ask: data.call_ask.map(|value| value.to_f64()),
-                mid: data.call_middle.map(|value| value.to_f64()),
-                delta: decimal_to_f64(data.delta_call),
-            },
-            put: OptionQuoteResponse {
-                bid: data.put_bid.map(|value| value.to_f64()),
-                ask: data.put_ask.map(|value| value.to_f64()),
-                mid: data.put_middle.map(|value| value.to_f64()),
-                delta: decimal_to_f64(data.delta_put),
-            },
-        }
+/// Views one strike at the requested greek level.
+///
+/// A free function rather than a `From` impl because the level has to reach it:
+/// the same `OptionData` renders three different payloads depending on what the
+/// caller asked for. `implied_volatility`, `gamma` and the per-side `delta`
+/// keep reading the convenience mirrors on `OptionData` — computed
+/// independently of the snapshots, and defined at expiry and at zero
+/// volatility where the full set is not — so the default response is
+/// unchanged at every strike, degenerate ones included.
+#[must_use]
+pub(crate) fn contract_response(data: &OptionData, level: GreekLevel) -> ContractResponse {
+    let (call_greeks, put_greeks) = greeks_for(data, level);
+    ContractResponse {
+        strike: data.strike_price.to_f64(),
+        implied_volatility: data.implied_volatility.to_f64(),
+        gamma: decimal_to_f64(data.gamma),
+        call: OptionQuoteResponse {
+            bid: data.call_bid.map(|value| value.to_f64()),
+            ask: data.call_ask.map(|value| value.to_f64()),
+            mid: data.call_middle.map(|value| value.to_f64()),
+            delta: decimal_to_f64(data.delta_call),
+            greeks: call_greeks,
+        },
+        put: OptionQuoteResponse {
+            bid: data.put_bid.map(|value| value.to_f64()),
+            ask: data.put_ask.map(|value| value.to_f64()),
+            mid: data.put_middle.map(|value| value.to_f64()),
+            delta: decimal_to_f64(data.delta_put),
+            greeks: put_greeks,
+        },
     }
 }
 
@@ -375,6 +396,7 @@ fn render_system_time(time: std::time::SystemTime) -> String {
 pub(crate) fn snapshot_response(
     simulation: &SessionV2,
     snapshot: &SeriesSnapshot,
+    level: GreekLevel,
 ) -> SnapshotResponse {
     SnapshotResponse {
         id: simulation.id.to_string(),
@@ -397,7 +419,11 @@ pub(crate) fn snapshot_response(
                 expires_at: render_instant(chain.expires_at),
                 days_to_expiration: chain.days_to_expiration.to_f64(),
                 labels: chain.labels.clone(),
-                contracts: chain.chain.iter().map(Into::into).collect(),
+                contracts: chain
+                    .chain
+                    .iter()
+                    .map(|data| contract_response(data, level))
+                    .collect(),
             })
             .collect(),
     }

--- a/src/api/rest/routes.rs
+++ b/src/api/rest/routes.rs
@@ -5,7 +5,7 @@ use crate::api::rest::handlers::{
 };
 use crate::api::rest::handlers_v2::{
     advance_simulation, create_simulation, delete_simulation, get_simulation, json_error_handler,
-    peek_snapshot,
+    peek_snapshot, query_error_handler,
 };
 use crate::api::rest::middleware::metrics_endpoint;
 use crate::api::rest::swagger::ApiDoc;
@@ -76,6 +76,10 @@ pub fn configure_routes(
     cfg.app_data(web::Data::new(session_manager))
         .app_data(web::Data::new(metrics_collector.clone()))
         .app_data(web::Data::new(mongodb_repo))
+        // v1's query DTOs reject unknown keys too, for the same reason: a
+        // misspelled `greeks` must not read as the default level. The rejection
+        // is rendered in the `{error, field}` shape v1 already documents.
+        .app_data(web::QueryConfig::default().error_handler(query_error_handler))
         .service(
             web::resource("/api/v1/chain")
                 .route(web::post().to(create_session))
@@ -133,6 +137,11 @@ pub(crate) fn configure_v2_routes(
         // without this handler actix renders them as plaintext and the
         // structured field is lost.
         .app_data(web::JsonConfig::default().error_handler(json_error_handler))
+        // Same treatment for the query string. The v2 query DTOs reject unknown
+        // keys, so a misspelled `?greek=all` is an error rather than a silent
+        // downgrade to the default level; without this it would surface as
+        // actix's untyped plaintext instead of the documented shape.
+        .app_data(web::QueryConfig::default().error_handler(query_error_handler))
         .service(web::resource("/api/v2/simulations").route(web::post().to(create_simulation)))
         .service(
             web::resource("/api/v2/simulations/{id}")

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -37,7 +37,8 @@ use utoipa::OpenApi;
             crate::api::rest::responses_v2::CursorResponse,
             crate::api::rest::greeks::GreeksResponse,
             crate::api::rest::greeks::FirstOrderGreeks,
-            optionstratlib::greeks::GreeksSnapshot,
+            crate::api::rest::greeks::FullGreeks,
+            crate::api::rest::greeks::GreekLevel,
         )
     ),
     tags(
@@ -309,6 +310,65 @@ mod tests {
         }
     }
 
+    /// The `greeks` parameter is published as a closed enum, not a free string.
+    ///
+    /// A generated client then cannot send a fourth value at all, and a reader
+    /// of the document sees the vocabulary without reading the prose. The typed
+    /// 400 stays the runtime backstop for a hand-written client.
+    #[test]
+    fn test_the_greek_parameter_is_published_as_an_enum() {
+        let spec = match ApiDoc::openapi().to_json() {
+            Ok(json) => json,
+            Err(error) => panic!("the OpenAPI document must render: {error}"),
+        };
+        let parsed: Value = match serde_json::from_str(&spec) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("the OpenAPI document must parse: {error}"),
+        };
+
+        let level = parsed
+            .get("components")
+            .and_then(|components| components.get("schemas"))
+            .and_then(|schemas| schemas.get("GreekLevel"));
+        let level = match level {
+            Some(level) => level,
+            None => panic!("the document must carry the GreekLevel schema"),
+        };
+        let values: Vec<&str> = level
+            .get("enum")
+            .and_then(Value::as_array)
+            .map(|values| values.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert_eq!(values, vec!["none", "first", "all"], "{level}");
+
+        for (path, method) in [
+            ("/api/v1/chain", "get"),
+            ("/api/v1/chain/step", "post"),
+            ("/api/v2/simulations/{id}/snapshot", "get"),
+            ("/api/v2/simulations/{id}/step", "post"),
+        ] {
+            let greeks = parsed
+                .get("paths")
+                .and_then(|paths| paths.get(path))
+                .and_then(|operations| operations.get(method))
+                .and_then(|operation| operation.get("parameters"))
+                .and_then(Value::as_array)
+                .and_then(|parameters| {
+                    parameters.iter().find(|parameter| {
+                        parameter.get("name").and_then(Value::as_str) == Some("greeks")
+                    })
+                });
+            let schema = match greeks.and_then(|greeks| greeks.get("schema")) {
+                Some(schema) => schema.to_string(),
+                None => panic!("{method} {path} must give the greeks parameter a schema"),
+            };
+            assert!(
+                schema.contains("GreekLevel"),
+                "{method} {path} must type the parameter as the enum, got {schema}"
+            );
+        }
+    }
+
     /// The greek payload types reach the document, so a generated client has
     /// something to deserialise the new field into.
     #[test]
@@ -330,7 +390,7 @@ mod tests {
             None => panic!("the document must carry component schemas"),
         };
 
-        for name in ["GreeksResponse", "FirstOrderGreeks", "GreeksSnapshot"] {
+        for name in ["GreeksResponse", "FirstOrderGreeks", "FullGreeks"] {
             assert!(
                 schemas.contains_key(name),
                 "the document must carry the {name} schema"
@@ -394,7 +454,7 @@ mod tests {
         assert_eq!(
             refs,
             vec![
-                "#/components/schemas/GreeksSnapshot",
+                "#/components/schemas/FullGreeks",
                 "#/components/schemas/FirstOrderGreeks",
             ],
             "the full snapshot must come first, as it does for serde"

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -35,6 +35,9 @@ use utoipa::OpenApi;
             crate::api::rest::responses_v2::OptionQuoteResponse,
             crate::api::rest::responses_v2::UnderlyingResponse,
             crate::api::rest::responses_v2::CursorResponse,
+            crate::api::rest::greeks::GreeksResponse,
+            crate::api::rest::greeks::FirstOrderGreeks,
+            optionstratlib::greeks::GreeksSnapshot,
         )
     ),
     tags(
@@ -248,6 +251,232 @@ mod tests {
         assert_eq!(step_methods, vec!["post"]);
     }
 
+    /// Every chain-serving operation advertises the `greeks` parameter, names
+    /// its three values, and states the per-one-long-contract convention — the
+    /// one thing a client cannot infer from the numbers and would otherwise
+    /// double-count.
+    #[test]
+    fn test_the_openapi_document_describes_the_greek_parameter() {
+        let spec = match ApiDoc::openapi().to_json() {
+            Ok(json) => json,
+            Err(error) => panic!("the OpenAPI document must render: {error}"),
+        };
+        let parsed: Value = match serde_json::from_str(&spec) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("the OpenAPI document must parse: {error}"),
+        };
+
+        let serving = [
+            ("/api/v1/chain", "get"),
+            ("/api/v1/chain/step", "post"),
+            ("/api/v2/simulations/{id}/snapshot", "get"),
+            ("/api/v2/simulations/{id}/step", "post"),
+        ];
+
+        for (path, method) in serving {
+            let parameters = parsed
+                .get("paths")
+                .and_then(|paths| paths.get(path))
+                .and_then(|operations| operations.get(method))
+                .and_then(|operation| operation.get("parameters"))
+                .and_then(Value::as_array);
+            let parameters = match parameters {
+                Some(parameters) => parameters,
+                None => panic!("{method} {path} must document its parameters"),
+            };
+            let greeks = parameters
+                .iter()
+                .find(|parameter| parameter.get("name").and_then(Value::as_str) == Some("greeks"));
+            let greeks = match greeks {
+                Some(greeks) => greeks,
+                None => panic!("{method} {path} must advertise the greeks parameter"),
+            };
+            assert_eq!(
+                greeks.get("in").and_then(Value::as_str),
+                Some("query"),
+                "{method} {path}"
+            );
+            let description = greeks
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            for expected in ["`none`", "`first`", "`all`", "ONE LONG CONTRACT"] {
+                assert!(
+                    description.contains(expected),
+                    "{method} {path} must document {expected}, got {description}"
+                );
+            }
+        }
+    }
+
+    /// The greek payload types reach the document, so a generated client has
+    /// something to deserialise the new field into.
+    #[test]
+    fn test_the_openapi_document_carries_the_greek_schemas() {
+        let spec = match ApiDoc::openapi().to_json() {
+            Ok(json) => json,
+            Err(error) => panic!("the OpenAPI document must render: {error}"),
+        };
+        let parsed: Value = match serde_json::from_str(&spec) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("the OpenAPI document must parse: {error}"),
+        };
+        let schemas = parsed
+            .get("components")
+            .and_then(|components| components.get("schemas"))
+            .and_then(Value::as_object);
+        let schemas = match schemas {
+            Some(schemas) => schemas,
+            None => panic!("the document must carry component schemas"),
+        };
+
+        for name in ["GreeksResponse", "FirstOrderGreeks", "GreeksSnapshot"] {
+            assert!(
+                schemas.contains_key(name),
+                "the document must carry the {name} schema"
+            );
+        }
+
+        // The quote types carry the optional field the parameter fills in.
+        for quote in ["OptionPriceResponse", "OptionQuoteResponse"] {
+            let properties = schemas
+                .get(quote)
+                .and_then(|schema| schema.get("properties"))
+                .and_then(Value::as_object);
+            match properties {
+                Some(properties) => assert!(
+                    properties.contains_key("greeks"),
+                    "{quote} must document the greeks field"
+                ),
+                None => panic!("{quote} must document its properties"),
+            }
+        }
+    }
+
+    /// The two branches of the greek payload are mutually exclusive.
+    ///
+    /// `GreeksResponse` is an untagged enum, which utoipa renders as a `oneOf`
+    /// — "valid against exactly one". `FirstOrderGreeks` requires only `theta`
+    /// and `vega`, so without `additionalProperties: false` a full twelve-value
+    /// snapshot would satisfy BOTH branches and every `greeks=all` response
+    /// would be invalid against the document this service publishes: strict
+    /// validators reject it, and the `oneOf` deserialisers openapi-generator
+    /// emits for Java, C# and Python raise "multiple matches found". Serde is
+    /// unaffected either way because it resolves by variant order, so nothing
+    /// but this test would notice.
+    #[test]
+    fn test_the_two_greek_branches_are_mutually_exclusive() {
+        let spec = match ApiDoc::openapi().to_json() {
+            Ok(json) => json,
+            Err(error) => panic!("the OpenAPI document must render: {error}"),
+        };
+        let parsed: Value = match serde_json::from_str(&spec) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("the OpenAPI document must parse: {error}"),
+        };
+        let schema = parsed
+            .get("components")
+            .and_then(|components| components.get("schemas"))
+            .and_then(|schemas| schemas.get("GreeksResponse"));
+        let schema = match schema {
+            Some(schema) => schema,
+            None => panic!("the document must carry the GreeksResponse schema"),
+        };
+
+        let branches = match schema.get("oneOf").and_then(Value::as_array) {
+            Some(branches) => branches,
+            None => panic!("GreeksResponse must render as a oneOf: {schema}"),
+        };
+        let refs: Vec<&str> = branches
+            .iter()
+            .filter_map(|branch| branch.get("$ref").and_then(Value::as_str))
+            .collect();
+        assert_eq!(
+            refs,
+            vec![
+                "#/components/schemas/GreeksSnapshot",
+                "#/components/schemas/FirstOrderGreeks",
+            ],
+            "the full snapshot must come first, as it does for serde"
+        );
+
+        // What makes the `oneOf` satisfiable: the narrow branch is closed, so
+        // a twelve-value payload cannot also match it.
+        let first_order = parsed
+            .get("components")
+            .and_then(|components| components.get("schemas"))
+            .and_then(|schemas| schemas.get("FirstOrderGreeks"));
+        let first_order = match first_order {
+            Some(first_order) => first_order,
+            None => panic!("the document must carry the FirstOrderGreeks schema"),
+        };
+        assert_eq!(
+            first_order.get("additionalProperties"),
+            Some(&Value::Bool(false)),
+            "FirstOrderGreeks must be closed or the oneOf is ambiguous: {first_order}"
+        );
+    }
+
+    /// Every operation that takes the parameter documents a `400` for it, once,
+    /// and says which of the two bodies a client will get.
+    ///
+    /// utoipa keys responses by status, so a second `400` entry silently
+    /// replaces the first: an edit that appended one instead of replacing it
+    /// would publish the description without the greek wording, and nothing
+    /// else would notice.
+    #[test]
+    fn test_every_greek_operation_documents_its_400() {
+        let spec = match ApiDoc::openapi().to_json() {
+            Ok(json) => json,
+            Err(error) => panic!("the OpenAPI document must render: {error}"),
+        };
+        let parsed: Value = match serde_json::from_str(&spec) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("the OpenAPI document must parse: {error}"),
+        };
+
+        for (path, method) in [
+            ("/api/v1/chain", "get"),
+            ("/api/v1/chain/step", "post"),
+            ("/api/v2/simulations/{id}/snapshot", "get"),
+            ("/api/v2/simulations/{id}/step", "post"),
+        ] {
+            let bad_request = parsed
+                .get("paths")
+                .and_then(|paths| paths.get(path))
+                .and_then(|operations| operations.get(method))
+                .and_then(|operation| operation.get("responses"))
+                .and_then(|responses| responses.get("400"));
+            let bad_request = match bad_request {
+                Some(bad_request) => bad_request,
+                None => panic!("{method} {path} must document a 400"),
+            };
+
+            let description = bad_request
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            assert!(
+                description.contains("greeks"),
+                "{method} {path} must say the 400 covers an unknown greek level, got {description}"
+            );
+            // These operations answer 400 with two different bodies — the
+            // typed `{error, field}` for a rejected level, and `{error}` alone
+            // for a malformed id or a terminal state — so there is no single
+            // schema to publish. The description has to say which is which
+            // instead of the document promising a `field` that is sometimes
+            // absent.
+            assert!(
+                description.contains("ValidationErrorResponse"),
+                "{method} {path} must say when the 400 body is the typed one, got {description}"
+            );
+            assert!(
+                bad_request.get("content").is_none(),
+                "{method} {path} must not promise one body schema for two shapes"
+            );
+        }
+    }
+
     /// The v1 operations keep their documented status codes.
     ///
     /// The other half of §12.1's OpenAPI freeze: a cleanup that dropped the `412`
@@ -281,13 +510,18 @@ mod tests {
             }
         };
 
+        // `400` joined both serving paths when the `greeks` parameter did. It
+        // is a documentation completion rather than a new outcome: a malformed
+        // `sessionid` has always been mapped to `400` through
+        // `ChainError::InvalidState`, and the document simply never said so.
+        // Every code that was frozen is still here; none was dropped.
         assert_eq!(
             codes("/api/v1/chain/step", "post"),
-            vec!["200", "404", "409", "410", "412", "500"]
+            vec!["200", "400", "404", "409", "410", "412", "500"]
         );
         assert_eq!(
             codes("/api/v1/chain", "get"),
-            vec!["200", "404", "410", "500"]
+            vec!["200", "400", "404", "410", "500"]
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,80 @@
 //! }
 //! ```
 //!
+//! #### The `greeks` query parameter
+//!
+//! Both chain-serving endpoints on each version — `GET /api/v1/chain`,
+//! `POST /api/v1/chain/step`, `GET /api/v2/simulations/{id}/snapshot` and
+//! `POST /api/v2/simulations/{id}/step` — accept an optional `greeks` level.
+//! It is opt-in, and its default is the response shown above: the full set is
+//! twelve values per option style, and a chain can be a thousand strikes wide
+//! across many expirations, so a play-loop client that does not need them must
+//! not be made to download them.
+//!
+//! | `greeks` | The `greeks` key on each quoted side |
+//! |----------|--------------------------------------|
+//! | absent, or `none` | Not present at all. `implied_volatility`, `gamma` and the per-side `delta` as before |
+//! | `first` | `theta`, `vega`, `rho`, `rho_d` |
+//! | `all` | The full twelve-value snapshot: `delta`, `gamma`, `theta`, `vega`, `rho`, `rho_d`, `alpha`, `vanna`, `vomma`, `veta`, `charm`, `color` |
+//!
+//! Any other value is a `400` naming `greeks`, never a silent fall back to the
+//! default: a client that asked for `all` and quietly received nothing would
+//! price a position against greeks it never got.
+//!
+//! One quoted side at `greeks=all`: the 105 strike of a chain built on a 100
+//! underlying, 30 days to expiration, a 4% rate and a 1.5% dividend yield, with
+//! a base volatility of 20% that the skew and smile shape to 0.1983 at this
+//! strike:
+//!
+//! ```json
+//! "call": {
+//!     "bid": 0.66,
+//!     "ask": 0.68,
+//!     "mid": 0.67164031192058,
+//!     "delta": 0.21342098496717668,
+//!     "greeks": {
+//!         "delta": "0.2134209849671766791739391948",
+//!         "gamma": "0.0511531622872449408680866469",
+//!         "theta": "-0.0289390751520225679360302935",
+//!         "vega": "0.083366946728269604768867711",
+//!         "rho": "0.0169894176861345909734753825",
+//!         "rho_d": "-0.0175414508192199992738499204",
+//!         "alpha": "-1.7676156552525424476306277983",
+//!         "vanna": "1.2473442995808183501801769442",
+//!         "vomma": "0.2838300607436393803867085535",
+//!         "veta": "0.0000348161009099551782779877",
+//!         "charm": "-0.0044637844401925672319270818",
+//!         "color": "-0.0002301924225239124326433752"
+//!     }
+//! }
+//! ```
+//!
+//! The put of the same strike carries `"rho": "-0.069028687541464627650228228"`
+//! and `"charm": "-0.0045048296956570029453340524"`: the sign flips on `rho`
+//! and the value differs on `charm`, so the two sides are genuinely computed
+//! rather than one copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and
+//! `color` are style-independent and do agree.
+//!
+//! Three things a client has to know about those numbers:
+//!
+//! - **Every value is per ONE LONG CONTRACT.** The client applies position
+//!   sign and size, exactly once. Upstream builds the snapshot as a long
+//!   position and applies the side sign inside every greek, so a consumer that
+//!   applies it again double-counts.
+//! - **They are decimals, so they arrive as JSON strings**, not numbers. That
+//!   is deliberate: they are the values upstream computed, not a lossy `f64`
+//!   view of them. Everything else on the wire stays `f64`.
+//! - **`null` means not meaningful for these inputs**, never zero. Only `rho`,
+//!   `rho_d` and `alpha` can be null. Distinct from that: a strike whose option
+//!   cannot be built carries **no `greeks` key at all**, which on the wire looks
+//!   like the default level. Its `implied_volatility`, `gamma` and `delta` are
+//!   still there — they are defined where the full set is not.
+//!
+//! `delta` and `gamma` keep their existing places on the quote and the
+//! contract. They are computed independently of the snapshot and stay defined
+//! at expiry and at zero volatility, where the full set is not, so the default
+//! response is unchanged at every strike — degenerate ones included.
+//!
 //! ### 3. Update Session Parameters (PATCH /api/v1/chain?sessionid=6af613b6-569c-5c22-9c37-2ed93f31d3af)
 //!
 //! **Request Body:**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,8 @@
 //! deliberately different failure behaviour:
 //!
 //! - **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
-//!   `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CACHED_WALKS` — warn and fall back
+//!   `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CONCURRENT_GREEK_RENDERS`,
+//!   `OCS_MAX_CACHED_WALKS` — warn and fall back
 //!   to their defaults when set to something invalid. A bad value there
 //!   degrades one request.
 //! - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
@@ -644,27 +645,28 @@
 //!     "mid": 0.67164031192058,
 //!     "delta": 0.21342098496717668,
 //!     "greeks": {
-//!         "delta": "0.2134209849671766791739391948",
-//!         "gamma": "0.0511531622872449408680866469",
-//!         "theta": "-0.0289390751520225679360302935",
-//!         "vega": "0.083366946728269604768867711",
-//!         "rho": "0.0169894176861345909734753825",
-//!         "rho_d": "-0.0175414508192199992738499204",
-//!         "alpha": "-1.7676156552525424476306277983",
-//!         "vanna": "1.2473442995808183501801769442",
-//!         "vomma": "0.2838300607436393803867085535",
-//!         "veta": "0.0000348161009099551782779877",
-//!         "charm": "-0.0044637844401925672319270818",
-//!         "color": "-0.0002301924225239124326433752"
+//!         "delta": 0.21342098496717668,
+//!         "gamma": 0.051153162287244945,
+//!         "theta": -0.028939075152022566,
+//!         "vega": 0.0833669467282696,
+//!         "rho": 0.016989417686134593,
+//!         "rho_d": -0.01754145081922,
+//!         "alpha": -1.7676156552525426,
+//!         "vanna": 1.2473442995808184,
+//!         "vomma": 0.28383006074363937,
+//!         "veta": 0.00003481610090995518,
+//!         "charm": -0.0044637844401925674,
+//!         "color": -0.00023019242252391244
 //!     }
 //! }
 //! ```
 //!
-//! The put of the same strike carries `"rho": "-0.069028687541464627650228228"`
-//! and `"charm": "-0.0045048296956570029453340524"`: the sign flips on `rho`
-//! and the value differs on `charm`, so the two sides are genuinely computed
-//! rather than one copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and
-//! `color` are style-independent and do agree.
+//! The put of the same strike carries `"rho": -0.06902868754146463` and
+//! `"charm": -0.004504829695657003`: the sign flips on `rho` and the value
+//! differs on `charm`, so the two sides are genuinely computed rather than one
+//! copied twice. `gamma`, `vega`, `vanna`, `vomma`, `veta` and `color` are
+//! style-independent and do agree. `alpha` differs too — it is a ratio, and the
+//! two sides have different thetas.
 //!
 //! Three things a client has to know about those numbers:
 //!
@@ -672,9 +674,10 @@
 //!   sign and size, exactly once. Upstream builds the snapshot as a long
 //!   position and applies the side sign inside every greek, so a consumer that
 //!   applies it again double-counts.
-//! - **They are decimals, so they arrive as JSON strings**, not numbers. That
-//!   is deliberate: they are the values upstream computed, not a lossy `f64`
-//!   view of them. Everything else on the wire stays `f64`.
+//! - **They are `f64`, like every other number on this surface.** The DTOs are
+//!   this crate's own twelve- and four-field types, converted from upstream's
+//!   `Decimal` exactly once at the boundary, so upstream's serialisation never
+//!   becomes part of this service's contract by accident.
 //! - **`null` means not meaningful for these inputs**, never zero. Only `rho`,
 //!   `rho_d` and `alpha` can be null. Distinct from that: a strike whose option
 //!   cannot be built carries **no `greeks` key at all**, which on the wire looks

--- a/tests/v1_contract.rs
+++ b/tests/v1_contract.rs
@@ -314,6 +314,9 @@ fn test_v1_chain_response_shape_is_unchanged() {
                 ask: Some(26.1),
                 mid: Some(26.09),
                 delta: Some(0.95),
+                // The default greek level. The field is skipped when absent,
+                // so the JSON below is the pre-parameter response verbatim.
+                greeks: None,
             },
             put: OptionPriceResponse::default(),
             implied_volatility: Some(0.25),


### PR DESCRIPTION
## What

Both chain-serving endpoints on each version — `GET /api/v1/chain`,
`POST /api/v1/chain/step`, `GET /api/v2/simulations/{id}/snapshot` and
`POST /api/v2/simulations/{id}/step` — accept an optional `greeks` level that
adds the rest of the greek set to each quoted side.

Closes #73.

| `greeks` | The `greeks` key on each quoted side |
|---|---|
| absent, or `none` | Not present at all. The response is what clients get today |
| `first` | `theta`, `vega`, `rho`, `rho_d` |
| `all` | The full twelve-value `GreeksSnapshot`: `delta`, `gamma`, `theta`, `vega`, `rho`, `rho_d`, `alpha`, `vanna`, `vomma`, `veta`, `charm`, `color` |

This is the enabling change for a live strategy viewer: pick a strategy, step
the simulation, and watch P&L move next to the position's greeks — without a
second, divergent pricing implementation in the client.

## Why it is opt-in

Twelve values on two styles is 24 numbers per strike on top of the existing
quote, and a snapshot can be 1 001 strikes wide across 512 expirations. A
play-loop UI stepping every 700 ms would pull that continuously.

Measured on a 29-strike 0DTE snapshot (debug build; the byte counts are
build-independent, the timings are not):

| Level | Body | Ratio | Marginal per contract |
|---|---|---|---|
| absent / `none` | 7 754 B | 1.00x | — |
| `first` | 17 819 B | 2.30x | +347 B |
| `all` | 36 926 B | 4.76x | +1 006 B |

`first` and `all` cost the same to compute — upstream builds the snapshot whole
either way — and differ only in what is written out.

## Rejection, not fallback

Any other value is a `400` naming `greeks`. A client that asked for `all` and
quietly received the default would price a position against greeks it never
got. On `POST /step` the level is resolved **before** the cursor moves, so a
rejected level cannot consume a step — a 400 that advanced the simulation would
make the error unrepeatable.

## Where the values come from, and where they run

`OptionData::greeks_call` / `greeks_put`, computed by upstream's
`calculate_greeks`. **No greek mathematics is added to this crate.**

They are computed lazily in `greeks_for` (`src/api/rest/greeks.rs`), on a clone
— `calculate_greeks` needs `&mut`, and the DTO layer has no business mutating
what it was handed to render. Upstream's `with_greek_snapshots` stays off:
turning it on globally would charge every client for a payload most never ask
for.

**The pricing runs on the blocking pool.** At roughly 40 µs per contract and a
`DEFAULT_MAX_SNAPSHOT_CONTRACTS` of 200 000, a single `?greeks=all` call can be
seconds of uninterrupted CPU; left on a tokio worker it would stall every other
request that worker holds. Both versions render above the default level inside
`spawn_blocking`, for the same reason and in the same way as the v2 tape build
(`session/manager_v2.rs`) and the export path. The default level stays inline —
it is a field-by-field copy of numbers the snapshot already holds.

**The MongoDB event log is written at the default level** regardless of what the
caller asked for. It records the chain at step N, not what the client who
happened to advance it wanted; without that, two clients advancing the same
session would write differently-shaped documents, and a `greeks=all` advance
would write roughly five times the BSON for no gain.

## The shape on the wire

`first` cannot be a partial `GreeksSnapshot` — nine of its twelve fields are
non-optional `Decimal` — so `GreeksResponse` is an untagged enum over the
upstream snapshot and a four-field first-order projection. Untagged keeps the
key a plain object at both levels.

`FirstOrderGreeks` carries `deny_unknown_fields`, which does two jobs at once:
it makes serde's untagged resolution independent of variant order, and utoipa
derives `additionalProperties: false` from it. That is what keeps the published
`oneOf` **satisfiable**. Without it a twelve-value payload would match both
branches, so every `greeks=all` response would be invalid against the document
this service publishes: strict validators reject it, and the `oneOf`
deserialisers openapi-generator emits for Java, C# and Python raise "multiple
matches found". A test now pins both the branch order and the closed shape.

Three things a consumer has to know, all of them in the OpenAPI description and
the crate docs:

- **Every value is per ONE LONG CONTRACT.** The client applies position sign
  and size exactly once. Upstream builds the snapshot as a long position and,
  since 0.20, applies the side sign inside *every* greek — so a consumer that
  applies it again double-counts.
- **They are decimals, so they arrive as JSON strings**, not numbers. That is
  the deliberate consequence of carrying the upstream type verbatim rather than
  an `f64` mirror that could drift from what upstream computed. Everything else
  on the wire stays `f64`.
- **`null` means not meaningful for these inputs**, never zero. Only `rho`,
  `rho_d` and `alpha` can be null; upstream normalises `alpha` to `null` where
  it would otherwise be `Decimal::MAX`. Distinct from that: a strike whose
  option cannot be built carries **no `greeks` key at all**, which on the wire
  looks like the default level. Its `implied_volatility`, `gamma` and `delta`
  are still there.

`delta` and `gamma` keep their existing places on the quote and the contract.
They are upstream's convenience mirrors, computed independently of the
snapshots and defined at expiry and at zero volatility where the full set is
not — so the default response is unchanged at **every** strike, degenerate ones
included.

## Tests

Thirty-two new tests. The load-bearing ones:

- the default response is identical to `greeks=none` and carries no `greeks`
  key at all, on v1 and v2 — the regression that protects existing clients
- `greeks=all` carries exactly the twelve documented values per style;
  `greeks=first` exactly the four the default lacks
- `charm` differs between call and put and `rho` carries opposite signs, while
  the six style-independent greeks agree exactly — so the split is real rather
  than one value copied twice
- the snapshot's `delta` and `gamma` agree with the `f64` mirrors the response
  duplicates, so a client never has to decide which to believe
- prices, delta and gamma are the same numbers at all three levels, and two
  simulations sharing a seed serve identical `greeks=all` snapshots
- an unknown level is a typed 400 naming the field on **both** versions, and on
  either `/step` it does not advance the cursor (the v1 half needs MongoDB, so
  it is `#[ignore]`d and runs in CI's integration job)
- `greeks_for` covers both branches, including the pre-populated one no handler
  reaches today
- the OpenAPI document advertises the parameter on all four chain-serving
  operations, names its three values and the per-one-long-contract convention,
  publishes the three schemas, and keeps the two `oneOf` branches mutually
  exclusive

Reproducibility is untouched: the greeks are read off the option and never fed
back into the walk, pinned both by the "same numbers at all three levels" test
and by the same-seed comparison at `greeks=all`.

### Documented-surface changes

`400` joins the documented codes on both v1 chain endpoints. That completes the
document rather than changing behaviour: a malformed `sessionid` has always
mapped to `400` through `ChainError::InvalidState`, and the frozen-code test now
records it. Every previously frozen code is still there. The entry deliberately
publishes **no** body schema: these operations answer 400 with two different
shapes — the typed `{error, field}` for a rejected level, `{error}` alone for a
malformed id — and promising one would document a `field` that is sometimes
absent. The description says which is which.

**ADR 0001 §7 is amended.** It stated that all v2 numeric fields are `f64` at
the REST boundary; the greeks are the documented exception, and the contract of
record now says so.

`utoipa` now declares `features = ["decimal"]` first-hand. The greek DTOs derive
`ToSchema` over `Decimal`, so that schema is a requirement of this crate rather
than a side effect of what optionstratlib happens to enable.

### Semver

`OptionPriceResponse` is publicly re-exported with all-public fields, so adding
`greeks` breaks any downstream struct literal — the edit to
`tests/v1_contract.rs` in this diff is the proof. The next release is **0.3.0**,
which #76 already established for the `positive` 0.6 public-dependency bump.
Worth considering separately: `#[non_exhaustive]` on the quote DTOs, so this is
the last time an additive field breaks construction.

## Consumer coordination

IronCondor's `RawQuote` already has `theta` and `vega` fields filled with
placeholder zeros for simulator-sourced tapes. Once this ships,
`src/data/simulator.rs` there can request `greeks=first` and carry real values.
The fields are additive and skipped when absent, so no coordinated release is
needed — but note the decimal-as-string rendering when wiring the parser.

## Reviewed before opening

`architect` and `api-expert` audited the diff. Their findings are folded in
rather than noted: the blocking-pool move, the unsatisfiable `oneOf`, the
duplicate `400` that silently dropped its own description, the over-promised
400 body schema, the client-shaped event log, the missing v1 HTTP coverage, the
unreachable `greeks_for` branch, the undeclared `utoipa/decimal` feature, the
ADR amendment, and several doc claims that were measurably wrong (the greek
build cost is 1.5x a chain build, not seven; the clone is needed for the `&mut`,
not for cache sharing).

## Checks

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `LOGLEVEL=WARN cargo test --workspace` clean — 760 lib tests, 16 contract
  tests, 3 doctests, 0 failures
- `cargo test --workspace -- --ignored` clean — 19 live-service tests against
  Redis, ClickHouse and MongoDB containers
- `cargo build --release` clean, zero warnings
- `src/lib.rs` docs and `README.md` regenerated via `make readme`

## Stack

- **Base branch: `main`.** #77 merged, so this branch was rebased onto the
  squashed commit and the diff now reads cleanly against `main`.
- **Stacked on: #77 (merged).**
- **Stack: #76 → #73 → #74 → #75.** This one is #73; #74 stacks on it next.
- **Blocks: #85**, which stacks on this one.
