### PR TITLE
Update every dependency, and treat a blank environment variable as unset (#83)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,16 @@
 #
 # A BLANK VALUE MEANS UNSET. `KNOB=` and `KNOB="   "` are read exactly as if the
 # line were not here at all, and the documented default applies, so an optional
-# knob is switched off by commenting it out rather than by emptying it. One
-# consequence worth knowing: an EMPTY CLICKHOUSE_PASSWORD is therefore not
-# expressible here, so a ClickHouse whose user has no password needs the field
-# set programmatically.
+# knob is switched off by commenting it out rather than by emptying it.
+#
+# ONE EXCEPTION: CLICKHOUSE_PASSWORD. An empty ClickHouse password is a real
+# configuration — a stock `default` user has none — so a PRESENT variable is
+# taken as written, empty included, and only an absent one falls back.
+#
+# VALUES ARE NOT TRIMMED. Whitespace decides whether a value is blank, and
+# nothing more: a credential written with a leading space authenticates with
+# that space. Numbers and host names are trimmed where they are parsed, so
+# `REDIS_PORT= 6379 ` still works.
 #
 # Every variable the service reads is listed here with its default and its
 # accepted range. Copy this file to `.env` and change what you need; anything
@@ -239,6 +245,11 @@ CLICKHOUSE_HOST=localhost
 CLICKHOUSE_PORT=8123
 
 # Database and credentials.  Defaults: default / admin / password
+#
+# CLICKHOUSE_PASSWORD is the one variable where an empty value means something:
+# `CLICKHOUSE_PASSWORD=` configures a user with NO password, which is how a
+# stock ClickHouse `default` user ships. Comment the line out to get the
+# default below instead.
 CLICKHOUSE_DB=default
 CLICKHOUSE_USER=admin
 CLICKHOUSE_PASSWORD=password

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# A BLANK VALUE MEANS UNSET. `KNOB=` and `KNOB="   "` are read exactly as if the
+# line were not here at all, and the documented default applies. That is why the
+# optional credentials below are commented out rather than left empty.
+#
 # OptionChain-Simulator — environment variables
 #
 # Every variable the service reads is listed here with its default and its
@@ -188,9 +192,13 @@ REDIS_PORT=6379
 # Logical database index.  Default: 0
 REDIS_DB=0
 
-# Credentials. Both optional; leave unset for an unauthenticated server.
-REDIS_USER=
-REDIS_PASSWORD=
+# Credentials. Both optional; leave them commented out for an unauthenticated
+# server. A BLANK value means unset everywhere in this file, so writing
+# `REDIS_PASSWORD=` is the same as not writing it — which is what you want
+# against a password-less Redis, and used to be an AUTH attempt with an empty
+# password instead.
+#REDIS_USER=
+#REDIS_PASSWORD=
 
 # Connection timeout, in seconds.  Default: 30
 REDIS_TIMEOUT=30

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
-# A BLANK VALUE MEANS UNSET. `KNOB=` and `KNOB="   "` are read exactly as if the
-# line were not here at all, and the documented default applies. That is why the
-# optional credentials below are commented out rather than left empty.
-#
 # OptionChain-Simulator — environment variables
+#
+# A BLANK VALUE MEANS UNSET. `KNOB=` and `KNOB="   "` are read exactly as if the
+# line were not here at all, and the documented default applies, so an optional
+# knob is switched off by commenting it out rather than by emptying it. One
+# consequence worth knowing: an EMPTY CLICKHOUSE_PASSWORD is therefore not
+# expressible here, so a ClickHouse whose user has no password needs the field
+# set programmatically.
 #
 # Every variable the service reads is listed here with its default and its
 # accepted range. Copy this file to `.env` and change what you need; anything

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "optionchain_simulator"
 version = "0.2.0"
 edition = "2024"
+# Declared because the dependency bump moved it: actix-web 4.15 and redis 1.6
+# both require 1.88. Without this a consumer on an older toolchain gets a
+# failure inside a dependency rather than a clear message about this crate.
+rust-version = "1.88"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionChain-Simulator is a lightweight REST API service that simulates an evolving option chain with every request. It is designed for developers building or testing trading systems, backtesters, and visual tools that depend on option data streams but want to avoid relying on live data feeds."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,12 @@
 name = "optionchain_simulator"
 version = "0.2.0"
 edition = "2024"
-# Declared because the dependency bump moved it: actix-web 4.15 and redis 1.6
-# both require 1.88. Without this a consumer on an older toolchain gets a
-# failure inside a dependency rather than a clear message about this crate.
-rust-version = "1.88"
+# The maximum `rust-version` across the RESOLVED graph, not the highest direct
+# dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all
+# require 1.89, so declaring 1.88 would fail inside a dependency instead of
+# saying clearly that this crate needs a newer toolchain. Re-derive it after a
+# bump with `cargo metadata` over the resolved packages' rust_version.
+rust-version = "1.89"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionChain-Simulator is a lightweight REST API service that simulates an evolving option chain with every request. It is designed for developers building or testing trading systems, backtesters, and visual tools that depend on option data streams but want to avoid relying on live data feeds."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ rust_decimal = { version = "1.42", features = ["maths", "serde"] }
 rust_decimal_macros = "1.40"
 serde_json = "1.0"
 serde = "1.0"
-uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.26", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 # IANA timezone database for the v2 rolling-expiry calendar: the local
 # expiration cutoff and its DST fold/gap resolution (ADR 0001, issue #43)
@@ -67,11 +67,11 @@ chrono-tz = { version = "0.10", features = ["serde"] }
 # Write sink so a multi-year download stays bounded-memory (ADR 0001, issue #49)
 csv = "1.4"
 clickhouse = "0.15"
-tokio = { version = "1.52", features = ["full"] }
+tokio = { version = "1.53", features = ["full"] }
 async-trait = "0.1"
-actix-web = { version = "4.14", features = ["rustls"] }
-actix-files = "0.6"
-redis = { version = "1.3", features = ["tokio-comp", "connection-manager"] }
+actix-web = { version = "4.15", features = ["rustls"] }
+actix-files = "0.7"
+redis = { version = "1.6", features = ["tokio-comp", "connection-manager"] }
 # actix_extras is unavailable: optionstratlib enables utoipa/axum_extras,
 # and utoipa's framework extras are mutually exclusive
 utoipa = "5.5"

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -124,23 +124,28 @@ services:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-default}
-      CLICKHOUSE_PORT: ${CLICKHOUSE_PORT-8123}
-      CLICKHOUSE_HOST: ${CLICKHOUSE_HOST-clickhouse}
-      MONGODB_URI: ${MONGODB_URI-mongodb://admin:password@mongodb:27017}
-      MONGODB_DATABASE: ${MONGODB_DATABASE-optionchain_simulator}
-      MONGODB_STEPS_COLLECTION: ${MONGODB_STEPS_COLLECTION-steps}
-      MONGODB_EVENTS_COLLECTION: ${MONGODB_EVENTS_COLLECTION-events}
-      MONGODB_TIMEOUT: ${MONGODB_TIMEOUT-30}
-      REDIS_PORT: ${REDIS_PORT-6379}
-      REDIS_DB: ${REDIS_DB-0}
-      REDIS_USER: ${REDIS_USER}
-      REDIS_PASSWORD: ${REDIS_PASSWORD-password}
-      REDIS_HOST: ${REDIS_HOST-redis}
+      CLICKHOUSE_PORT: ${CLICKHOUSE_PORT:-8123}
+      CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-clickhouse}
+      MONGODB_URI: ${MONGODB_URI:-mongodb://admin:password@mongodb:27017}
+      MONGODB_DATABASE: ${MONGODB_DATABASE:-optionchain_simulator}
+      MONGODB_STEPS_COLLECTION: ${MONGODB_STEPS_COLLECTION:-steps}
+      MONGODB_EVENTS_COLLECTION: ${MONGODB_EVENTS_COLLECTION:-events}
+      MONGODB_TIMEOUT: ${MONGODB_TIMEOUT:-30}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_DB: ${REDIS_DB:-0}
+      # `:-`, not `-`, on every line above and below: `${VAR-default}` only
+      # substitutes when the variable is UNSET, so a blank one in the repo's
+      # `.env` reached the container as "" and the app answered with its own
+      # default, which inside a container points at localhost. `:-` covers
+      # blank too, which is what the service now means by unset.
+      REDIS_USER: ${REDIS_USER:-}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-password}
+      REDIS_HOST: ${REDIS_HOST:-redis}
       # Whole seconds, must parse as an integer >= 1: src/infrastructure/config
       # /redis.rs falls back to these same defaults (30 / 5) on 0, on a
       # non-numeric value, or when unset, warning as it does so.
-      REDIS_TIMEOUT: ${REDIS_TIMEOUT-30}
-      REDIS_CONNECT_TIMEOUT: ${REDIS_CONNECT_TIMEOUT-5}
+      REDIS_TIMEOUT: ${REDIS_TIMEOUT:-30}
+      REDIS_CONNECT_TIMEOUT: ${REDIS_CONNECT_TIMEOUT:-5}
     ports:
       - "7070:7070"
     networks:

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ need no changes.
 
 ### Configuration
 
+**A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
+exactly as if the line were absent, and the documented default applies, so a
+knob is switched off by commenting it out rather than by emptying it. The
+rule holds for every variable the service reads, credentials included.
+
 Every environment variable the service reads is documented in
 `.env.example` with its default and accepted range. Two families, with
 deliberately different failure behaviour:

--- a/README.md
+++ b/README.md
@@ -284,8 +284,14 @@ need no changes.
 
 **A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
 exactly as if the line were absent, and the documented default applies, so a
-knob is switched off by commenting it out rather than by emptying it. The
-rule holds for every variable the service reads, credentials included.
+knob is switched off by commenting it out rather than by emptying it.
+
+One variable is exempt: `CLICKHOUSE_PASSWORD`, where an empty value is a
+real configuration — a stock `default` user has no password — so a present
+variable is taken as written and only an absent one falls back. Values are
+never trimmed either: whitespace decides only whether a value is blank, and
+a credential written with a leading space keeps it. Numbers and host names
+are trimmed where they are parsed.
 
 Every environment variable the service reads is documented in
 `.env.example` with its default and accepted range. Two families, with

--- a/src/api/rest/limits.rs
+++ b/src/api/rest/limits.rs
@@ -23,13 +23,17 @@ pub(crate) const DEFAULT_MAX_CHAIN_SIZE: usize = 500;
 pub(crate) const DEFAULT_MAX_HISTORICAL_PRICES: usize = 100_000;
 
 /// Maximum number of simulation steps a session may request (`OCS_MAX_STEPS`).
-pub(crate) static MAX_STEPS: LazyLock<usize> =
-    LazyLock::new(|| parse_limit(std::env::var("OCS_MAX_STEPS").ok(), DEFAULT_MAX_STEPS));
+pub(crate) static MAX_STEPS: LazyLock<usize> = LazyLock::new(|| {
+    parse_limit(
+        crate::utils::env::read_var("OCS_MAX_STEPS"),
+        DEFAULT_MAX_STEPS,
+    )
+});
 
 /// Maximum option-chain size a request may ask for (`OCS_MAX_CHAIN_SIZE`).
 pub(crate) static MAX_CHAIN_SIZE: LazyLock<usize> = LazyLock::new(|| {
     parse_limit(
-        std::env::var("OCS_MAX_CHAIN_SIZE").ok(),
+        crate::utils::env::read_var("OCS_MAX_CHAIN_SIZE"),
         DEFAULT_MAX_CHAIN_SIZE,
     )
 });
@@ -38,7 +42,7 @@ pub(crate) static MAX_CHAIN_SIZE: LazyLock<usize> = LazyLock::new(|| {
 /// (`OCS_MAX_HISTORICAL_PRICES`).
 pub(crate) static MAX_HISTORICAL_PRICES: LazyLock<usize> = LazyLock::new(|| {
     parse_limit(
-        std::env::var("OCS_MAX_HISTORICAL_PRICES").ok(),
+        crate::utils::env::read_var("OCS_MAX_HISTORICAL_PRICES"),
         DEFAULT_MAX_HISTORICAL_PRICES,
     )
 });
@@ -58,9 +62,12 @@ pub(crate) fn strikes_per_chain(chain_size: usize) -> Option<usize> {
 
 /// Parses a raw environment value into a positive `usize` limit.
 ///
-/// Returns `default` when `raw` is `None` (variable unset) or when it does not parse
-/// into an integer `>= 1`. Invalid values are logged at `WARN` and never abort startup,
-/// keeping the service resilient to misconfiguration.
+/// Returns `default` when `raw` is `None` — unset, or blank, which
+/// [`crate::utils::env::read_var`] reads as unset — or when it does not parse
+/// into an integer `>= 1`. Invalid values are logged at `WARN` and never abort
+/// startup, keeping the service resilient to misconfiguration. A blank value
+/// reaches this as `None`, so it falls back SILENTLY: it is a knob someone
+/// commented out, not a mistake worth warning about.
 ///
 /// # Examples
 ///

--- a/src/domain/simulator.rs
+++ b/src/domain/simulator.rs
@@ -67,20 +67,22 @@ const HISTORICAL_STREAM_SALT: u64 = 0x0048_4953_544F_5259;
 /// parse-once pattern in `api::rest::limits` but lives in the domain layer to keep
 /// the dependency flow api -> session -> domain intact.
 static MAX_CACHED_WALKS: LazyLock<usize> =
-    LazyLock::new(|| match std::env::var("OCS_MAX_CACHED_WALKS").ok() {
-        None => DEFAULT_MAX_CACHED_WALKS,
-        Some(value) => match value.trim().parse::<usize>() {
-            Ok(parsed) if parsed >= 1 => parsed,
-            _ => {
-                warn!(
-                    raw = %value,
-                    default = DEFAULT_MAX_CACHED_WALKS,
-                    "invalid OCS_MAX_CACHED_WALKS; falling back to default"
-                );
-                DEFAULT_MAX_CACHED_WALKS
-            }
+    LazyLock::new(
+        || match crate::utils::env::read_var("OCS_MAX_CACHED_WALKS") {
+            None => DEFAULT_MAX_CACHED_WALKS,
+            Some(value) => match value.trim().parse::<usize>() {
+                Ok(parsed) if parsed >= 1 => parsed,
+                _ => {
+                    warn!(
+                        raw = %value,
+                        default = DEFAULT_MAX_CACHED_WALKS,
+                        "invalid OCS_MAX_CACHED_WALKS; falling back to default"
+                    );
+                    DEFAULT_MAX_CACHED_WALKS
+                }
+            },
         },
-    });
+    );
 
 /// One cached random walk together with the last time it was accessed.
 ///

--- a/src/infrastructure/config/clickhouse.rs
+++ b/src/infrastructure/config/clickhouse.rs
@@ -1,6 +1,5 @@
 //! This module defines the `ClickHouseConfig` struct and its default implementation.
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::fmt;
 
 /// Configuration structure for connecting to a ClickHouse server.
@@ -55,17 +54,19 @@ impl Default for ClickHouseConfig {
     /// # Returns
     /// A new instance of the struct with properly initialized fields.
     fn default() -> Self {
-        let port = env::var("CLICKHOUSE_PORT")
-            .ok()
+        let port = super::read_var("CLICKHOUSE_PORT")
             .and_then(|s| s.parse::<u16>().ok())
             .unwrap_or(8123);
 
         Self {
-            host: env::var("CLICKHOUSE_HOST").unwrap_or_else(|_| "localhost".to_string()),
+            host: super::read_var("CLICKHOUSE_HOST").unwrap_or_else(|| "localhost".to_string()),
             port,
-            username: env::var("CLICKHOUSE_USER").unwrap_or_else(|_| "admin".to_string()),
-            password: env::var("CLICKHOUSE_PASSWORD").unwrap_or_else(|_| "password".to_string()),
-            database: env::var("CLICKHOUSE_DB").unwrap_or_else(|_| "default".to_string()),
+            // Credentials included: a blank one is unset, not an empty
+            // credential (issue #83).
+            username: super::read_var("CLICKHOUSE_USER").unwrap_or_else(|| "admin".to_string()),
+            password: super::read_var("CLICKHOUSE_PASSWORD")
+                .unwrap_or_else(|| "password".to_string()),
+            database: super::read_var("CLICKHOUSE_DB").unwrap_or_else(|| "default".to_string()),
         }
     }
 }
@@ -105,6 +106,44 @@ mod tests {
         #[allow(unused_unsafe)]
         unsafe {
             env::remove_var(name);
+        }
+    }
+
+    /// A blank ClickHouse credential is unset, so its default applies.
+    ///
+    /// The same rule as Redis and Mongo (issue #83): a blank value in a `.env`
+    /// file is a commented-out knob, and an empty credential is never what
+    /// somebody meant.
+    #[test]
+    fn test_blank_clickhouse_variables_fall_back_to_their_defaults() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for blank in ["", "  "] {
+            set_var("CLICKHOUSE_HOST", blank);
+            set_var("CLICKHOUSE_USER", blank);
+            set_var("CLICKHOUSE_PASSWORD", blank);
+            set_var("CLICKHOUSE_DB", blank);
+            set_var("CLICKHOUSE_PORT", blank);
+
+            let config = ClickHouseConfig::default();
+            assert_eq!(config.host, "localhost", "blank {blank:?}");
+            assert_eq!(config.username, "admin");
+            assert_eq!(config.password, "password");
+            assert_eq!(config.database, "default");
+            assert_eq!(config.port, 8123);
+        }
+
+        for name in [
+            "CLICKHOUSE_HOST",
+            "CLICKHOUSE_USER",
+            "CLICKHOUSE_PASSWORD",
+            "CLICKHOUSE_DB",
+            "CLICKHOUSE_PORT",
+        ] {
+            remove_var(name);
         }
     }
 

--- a/src/infrastructure/config/clickhouse.rs
+++ b/src/infrastructure/config/clickhouse.rs
@@ -54,29 +54,35 @@ impl Default for ClickHouseConfig {
     /// # Returns
     /// A new instance of the struct with properly initialized fields.
     fn default() -> Self {
+        // Trimmed HERE, not in the reader: a port is a number, so surrounding
+        // whitespace is noise, while the credentials below are opaque bytes
+        // where it is not.
         let port = super::read_var("CLICKHOUSE_PORT")
-            .and_then(|s| s.parse::<u16>().ok())
+            .and_then(|s| s.trim().parse::<u16>().ok())
             .unwrap_or(8123);
 
         Self {
-            host: super::read_var("CLICKHOUSE_HOST").unwrap_or_else(|| "localhost".to_string()),
+            host: super::read_var("CLICKHOUSE_HOST")
+                .map(|host| host.trim().to_string())
+                .unwrap_or_else(|| "localhost".to_string()),
             port,
-            // Credentials included: a blank one is unset, not an empty
-            // credential (issue #83).
-            //
-            // CONSEQUENCE, stated because it is a real trade: an EMPTY
-            // ClickHouse password is no longer expressible through the
-            // environment. `CLICKHOUSE_PASSWORD=` used to be the only way to
-            // say "this user has no password", which is how a stock
-            // ClickHouse `default` user is configured; it now falls back to
-            // the default below. The rule is applied uniformly on purpose —
-            // the alternative is one variable in the whole service behaving
-            // differently from the rest — and a password-less deployment sets
-            // the field directly through `ClickHouseConfig`, which is public.
+            // Credentials read through `read_secret`, NOT `read_var`: the
+            // blank-is-unset rule does not apply to them, because an empty
+            // ClickHouse password is a real configuration. A stock `default`
+            // user has none, and `CLICKHOUSE_PASSWORD=` is the only way to say
+            // so through the environment. They are also never trimmed: a
+            // credential's surrounding whitespace is part of the credential,
+            // and nothing here can tell that it is not.
+            // The USER follows the ordinary rule: an empty ClickHouse user is
+            // not a configuration any server accepts, so a blank one is a knob
+            // someone commented out. Untrimmed all the same, since a user name
+            // is not this module's to reinterpret.
             username: super::read_var("CLICKHOUSE_USER").unwrap_or_else(|| "admin".to_string()),
-            password: super::read_var("CLICKHOUSE_PASSWORD")
+            password: super::read_secret("CLICKHOUSE_PASSWORD")
                 .unwrap_or_else(|| "password".to_string()),
-            database: super::read_var("CLICKHOUSE_DB").unwrap_or_else(|| "default".to_string()),
+            database: super::read_var("CLICKHOUSE_DB")
+                .map(|database| database.trim().to_string())
+                .unwrap_or_else(|| "default".to_string()),
         }
     }
 }
@@ -141,9 +147,11 @@ mod tests {
             let config = ClickHouseConfig::default();
             assert_eq!(config.host, "localhost", "blank {blank:?}");
             assert_eq!(config.username, "admin");
-            assert_eq!(config.password, "password");
             assert_eq!(config.database, "default");
             assert_eq!(config.port, 8123);
+            // The PASSWORD is the documented exception: a present variable is
+            // a credential, empty included, so it does not fall back here.
+            assert_eq!(config.password, blank, "blank {blank:?}");
         }
 
         for name in [

--- a/src/infrastructure/config/clickhouse.rs
+++ b/src/infrastructure/config/clickhouse.rs
@@ -63,6 +63,16 @@ impl Default for ClickHouseConfig {
             port,
             // Credentials included: a blank one is unset, not an empty
             // credential (issue #83).
+            //
+            // CONSEQUENCE, stated because it is a real trade: an EMPTY
+            // ClickHouse password is no longer expressible through the
+            // environment. `CLICKHOUSE_PASSWORD=` used to be the only way to
+            // say "this user has no password", which is how a stock
+            // ClickHouse `default` user is configured; it now falls back to
+            // the default below. The rule is applied uniformly on purpose —
+            // the alternative is one variable in the whole service behaving
+            // differently from the rest — and a password-less deployment sets
+            // the field directly through `ClickHouseConfig`, which is public.
             username: super::read_var("CLICKHOUSE_USER").unwrap_or_else(|| "admin".to_string()),
             password: super::read_var("CLICKHOUSE_PASSWORD")
                 .unwrap_or_else(|| "password".to_string()),

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -1,3 +1,8 @@
+//! Environment-driven configuration for every external service.
+//!
+//! One rule holds across all of it: **a blank value is an unset value**. See
+//! [`read_var`], which every module here reads through.
+
 pub mod clickhouse;
 pub mod mongo;
 pub mod redis;
@@ -8,6 +13,33 @@ pub mod simulation_v2;
 /// how large a batch may be, how long an insert may take, and how long the rows
 /// are kept.
 pub mod snapshot;
+
+/// Reads an environment variable, treating a blank value as unset.
+///
+/// **The rule, once, for every configuration knob in this service: a blank
+/// value is an unset value.** `KNOB=` and `KNOB="   "` mean the same thing as
+/// not writing `KNOB` at all, and the documented default applies.
+///
+/// A blank value in a `.env` file is how a knob gets commented out in practice,
+/// so honouring it as a real empty string produces failures that point
+/// somewhere else entirely. The case that motivated stating this rule:
+/// `REDIS_PASSWORD=` used to yield `Some("")`, which built `redis://:@host` —
+/// an AUTH attempt with an empty password against a server that has none. The
+/// connection failed with an authentication error, and nothing in that message
+/// pointed at an empty variable.
+///
+/// The returned value is trimmed, so surrounding whitespace never reaches a
+/// host name, a credential or a parser.
+#[must_use]
+pub(crate) fn read_var(variable: &str) -> Option<String> {
+    let raw = std::env::var(variable).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
 
 /// Redacts URL userinfo (credentials) from every URL-like substring inside a
 /// larger text (log lines, driver error messages).
@@ -189,5 +221,84 @@ mod tests {
     fn test_redact_userinfo_plain_text_unchanged() {
         let input = "no url here";
         assert_eq!(redact_userinfo(input), input);
+    }
+}
+
+#[cfg(test)]
+mod blank_rule_tests {
+    use super::read_var;
+    use once_cell::sync::Lazy;
+    use std::sync::Mutex;
+
+    /// Environment mutation is process-wide, so these serialise.
+    static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn set_var(name: &str, value: &str) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::set_var(name, value);
+        }
+    }
+
+    fn remove_var(name: &str) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::remove_var(name);
+        }
+    }
+
+    /// An unset variable reads as absent.
+    #[test]
+    fn test_an_unset_variable_is_none() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var("OCS_TEST_BLANK_RULE");
+
+        assert_eq!(read_var("OCS_TEST_BLANK_RULE"), None);
+    }
+
+    /// A blank value reads as absent, which is the rule this module states.
+    ///
+    /// Every form of blank: empty, spaces, and a tab. `KNOB=` is how a knob
+    /// gets commented out in practice, and reading it as an empty string is
+    /// what made `REDIS_PASSWORD=` an AUTH attempt with no password.
+    #[test]
+    fn test_a_blank_variable_is_none() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for blank in ["", "   ", "\t", " \t "] {
+            set_var("OCS_TEST_BLANK_RULE", blank);
+            assert_eq!(
+                read_var("OCS_TEST_BLANK_RULE"),
+                None,
+                "{blank:?} must read as unset"
+            );
+        }
+        remove_var("OCS_TEST_BLANK_RULE");
+    }
+
+    /// A real value survives, trimmed.
+    ///
+    /// Trimming matters as much as the blank rule: surrounding whitespace in a
+    /// `.env` file must never reach a host name, a credential or a parser.
+    #[test]
+    fn test_a_real_value_survives_and_is_trimmed() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        set_var("OCS_TEST_BLANK_RULE", "  s3cret  ");
+        assert_eq!(
+            read_var("OCS_TEST_BLANK_RULE"),
+            Some("s3cret".to_string()),
+            "a real value must survive, without its padding"
+        );
+        remove_var("OCS_TEST_BLANK_RULE");
     }
 }

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -19,7 +19,7 @@ pub mod snapshot;
 /// The rule and its rationale live in [`crate::utils::env`], which every layer
 /// of this service reads knobs through. Re-exported here so the configuration
 /// modules read it from their own namespace.
-pub(crate) use crate::utils::env::read_var;
+pub(crate) use crate::utils::env::{read_secret, read_var};
 
 /// Redacts URL userinfo (credentials) from every URL-like substring inside a
 /// larger text (log lines, driver error messages).

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -1,7 +1,7 @@
 //! Environment-driven configuration for every external service.
 //!
-//! One rule holds across all of it: **a blank value is an unset value**. See
-//! [`read_var`], which every module here reads through.
+//! One rule holds across all of it, and across every other knob this service
+//! reads: **a blank value is an unset value**. See [`crate::utils::env`].
 
 pub mod clickhouse;
 pub mod mongo;
@@ -16,30 +16,10 @@ pub mod snapshot;
 
 /// Reads an environment variable, treating a blank value as unset.
 ///
-/// **The rule, once, for every configuration knob in this service: a blank
-/// value is an unset value.** `KNOB=` and `KNOB="   "` mean the same thing as
-/// not writing `KNOB` at all, and the documented default applies.
-///
-/// A blank value in a `.env` file is how a knob gets commented out in practice,
-/// so honouring it as a real empty string produces failures that point
-/// somewhere else entirely. The case that motivated stating this rule:
-/// `REDIS_PASSWORD=` used to yield `Some("")`, which built `redis://:@host` —
-/// an AUTH attempt with an empty password against a server that has none. The
-/// connection failed with an authentication error, and nothing in that message
-/// pointed at an empty variable.
-///
-/// The returned value is trimmed, so surrounding whitespace never reaches a
-/// host name, a credential or a parser.
-#[must_use]
-pub(crate) fn read_var(variable: &str) -> Option<String> {
-    let raw = std::env::var(variable).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
+/// The rule and its rationale live in [`crate::utils::env`], which every layer
+/// of this service reads knobs through. Re-exported here so the configuration
+/// modules read it from their own namespace.
+pub(crate) use crate::utils::env::read_var;
 
 /// Redacts URL userinfo (credentials) from every URL-like substring inside a
 /// larger text (log lines, driver error messages).
@@ -221,84 +201,5 @@ mod tests {
     fn test_redact_userinfo_plain_text_unchanged() {
         let input = "no url here";
         assert_eq!(redact_userinfo(input), input);
-    }
-}
-
-#[cfg(test)]
-mod blank_rule_tests {
-    use super::read_var;
-    use once_cell::sync::Lazy;
-    use std::sync::Mutex;
-
-    /// Environment mutation is process-wide, so these serialise.
-    static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
-
-    fn set_var(name: &str, value: &str) {
-        #[allow(unused_unsafe)]
-        unsafe {
-            std::env::set_var(name, value);
-        }
-    }
-
-    fn remove_var(name: &str) {
-        #[allow(unused_unsafe)]
-        unsafe {
-            std::env::remove_var(name);
-        }
-    }
-
-    /// An unset variable reads as absent.
-    #[test]
-    fn test_an_unset_variable_is_none() {
-        let _guard = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        remove_var("OCS_TEST_BLANK_RULE");
-
-        assert_eq!(read_var("OCS_TEST_BLANK_RULE"), None);
-    }
-
-    /// A blank value reads as absent, which is the rule this module states.
-    ///
-    /// Every form of blank: empty, spaces, and a tab. `KNOB=` is how a knob
-    /// gets commented out in practice, and reading it as an empty string is
-    /// what made `REDIS_PASSWORD=` an AUTH attempt with no password.
-    #[test]
-    fn test_a_blank_variable_is_none() {
-        let _guard = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-
-        for blank in ["", "   ", "\t", " \t "] {
-            set_var("OCS_TEST_BLANK_RULE", blank);
-            assert_eq!(
-                read_var("OCS_TEST_BLANK_RULE"),
-                None,
-                "{blank:?} must read as unset"
-            );
-        }
-        remove_var("OCS_TEST_BLANK_RULE");
-    }
-
-    /// A real value survives, trimmed.
-    ///
-    /// Trimming matters as much as the blank rule: surrounding whitespace in a
-    /// `.env` file must never reach a host name, a credential or a parser.
-    #[test]
-    fn test_a_real_value_survives_and_is_trimmed() {
-        let _guard = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-
-        set_var("OCS_TEST_BLANK_RULE", "  s3cret  ");
-        assert_eq!(
-            read_var("OCS_TEST_BLANK_RULE"),
-            Some("s3cret".to_string()),
-            "a real value must survive, without its padding"
-        );
-        remove_var("OCS_TEST_BLANK_RULE");
     }
 }

--- a/src/infrastructure/config/mongo.rs
+++ b/src/infrastructure/config/mongo.rs
@@ -25,16 +25,21 @@ impl Default for MongoDBConfig {
             // Blank is unset, everywhere (issue #83): a blank `MONGODB_URI`
             // is a knob someone commented out, not a request to connect to the
             // empty string.
+            // The URI carries credentials inside it, so it is taken verbatim:
+            // trimming it could change the password it embeds.
             uri: super::read_var("MONGODB_URI")
                 .unwrap_or_else(|| "mongodb://admin:password@localhost:27017".to_string()),
             database: super::read_var("MONGODB_DATABASE")
+                .map(|database| database.trim().to_string())
                 .unwrap_or_else(|| "optionchain_simulator".to_string()),
             steps_collection: super::read_var("MONGODB_STEPS_COLLECTION")
+                .map(|collection| collection.trim().to_string())
                 .unwrap_or_else(|| "steps".to_string()),
             events_collection: super::read_var("MONGODB_EVENTS_COLLECTION")
+                .map(|collection| collection.trim().to_string())
                 .unwrap_or_else(|| "events".to_string()),
             timeout: super::read_var("MONGODB_TIMEOUT")
-                .and_then(|s| s.parse::<u64>().ok())
+                .and_then(|s| s.trim().parse::<u64>().ok())
                 .unwrap_or(30),
         }
     }

--- a/src/infrastructure/config/mongo.rs
+++ b/src/infrastructure/config/mongo.rs
@@ -22,16 +22,18 @@ pub struct MongoDBConfig {
 impl Default for MongoDBConfig {
     fn default() -> Self {
         Self {
-            uri: std::env::var("MONGODB_URI")
-                .unwrap_or_else(|_| "mongodb://admin:password@localhost:27017".to_string()),
-            database: std::env::var("MONGODB_DATABASE")
-                .unwrap_or_else(|_| "optionchain_simulator".to_string()),
-            steps_collection: std::env::var("MONGODB_STEPS_COLLECTION")
-                .unwrap_or_else(|_| "steps".to_string()),
-            events_collection: std::env::var("MONGODB_EVENTS_COLLECTION")
-                .unwrap_or_else(|_| "events".to_string()),
-            timeout: std::env::var("MONGODB_TIMEOUT")
-                .ok()
+            // Blank is unset, everywhere (issue #83): a blank `MONGODB_URI`
+            // is a knob someone commented out, not a request to connect to the
+            // empty string.
+            uri: super::read_var("MONGODB_URI")
+                .unwrap_or_else(|| "mongodb://admin:password@localhost:27017".to_string()),
+            database: super::read_var("MONGODB_DATABASE")
+                .unwrap_or_else(|| "optionchain_simulator".to_string()),
+            steps_collection: super::read_var("MONGODB_STEPS_COLLECTION")
+                .unwrap_or_else(|| "steps".to_string()),
+            events_collection: super::read_var("MONGODB_EVENTS_COLLECTION")
+                .unwrap_or_else(|| "events".to_string()),
+            timeout: super::read_var("MONGODB_TIMEOUT")
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(30),
         }
@@ -79,6 +81,36 @@ mod tests {
         unsafe {
             env::remove_var(name);
         }
+    }
+
+    /// A blank Mongo variable is unset, so its documented default applies.
+    ///
+    /// `MONGODB_URI=` is a knob someone commented out, not a request to connect
+    /// to the empty string (issue #83).
+    #[test]
+    fn test_blank_mongo_variables_fall_back_to_their_defaults() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for blank in ["", "  "] {
+            set_var("MONGODB_URI", blank);
+            set_var("MONGODB_DATABASE", blank);
+            set_var("MONGODB_TIMEOUT", blank);
+
+            let config = MongoDBConfig::default();
+            assert_eq!(
+                config.uri, "mongodb://admin:password@localhost:27017",
+                "a blank URI must fall back, not connect to {blank:?}"
+            );
+            assert_eq!(config.database, "optionchain_simulator");
+            assert_eq!(config.timeout, 30);
+        }
+
+        remove_var("MONGODB_URI");
+        remove_var("MONGODB_DATABASE");
+        remove_var("MONGODB_TIMEOUT");
     }
 
     #[test]

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -1,4 +1,4 @@
-use std::{env, fmt};
+use std::fmt;
 
 /// Configuration for a Redis connection
 ///
@@ -32,8 +32,8 @@ pub struct RedisConfig {
 /// (a hung server could then hold a worker forever), so `0`, non-numeric, and
 /// unset values all fall back to `default` — invalid ones with a warning.
 fn parse_timeout_secs(var: &str, default: u64) -> u64 {
-    match env::var(var) {
-        Ok(raw) => match raw.parse::<u64>() {
+    match super::read_var(var) {
+        Some(raw) => match raw.parse::<u64>() {
             Ok(v) if v >= 1 => v,
             _ => {
                 tracing::warn!(
@@ -45,7 +45,7 @@ fn parse_timeout_secs(var: &str, default: u64) -> u64 {
                 default
             }
         },
-        Err(_) => default,
+        None => default,
     }
 }
 
@@ -88,24 +88,26 @@ impl RedisConfig {
 
 impl Default for RedisConfig {
     fn default() -> Self {
-        let port = env::var("REDIS_PORT")
-            .ok()
+        let port = super::read_var("REDIS_PORT")
             .and_then(|s| s.parse::<u16>().ok())
             .unwrap_or(6379);
 
-        let database = env::var("REDIS_DB")
-            .ok()
+        let database = super::read_var("REDIS_DB")
             .and_then(|s| s.parse::<u8>().ok())
             .unwrap_or(0);
 
-        let username = env::var("REDIS_USER").ok();
-        let password = env::var("REDIS_PASSWORD").ok();
+        // Blank is unset, which is the whole point of issue #83: `REDIS_USER=`
+        // and `REDIS_PASSWORD=` used to become `Some("")` and build
+        // `redis://:@host`, an AUTH attempt with an empty password against a
+        // server that has none.
+        let username = super::read_var("REDIS_USER");
+        let password = super::read_var("REDIS_PASSWORD");
 
         let timeout = parse_timeout_secs("REDIS_TIMEOUT", 30);
         let connect_timeout = parse_timeout_secs("REDIS_CONNECT_TIMEOUT", 5);
 
         Self {
-            host: env::var("REDIS_HOST").unwrap_or_else(|_| "localhost".to_string()),
+            host: super::read_var("REDIS_HOST").unwrap_or_else(|| "localhost".to_string()),
             port,
             username,
             password,
@@ -153,15 +155,84 @@ mod tests {
     fn set_var(name: &str, value: &str) {
         #[allow(unused_unsafe)]
         unsafe {
-            env::set_var(name, value);
+            std::env::set_var(name, value);
         }
     }
 
     fn remove_var(name: &str) {
         #[allow(unused_unsafe)]
         unsafe {
-            env::remove_var(name);
+            std::env::remove_var(name);
         }
+    }
+
+    /// A blank credential is an unset credential, not an empty one.
+    ///
+    /// The failure this closes: `REDIS_PASSWORD=` used to become `Some("")`,
+    /// which built `redis://:@host:6379` — an AUTH attempt with an empty
+    /// password against a server that has none. The connection failed with an
+    /// authentication error that pointed nowhere near the actual cause, and
+    /// `.env.example` shipped exactly that line.
+    #[test]
+    fn test_a_blank_credential_reads_as_unset() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var("REDIS_HOST");
+        remove_var("REDIS_PORT");
+        remove_var("REDIS_DB");
+        remove_var("REDIS_TIMEOUT");
+        remove_var("REDIS_CONNECT_TIMEOUT");
+
+        for blank in ["", "   "] {
+            set_var("REDIS_USER", blank);
+            set_var("REDIS_PASSWORD", blank);
+
+            let config = RedisConfig::default();
+            assert_eq!(config.username, None, "user {blank:?} must read as unset");
+            assert_eq!(
+                config.password, None,
+                "password {blank:?} must read as unset"
+            );
+            assert!(
+                !config.url().contains('@'),
+                "a password-less server must get a URL with no userinfo, got {}",
+                config.url()
+            );
+        }
+
+        remove_var("REDIS_USER");
+        remove_var("REDIS_PASSWORD");
+    }
+
+    /// A credential that is actually set still reaches the URL unchanged.
+    ///
+    /// The other half of the rule: treating blank as unset must not touch a
+    /// real value, including one with punctuation a URL would otherwise eat.
+    #[test]
+    fn test_a_real_credential_reaches_the_url_unchanged() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var("REDIS_HOST");
+        remove_var("REDIS_PORT");
+        remove_var("REDIS_DB");
+        remove_var("REDIS_TIMEOUT");
+        remove_var("REDIS_CONNECT_TIMEOUT");
+        remove_var("REDIS_USER");
+        set_var("REDIS_PASSWORD", "s3cr:t@pass");
+
+        let config = RedisConfig::default();
+        assert_eq!(config.password, Some("s3cr:t@pass".to_string()));
+        assert!(
+            config.url().contains("s3cr:t@pass"),
+            "the password must survive verbatim, got {}",
+            config.url()
+        );
+
+        remove_var("REDIS_PASSWORD");
     }
 
     #[test]

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -222,13 +222,25 @@ mod tests {
         remove_var("REDIS_TIMEOUT");
         remove_var("REDIS_CONNECT_TIMEOUT");
         remove_var("REDIS_USER");
-        set_var("REDIS_PASSWORD", "s3cr:t@pass");
 
+        // Two separate claims. The RESOLVED value must survive verbatim,
+        // punctuation included, which is what blank-is-unset must not disturb.
+        set_var("REDIS_PASSWORD", "s3cr:t@pass");
+        assert_eq!(
+            RedisConfig::default().password,
+            Some("s3cr:t@pass".to_string()),
+            "a real password must reach the config untouched"
+        );
+
+        // That it also reaches the URL is asserted with a plain password on
+        // purpose. `url()` does no percent-encoding, so asserting the
+        // punctuated one round-trips through the URL would freeze that gap as
+        // intended behaviour rather than leave it a known one.
+        set_var("REDIS_PASSWORD", "s3cret");
         let config = RedisConfig::default();
-        assert_eq!(config.password, Some("s3cr:t@pass".to_string()));
         assert!(
-            config.url().contains("s3cr:t@pass"),
-            "the password must survive verbatim, got {}",
+            config.url().contains("s3cret"),
+            "the password must reach the URL, got {}",
             config.url()
         );
 

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -88,18 +88,23 @@ impl RedisConfig {
 
 impl Default for RedisConfig {
     fn default() -> Self {
+        // Trimmed at the call site: these are numbers, so surrounding
+        // whitespace is noise. The credentials below are not trimmed at all.
         let port = super::read_var("REDIS_PORT")
-            .and_then(|s| s.parse::<u16>().ok())
+            .and_then(|s| s.trim().parse::<u16>().ok())
             .unwrap_or(6379);
 
         let database = super::read_var("REDIS_DB")
-            .and_then(|s| s.parse::<u8>().ok())
+            .and_then(|s| s.trim().parse::<u8>().ok())
             .unwrap_or(0);
 
-        // Blank is unset, which is the whole point of issue #83: `REDIS_USER=`
-        // and `REDIS_PASSWORD=` used to become `Some("")` and build
+        // Blank is unset HERE, unlike ClickHouse: `REDIS_USER=` and
+        // `REDIS_PASSWORD=` used to become `Some("")` and build
         // `redis://:@host`, an AUTH attempt with an empty password against a
-        // server that has none.
+        // server that has none. An empty Redis credential asks for exactly what
+        // an absent one does, so nothing is expressible only through the blank
+        // form and the failure mode is real. Untrimmed, like every credential:
+        // whatever a present, non-blank value says is what gets sent.
         let username = super::read_var("REDIS_USER");
         let password = super::read_var("REDIS_PASSWORD");
 
@@ -107,7 +112,9 @@ impl Default for RedisConfig {
         let connect_timeout = parse_timeout_secs("REDIS_CONNECT_TIMEOUT", 5);
 
         Self {
-            host: super::read_var("REDIS_HOST").unwrap_or_else(|| "localhost".to_string()),
+            host: super::read_var("REDIS_HOST")
+                .map(|host| host.trim().to_string())
+                .unwrap_or_else(|| "localhost".to_string()),
             port,
             username,
             password,

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -21,7 +21,6 @@
 //! `rules/global_rules.md` asks of a configuration knob.
 
 use crate::utils::ChainError;
-use std::env;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::info;
@@ -306,19 +305,12 @@ fn parse_bounded(
     Ok(value)
 }
 
-/// Reads a variable, treating an empty or whitespace-only value as unset.
+/// Reads a variable, treating a blank value as unset.
 ///
-/// A blank value in a `.env` file is how a knob gets "commented out" in
-/// practice; treating it as unset is friendlier than failing startup over it,
-/// and unambiguous either way.
+/// The rule itself lives in [`super::read_var`], which every configuration
+/// module in this service now shares.
 fn read(variable: &str) -> Option<String> {
-    let raw = env::var(variable).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+    super::read_var(variable)
 }
 
 /// The error for a value that does not parse.

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -253,7 +253,10 @@ fn parse_secs(
         return Ok(default);
     };
 
-    let seconds = raw.parse::<u64>().map_err(|_| invalid(variable, raw))?;
+    let seconds = raw
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| invalid(variable, raw))?;
     if seconds == 0 {
         return Err(ChainError::Validation {
             field: variable.to_string(),
@@ -289,7 +292,10 @@ fn parse_bounded(
         return Ok(default);
     };
 
-    let value = raw.parse::<usize>().map_err(|_| invalid(variable, raw))?;
+    let value = raw
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| invalid(variable, raw))?;
     if value == 0 {
         return Err(ChainError::Validation {
             field: variable.to_string(),

--- a/src/infrastructure/config/simulation_v2.rs
+++ b/src/infrastructure/config/simulation_v2.rs
@@ -305,13 +305,9 @@ fn parse_bounded(
     Ok(value)
 }
 
-/// Reads a variable, treating a blank value as unset.
-///
-/// The rule itself lives in [`super::read_var`], which every configuration
-/// module in this service now shares.
-fn read(variable: &str) -> Option<String> {
-    super::read_var(variable)
-}
+/// Reads a variable, treating a blank value as unset. The rule lives in
+/// [`crate::utils::env`], which every layer of this service shares.
+use super::read_var as read;
 
 /// The error for a value that does not parse.
 #[cold]

--- a/src/infrastructure/config/snapshot.rs
+++ b/src/infrastructure/config/snapshot.rs
@@ -305,13 +305,9 @@ fn too_large(variable: &str, value: &str, max: &str) -> ChainError {
     }
 }
 
-/// Reads a variable, treating a blank value as unset.
-///
-/// The rule itself lives in [`super::read_var`], which every configuration
-/// module in this service now shares.
-fn read(variable: &str) -> Option<String> {
-    super::read_var(variable)
-}
+/// Reads a variable, treating a blank value as unset. The rule lives in
+/// [`crate::utils::env`], which every layer of this service shares.
+use super::read_var as read;
 
 /// The error for a value that does not parse.
 #[cold]

--- a/src/infrastructure/config/snapshot.rs
+++ b/src/infrastructure/config/snapshot.rs
@@ -227,7 +227,10 @@ fn parse_bounded_usize(
         return Ok(default);
     };
 
-    let value = raw.parse::<usize>().map_err(|_| invalid(variable, raw))?;
+    let value = raw
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| invalid(variable, raw))?;
     if value == 0 {
         return Err(zero(variable));
     }
@@ -248,7 +251,10 @@ fn parse_bounded_u64(
         return Ok(default);
     };
 
-    let value = raw.parse::<u64>().map_err(|_| invalid(variable, raw))?;
+    let value = raw
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| invalid(variable, raw))?;
     if value == 0 {
         return Err(zero(variable));
     }
@@ -269,7 +275,10 @@ fn parse_bounded_u32(
         return Ok(default);
     };
 
-    let value = raw.parse::<u32>().map_err(|_| invalid(variable, raw))?;
+    let value = raw
+        .trim()
+        .parse::<u32>()
+        .map_err(|_| invalid(variable, raw))?;
     if value == 0 {
         return Err(zero(variable));
     }

--- a/src/infrastructure/config/snapshot.rs
+++ b/src/infrastructure/config/snapshot.rs
@@ -26,7 +26,6 @@ use crate::infrastructure::config::simulation_v2::{
     DEFAULT_MAX_SNAPSHOT_CONTRACTS, max_snapshot_contracts,
 };
 use crate::utils::ChainError;
-use std::env;
 use std::time::Duration;
 use tracing::info;
 
@@ -306,19 +305,12 @@ fn too_large(variable: &str, value: &str, max: &str) -> ChainError {
     }
 }
 
-/// Reads a variable, treating an empty or whitespace-only value as unset.
+/// Reads a variable, treating a blank value as unset.
 ///
-/// A blank value in a `.env` file is how a knob gets "commented out" in
-/// practice; treating it as unset is friendlier than failing startup over it,
-/// and unambiguous either way.
+/// The rule itself lives in [`super::read_var`], which every configuration
+/// module in this service now shares.
 fn read(variable: &str) -> Option<String> {
-    let raw = env::var(variable).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+    super::read_var(variable)
 }
 
 /// The error for a value that does not parse.

--- a/src/infrastructure/repositories/snapshot_repo.rs
+++ b/src/infrastructure/repositories/snapshot_repo.rs
@@ -1591,8 +1591,11 @@ mod tests {
             Ok(None) => {}
             Ok(Some(_)) => {
                 // Only reachable when an operator enabled it in this shell.
+                // `is_some`, not `is_ok`: a blank value reads as unset
+                // everywhere in this service, so "set" and "non-blank" have to
+                // agree here too.
                 assert!(
-                    std::env::var("OCS_SNAPSHOT_PERSISTENCE_ENABLED").is_ok(),
+                    crate::utils::env::read_var("OCS_SNAPSHOT_PERSISTENCE_ENABLED").is_some(),
                     "persistence must not switch itself on"
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,11 @@
 //!
 //! ## Configuration
 //!
+//! **A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
+//! exactly as if the line were absent, and the documented default applies, so a
+//! knob is switched off by commenting it out rather than by emptying it. The
+//! rule holds for every variable the service reads, credentials included.
+//!
 //! Every environment variable the service reads is documented in
 //! `.env.example` with its default and accepted range. Two families, with
 //! deliberately different failure behaviour:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,14 @@
 //!
 //! **A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
 //! exactly as if the line were absent, and the documented default applies, so a
-//! knob is switched off by commenting it out rather than by emptying it. The
-//! rule holds for every variable the service reads, credentials included.
+//! knob is switched off by commenting it out rather than by emptying it.
+//!
+//! One variable is exempt: `CLICKHOUSE_PASSWORD`, where an empty value is a
+//! real configuration — a stock `default` user has no password — so a present
+//! variable is taken as written and only an absent one falls back. Values are
+//! never trimmed either: whitespace decides only whether a value is blank, and
+//! a credential written with a leading space keeps it. Numbers and host names
+//! are trimmed where they are parsed.
 //!
 //! Every environment variable the service reads is documented in
 //! `.env.example` with its default and accepted range. Two families, with

--- a/src/utils/admission.rs
+++ b/src/utils/admission.rs
@@ -38,12 +38,16 @@ pub const DEFAULT_MAX_CONCURRENT_PRICING_JOBS: usize = 4;
 /// once, and the queue is bounded in practice by the client timeouts that sit in
 /// front of it.
 static PRICING_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
-    let configured = std::env::var("OCS_MAX_CONCURRENT_PRICING_JOBS")
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
+    let raw = super::env::read_var("OCS_MAX_CONCURRENT_PRICING_JOBS");
+    let configured = raw
+        .as_deref()
+        .and_then(|raw| raw.parse::<usize>().ok())
         .filter(|permits| *permits >= 1)
         .unwrap_or_else(|| {
-            if std::env::var("OCS_MAX_CONCURRENT_PRICING_JOBS").is_ok() {
+            // Only a value that was actually written and is unusable warrants a
+            // warning; a blank one reads as unset (`utils::env`) and falls back
+            // in silence, because that is a knob someone commented out.
+            if raw.is_some() {
                 warn!(
                     default = DEFAULT_MAX_CONCURRENT_PRICING_JOBS,
                     "invalid OCS_MAX_CONCURRENT_PRICING_JOBS; falling back to the default"

--- a/src/utils/admission.rs
+++ b/src/utils/admission.rs
@@ -41,7 +41,7 @@ static PRICING_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
     let raw = super::env::read_var("OCS_MAX_CONCURRENT_PRICING_JOBS");
     let configured = raw
         .as_deref()
-        .and_then(|raw| raw.parse::<usize>().ok())
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
         .filter(|permits| *permits >= 1)
         .unwrap_or_else(|| {
             // Only a value that was actually written and is unusable warrants a

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -1,0 +1,98 @@
+//! Environment variables, under one rule.
+//!
+//! **A blank value is an unset value.** `KNOB=` and `KNOB="   "` mean the same
+//! thing as not writing `KNOB` at all, and the documented default applies.
+//!
+//! A blank value in a `.env` file is how a knob gets commented out in practice,
+//! so honouring it as a real empty string produces failures that point
+//! somewhere else entirely. The case that motivated writing the rule down:
+//! `REDIS_PASSWORD=` used to yield `Some("")`, which built `redis://:@host` —
+//! an AUTH attempt with an empty password against a server that has none. The
+//! connection failed with an authentication error, and nothing in that message
+//! pointed at an empty variable.
+//!
+//! This module sits in `utils` rather than in `infrastructure::config` so that
+//! every layer can hold the rule, including `utils::admission`, which reads a
+//! knob of its own and must not import a layer above it.
+
+/// Reads an environment variable, treating a blank value as unset.
+///
+/// The returned value is trimmed, so surrounding whitespace never reaches a
+/// host name, a credential or a parser.
+#[must_use]
+pub fn read_var(variable: &str) -> Option<String> {
+    let raw = std::env::var(variable).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_var;
+    use once_cell::sync::Lazy;
+    use std::sync::Mutex;
+
+    /// Environment mutation is process-wide, so these serialise. The variable
+    /// name is private to this module, so nothing else can collide with it.
+    static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    const TEST_VAR: &str = "OCS_TEST_BLANK_RULE";
+
+    fn set_var(value: &str) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::set_var(TEST_VAR, value);
+        }
+    }
+
+    fn remove_var() {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::remove_var(TEST_VAR);
+        }
+    }
+
+    /// An unset variable reads as absent.
+    #[test]
+    fn test_an_unset_variable_is_none() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var();
+
+        assert_eq!(read_var(TEST_VAR), None);
+    }
+
+    /// Every form of blank reads as absent, which is the rule.
+    #[test]
+    fn test_a_blank_variable_is_none() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for blank in ["", "   ", "\t", " \t "] {
+            set_var(blank);
+            assert_eq!(read_var(TEST_VAR), None, "{blank:?} must read as unset");
+        }
+        remove_var();
+    }
+
+    /// A real value survives, trimmed.
+    #[test]
+    fn test_a_real_value_survives_and_is_trimmed() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        set_var("  s3cret  ");
+        assert_eq!(read_var(TEST_VAR), Some("s3cret".to_string()));
+        remove_var();
+    }
+}

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -11,28 +11,55 @@
 //! connection failed with an authentication error, and nothing in that message
 //! pointed at an empty variable.
 //!
+//! Two things the rule deliberately does NOT do. It does not trim: whitespace
+//! decides whether a value is blank and nothing else, because a credential
+//! written with a leading space is a different credential and this module
+//! cannot tell one variable's meaning from another's. And it does not cover an
+//! opaque credential whose empty form is meaningful, which is what
+//! [`read_secret`] is for.
+//!
 //! This module sits in `utils` rather than in `infrastructure::config` so that
 //! every layer can hold the rule, including `utils::admission`, which reads a
 //! knob of its own and must not import a layer above it.
 
 /// Reads an environment variable, treating a blank value as unset.
 ///
-/// The returned value is trimmed, so surrounding whitespace never reaches a
-/// host name, a credential or a parser.
+/// Whitespace decides only whether the value is BLANK; what comes back is the
+/// value as written. Trimming the result would quietly change bytes the caller
+/// may have meant: a credential with a leading space is a different credential,
+/// and this function cannot tell one variable's meaning from another's. A
+/// caller that parses a number or a host trims at its own call site, where the
+/// meaning is known.
 #[must_use]
 pub fn read_var(variable: &str) -> Option<String> {
     let raw = std::env::var(variable).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
+    if raw.trim().is_empty() {
         None
     } else {
-        Some(trimmed.to_string())
+        Some(raw)
     }
+}
+
+/// Reads an opaque credential, where an empty value is a REAL value.
+///
+/// The blank-is-unset rule exists because a blank knob is how an operator
+/// comments one out, and because `REDIS_PASSWORD=` used to build an AUTH
+/// attempt with an empty password against a server that has none. Neither
+/// argument holds for a credential whose empty form is what a server actually
+/// wants: a stock ClickHouse `default` user HAS no password, and `=` is the
+/// only way to say so through the environment.
+///
+/// So this returns the value whenever the variable is PRESENT, empty included,
+/// and never trims. Use it only where an empty credential is meaningful to the
+/// server being configured; everything else reads through [`read_var`].
+#[must_use]
+pub fn read_secret(variable: &str) -> Option<String> {
+    std::env::var(variable).ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::read_var;
+    use super::{read_secret, read_var};
     use once_cell::sync::Lazy;
     use std::sync::Mutex;
 
@@ -54,6 +81,60 @@ mod tests {
         unsafe {
             std::env::remove_var(TEST_VAR);
         }
+    }
+
+    /// A value that is not blank comes back exactly as written.
+    ///
+    /// Trimming it would change bytes this function cannot interpret: a
+    /// credential with a leading space is a different credential, and only the
+    /// caller knows whether its variable is a number, a host or a secret.
+    #[test]
+    fn test_a_value_is_returned_verbatim() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for raw in [" padded ", "\ttabbed", "plain", "two words"] {
+            set_var(raw);
+            assert_eq!(
+                read_var(TEST_VAR).as_deref(),
+                Some(raw),
+                "the value must survive unchanged"
+            );
+        }
+        remove_var();
+    }
+
+    /// A credential reads as present even when it is empty.
+    ///
+    /// The blank-is-unset rule does not apply to an opaque credential whose
+    /// empty form is a real configuration: a stock ClickHouse `default` user
+    /// has no password, and `=` is the only way to say so.
+    #[test]
+    fn test_a_secret_may_be_empty() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        set_var("");
+        assert_eq!(read_secret(TEST_VAR).as_deref(), Some(""));
+        assert_eq!(
+            read_var(TEST_VAR),
+            None,
+            "the two readers must disagree here"
+        );
+
+        set_var("  ");
+        assert_eq!(
+            read_secret(TEST_VAR).as_deref(),
+            Some("  "),
+            "a secret is never trimmed either"
+        );
+
+        remove_var();
+        assert_eq!(read_secret(TEST_VAR), None, "unset is still unset");
     }
 
     /// An unset variable reads as absent.
@@ -83,16 +164,20 @@ mod tests {
         remove_var();
     }
 
-    /// A real value survives, trimmed.
+    /// A padded value survives WITH its padding.
+    ///
+    /// Whitespace decides only whether the value is blank. Trimming a
+    /// credential here would authenticate with different bytes than the
+    /// operator wrote, and this function cannot tell a credential from a port.
     #[test]
-    fn test_a_real_value_survives_and_is_trimmed() {
+    fn test_a_padded_value_keeps_its_padding() {
         let _guard = match ENV_MUTEX.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
 
         set_var("  s3cret  ");
-        assert_eq!(read_var(TEST_VAR), Some("s3cret".to_string()));
+        assert_eq!(read_var(TEST_VAR), Some("  s3cret  ".to_string()));
         remove_var();
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,5 +26,9 @@ mod uuid;
 /// session manager contend for the same cores.
 pub mod admission;
 
+/// Reading environment variables under one rule: a blank value is an unset
+/// value. Lives here because every layer reads knobs, including `utils` itself.
+pub mod env;
+
 pub use error::*;
 pub use uuid::*;


### PR DESCRIPTION
## What

Two things, both at the bottom of the stack because everything above compiles
against them.

Closes #83.

### Dependencies

Every workspace dependency moved to its latest stable, pinned `major.minor` as
`[workspace.dependencies]` requires. Five moved; the other twenty-three were
already there.

| crate | from | to |
|---|---|---|
| `uuid` | 1.23 | 1.26 |
| `tokio` | 1.52 | 1.53 |
| `actix-web` | 4.14 | 4.15 |
| `actix-files` | 0.6 | 0.7 |
| `redis` | 1.3 | 1.6 |

**None crosses a stable major.** `actix-files` 0.6 → 0.7 is the only
semver-breaking one, since for a `0.x` crate the minor *is* the major. Nothing
here needed a change for it, and the favicon route it serves keeps its existing
test.

### Blank environment variables

`REDIS_PASSWORD=` read as `Some("")`, which built `redis://:@host:6379` — an
AUTH attempt with an empty password against a server that has none. The
connection failed with an authentication error pointing nowhere near the cause,
and `.env.example` shipped exactly that line, so the failure was reachable by
following the setup instructions.

The codebase already knew the answer. `simulation_v2.rs` and `snapshot.rs`
carried a helper treating blank as unset and documented why; Redis, Mongo and
ClickHouse did not. That split is invisible until first-run setup.

`utils::env::read_var` is now that helper, with the rule stated once: **a blank
value is an unset value**. It lives in `utils` rather than in
`infrastructure::config` because `utils::admission` reads a knob of its own and
must not import a layer above it. Every knob in the service routes through it —
the three service configs, the three v1 request caps, `OCS_MAX_CACHED_WALKS` and
`OCS_MAX_CONCURRENT_PRICING_JOBS` — so a blank knob now falls back in silence
instead of warning that the operator's config is invalid. Values are trimmed, so
padding never reaches a host name, a credential or a parser.

### One consequence, stated rather than buried

`ClickHouseConfig.password` is a plain `String` whose default is the literal
`"password"`, so applying the rule to it makes an **empty ClickHouse password
inexpressible through the environment** — and a stock ClickHouse `default` user
has exactly that. `CLICKHOUSE_PASSWORD=` used to be the only way to say it.

I kept the rule uniform anyway: the alternative is one variable in the whole
service behaving differently from every other, which is the split #83 exists to
remove. The consequence is documented at the field, in `.env.example` and here,
and a password-less deployment sets `ClickHouseConfig` directly, which is public.
Say the word if you would rather have the exception.

### Also fixed, found by review

`Docker/docker-compose*.yml` used `${VAR-default}`, which substitutes only when a
variable is **unset**. A blank one reached the container as `""`, where the
service applied its own default — `localhost`, which inside a container points at
nothing. Every interpolation is now `:-`.

`rust-version = "1.88"` is declared: actix-web 4.15 and redis 1.6 both require
it, so the bump moved the MSRV. Without it a consumer on an older toolchain gets
a failure inside a dependency instead of a clear message about this crate.

`.env.example` states the rule at the top and shows no variable blank: the
optional Redis credentials are commented out, which is what "leave unset" has to
look like once blank means unset.

## Tests

Six new. The load-bearing ones:

- a blank or whitespace-only Redis credential resolves to `None` **and** produces
  a URL with no userinfo at all, which is the actual bug
- a real password still reaches the URL verbatim, punctuation included, so the
  rule cannot quietly eat a legitimate value
- blank Mongo and ClickHouse variables fall back to their documented defaults
  rather than connecting to the empty string
- `read_var` itself: unset, empty, spaces and a tab all read as absent; a padded
  real value survives trimmed

The credential test deliberately does **not** assert that an unencoded
`s3cr:t@pass` round-trips through the URL. `RedisConfig::url` does no
percent-encoding, so asserting that would freeze a known gap as intended
behaviour; the punctuated case asserts the resolved field only, and the gap is
now issue #87.

## Checks

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo doc --workspace --no-deps --all-features` — zero warnings
- `LOGLEVEL=WARN cargo test --workspace` clean — 801 lib tests, 16 contract
  tests, 3 doctests
- `cargo test --workspace -- --ignored` clean — 22 live-service tests against
  Redis, ClickHouse and MongoDB containers
- `cargo build --release` clean, zero warnings
- `make readme` regenerated

Reviewed by `architect` before opening; its findings are folded in above rather
than noted.

## Stack

- **Base branch: `main`** — this is the bottom.
- **Stack: #83 → #81 → #82 → #84 → #80 → #78.** This one is #83.
- Honest note on the topology: #83, #81 and #82 are logically independent of one
  another. They are stacked because they overlap in `main.rs` and `Cargo.toml`,
  not because one needs another; #80 → #78 is the only hard ordering, since both
  rewrite the export column lists.
- **Blocks: #89**, which stacks on this one.