### PR TITLE
Honour LOGLEVEL instead of hardcoding DEBUG (#81)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,14 @@
 # Logging
 # ---------------------------------------------------------------------------
 
-# Verbosity of the tracing subscriber.
-# Values: TRACE | DEBUG | INFO | WARN | ERROR.  Default: DEBUG
+# Verbosity of the tracing subscriber. Case-insensitive. An unrecognised value
+# warns once at startup and falls back to the default rather than aborting. The
+# effective level is logged at that same level, so setting WARN or ERROR still
+# confirms itself.
+#
+# DEBUG is loud: it includes hyper connection traces on every request, which for
+# a batch consumer materialising hundreds of tapes buries anything worth reading.
+# Values: TRACE | DEBUG | INFO | WARN | ERROR.  Default: INFO
 LOGLEVEL=INFO
 
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ need no changes.
 
 ### Configuration
 
+`LOGLEVEL` sets the verbosity, case-insensitively, defaulting to `INFO`. An
+unrecognised value warns once and falls back rather than aborting startup,
+and the effective level is logged at that same level, so setting `WARN` or
+`ERROR` still confirms itself.
+`DEBUG` includes hyper connection traces on every request, which a batch
+consumer will want to avoid.
+
 **A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
 exactly as if the line were absent, and the documented default applies, so a
 knob is switched off by commenting it out rather than by emptying it.

--- a/src/infrastructure/config/logging.rs
+++ b/src/infrastructure/config/logging.rs
@@ -1,0 +1,294 @@
+//! Resolving the process log level from `LOGLEVEL`.
+//!
+//! The service used to log at `DEBUG` unconditionally: `main` passed the
+//! literal `"DEBUG"`, and `LOGLEVEL` was read nowhere in `src/` at all.
+//! `.env.example` documented the variable, so an operator set it, saw no
+//! change, and reasonably concluded the logging configuration was broken rather
+//! than absent.
+//!
+//! The cost was not cosmetic. At `DEBUG` the service emits hyper connection
+//! traces on every request, which for a batch consumer materialising hundreds of
+//! tapes buries anything worth reading and costs real IO.
+//!
+//! Resolution is a pure function so it can be asserted directly, rather than by
+//! scraping log output for what did or did not appear.
+//!
+//! It lives beside the other configuration knobs rather than in `utils`: it has
+//! one caller, and `rules/global_rules.md` puts a new knob with its config
+//! module. `utils::env` is the exception, and only because `utils::admission`
+//! reads a knob of its own and must not import a layer above it.
+
+use super::read_var;
+use std::fmt;
+
+/// The environment variable that sets the process log level.
+pub const LOG_LEVEL_VAR: &str = "LOGLEVEL";
+
+/// The level used when `LOGLEVEL` is unset, blank, or unrecognised.
+pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::Info;
+
+/// A log level this service accepts.
+///
+/// The five `tracing` levels and nothing else, `#[repr(u8)]` as
+/// `rules/global_rules.md` asks of a small closed enum.
+///
+/// `Ord` is severity-ASCENDING — `Trace < Error` — which is the REVERSE of
+/// `tracing::Level`, where `TRACE > ERROR`. Nothing here compares the two, but
+/// anyone who starts to should know they disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum LogLevel {
+    /// Per-row, per-leg detail. Development only.
+    Trace,
+    /// Internal state transitions.
+    Debug,
+    /// Business events: started, resolved, finished.
+    Info,
+    /// Recoverable problems and constraint relaxations.
+    Warn,
+    /// Unrecoverable failures and invariant violations.
+    Error,
+}
+
+impl LogLevel {
+    /// The upper-case name upstream's `setup_logger_with_level` expects.
+    #[must_use]
+    #[inline]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LogLevel::Trace => "TRACE",
+            LogLevel::Debug => "DEBUG",
+            LogLevel::Info => "INFO",
+            LogLevel::Warn => "WARN",
+            LogLevel::Error => "ERROR",
+        }
+    }
+
+    /// Parses a level name, case-insensitively.
+    ///
+    /// Returns `None` for anything else, which the caller reports rather than
+    /// silently swallowing.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_uppercase().as_str() {
+            "TRACE" => Some(LogLevel::Trace),
+            "DEBUG" => Some(LogLevel::Debug),
+            "INFO" => Some(LogLevel::Info),
+            "WARN" => Some(LogLevel::Warn),
+            "ERROR" => Some(LogLevel::Error),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What `LOGLEVEL` resolved to, and whether anything was wrong with it.
+///
+/// The two are separate because they are consumed at different moments: the
+/// level has to be known BEFORE a subscriber exists, and the complaint about a
+/// bad value can only be logged AFTER one does. Returning both lets `main`
+/// install the subscriber first and then say what it ignored, instead of
+/// swallowing the mistake or aborting over it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLogLevel {
+    /// The level to configure.
+    pub level: LogLevel,
+    /// The value that was rejected, if one was. `None` when `LOGLEVEL` was
+    /// unset, blank, or valid.
+    pub rejected: Option<String>,
+}
+
+/// Resolves a raw `LOGLEVEL` value.
+///
+/// Unset or blank resolves to [`DEFAULT_LOG_LEVEL`] with nothing rejected: a
+/// blank value is an unset value everywhere in this service
+/// ([`crate::utils::env`]), and a knob nobody set is not a mistake.
+///
+/// An unrecognised value resolves to the same default but reports itself, so it
+/// can be warned about once. It never aborts startup: refusing to boot because
+/// a log level is misspelled trades a small problem for a total one.
+#[must_use]
+pub fn resolve_log_level(raw: Option<&str>) -> ResolvedLogLevel {
+    match raw {
+        None => ResolvedLogLevel {
+            level: DEFAULT_LOG_LEVEL,
+            rejected: None,
+        },
+        // Blank is unset, not a mistake. `read_var` filters it before
+        // `resolve_log_level_from_env` gets here, but this function is public
+        // and a direct caller must not be told its empty string was rejected.
+        Some(raw) if raw.trim().is_empty() => ResolvedLogLevel {
+            level: DEFAULT_LOG_LEVEL,
+            rejected: None,
+        },
+        Some(raw) => match LogLevel::parse(raw) {
+            Some(level) => ResolvedLogLevel {
+                level,
+                rejected: None,
+            },
+            None => ResolvedLogLevel {
+                level: DEFAULT_LOG_LEVEL,
+                rejected: Some(raw.to_string()),
+            },
+        },
+    }
+}
+
+/// Resolves `LOGLEVEL` from the environment.
+///
+/// See [`resolve_log_level`]; this only supplies the value, through the same
+/// blank-is-unset reader every other knob uses.
+#[must_use]
+pub fn resolve_log_level_from_env() -> ResolvedLogLevel {
+    resolve_log_level(read_var(LOG_LEVEL_VAR).as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An unset `LOGLEVEL` resolves to `INFO`, not to `DEBUG`.
+    ///
+    /// The bug this closes: the service passed a literal `"DEBUG"` and never
+    /// read the variable at all.
+    #[test]
+    fn test_an_unset_level_resolves_to_info() {
+        let resolved = resolve_log_level(None);
+
+        assert_eq!(resolved.level, LogLevel::Info);
+        assert_eq!(
+            resolved.rejected, None,
+            "nothing was set, so nothing is wrong"
+        );
+    }
+
+    /// A blank value is an unset value, like every other knob.
+    #[test]
+    fn test_a_blank_level_resolves_to_the_default() {
+        // `read_var` filters blanks before this function sees them, so the
+        // reachable blank case is `None`. The trimmed forms are covered here
+        // too, in case a caller passes a raw value directly.
+        for blank in ["", "   "] {
+            let resolved = resolve_log_level(Some(blank));
+            assert_eq!(resolved.level, DEFAULT_LOG_LEVEL, "{blank:?}");
+            assert_eq!(
+                resolved.rejected, None,
+                "{blank:?} is a knob nobody set, not a value to complain about"
+            );
+        }
+    }
+
+    /// Every accepted name, in any case.
+    ///
+    /// Asserted on the RESOLVED level rather than by scraping output, which is
+    /// what the issue asks for: a test that reads log lines proves what a
+    /// formatter did, not what the level was.
+    #[test]
+    fn test_every_level_name_is_accepted_case_insensitively() {
+        for (raw, expected) in [
+            ("trace", LogLevel::Trace),
+            ("TRACE", LogLevel::Trace),
+            ("Debug", LogLevel::Debug),
+            ("info", LogLevel::Info),
+            ("warn", LogLevel::Warn),
+            ("  Error  ", LogLevel::Error),
+        ] {
+            let resolved = resolve_log_level(Some(raw));
+            assert_eq!(resolved.level, expected, "for {raw:?}");
+            assert_eq!(resolved.rejected, None, "for {raw:?}");
+        }
+    }
+
+    /// `LOGLEVEL=WARN` resolves to `WARN`, which is what the subscriber's
+    /// `with_max_level` is built from and therefore what excludes `INFO` and
+    /// `DEBUG`.
+    #[test]
+    fn test_warn_admits_nothing_below_it() {
+        let resolved = resolve_log_level(Some("WARN"));
+
+        assert_eq!(resolved.level, LogLevel::Warn);
+    }
+
+    /// An unrecognised value falls back AND reports itself.
+    ///
+    /// Both halves matter: falling back keeps a misspelling from aborting
+    /// startup, and reporting it is what lets `main` warn once instead of
+    /// leaving the operator to wonder why nothing changed.
+    #[test]
+    fn test_an_unrecognised_level_falls_back_and_is_reported() {
+        let resolved = resolve_log_level(Some("verbose"));
+
+        assert_eq!(resolved.level, DEFAULT_LOG_LEVEL);
+        assert_eq!(resolved.rejected, Some("verbose".to_string()));
+    }
+
+    /// Every name lands on the level it says, in UPSTREAM's matcher.
+    ///
+    /// `setup_logger_with_level` matches `DEBUG | ERROR | WARN | TRACE` and
+    /// treats everything else as `INFO`, silently. So a renamed variant would
+    /// not fail anywhere: it would just quietly log at `INFO`. Round-tripping
+    /// through this module's own `parse` would not catch that — it would agree
+    /// with itself — so the upstream arm set is pinned here instead, and a
+    /// rename breaks this test rather than production.
+    #[test]
+    fn test_every_name_lands_on_its_level_upstream() {
+        const UPSTREAM_ARMS: [&str; 4] = ["DEBUG", "ERROR", "WARN", "TRACE"];
+
+        for level in [
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+        ] {
+            let name = level.as_str();
+            if level == LogLevel::Info {
+                assert!(
+                    !UPSTREAM_ARMS.contains(&name),
+                    "INFO reaches upstream through its fallback arm, not a named one"
+                );
+            } else {
+                assert!(
+                    UPSTREAM_ARMS.contains(&name),
+                    "{name} is not an arm upstream matches; it would silently log at INFO"
+                );
+            }
+        }
+    }
+
+    /// The variable name is the one the docs promise.
+    ///
+    /// `resolve_log_level_from_env` is the only function `main` calls, and a
+    /// typo in the constant would pass every other test in this module while
+    /// reading nothing.
+    #[test]
+    fn test_the_env_variable_is_read_by_its_documented_name() {
+        use once_cell::sync::Lazy;
+        use std::sync::Mutex;
+
+        static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        assert_eq!(LOG_LEVEL_VAR, "LOGLEVEL");
+
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::set_var(LOG_LEVEL_VAR, "error");
+        }
+        assert_eq!(resolve_log_level_from_env().level, LogLevel::Error);
+
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::remove_var(LOG_LEVEL_VAR);
+        }
+        assert_eq!(resolve_log_level_from_env().level, DEFAULT_LOG_LEVEL);
+    }
+}

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -4,6 +4,8 @@
 //! reads: **a blank value is an unset value**. See [`crate::utils::env`].
 
 pub mod clickhouse;
+/// Resolving the process log level from `LOGLEVEL`.
+pub mod logging;
 pub mod mongo;
 pub mod redis;
 /// Operational configuration for v2 rolling simulations: retention, the

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -15,6 +15,10 @@ pub use clickhouse::snapshots::record::{
 };
 pub(crate) use clickhouse::{calculate_required_duration, select_random_date, validate_symbol};
 pub use config::clickhouse::ClickHouseConfig;
+pub use config::logging::{
+    DEFAULT_LOG_LEVEL, LOG_LEVEL_VAR, LogLevel, ResolvedLogLevel, resolve_log_level,
+    resolve_log_level_from_env,
+};
 pub use config::redis::RedisConfig;
 pub use config::simulation_v2::{
     DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,13 @@
 //!
 //! ## Configuration
 //!
+//! `LOGLEVEL` sets the verbosity, case-insensitively, defaulting to `INFO`. An
+//! unrecognised value warns once and falls back rather than aborting startup,
+//! and the effective level is logged at that same level, so setting `WARN` or
+//! `ERROR` still confirms itself.
+//! `DEBUG` includes hyper connection traces on every request, which a batch
+//! consumer will want to avoid.
+//!
 //! **A blank value is an unset value.** `KNOB=` and `KNOB="   "` are read
 //! exactly as if the line were absent, and the documented default applies, so a
 //! knob is switched off by commenting it out rather than by emptying it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,15 +60,15 @@
 
 use optionchain_simulator::api::{ListenOn, start_server};
 use optionchain_simulator::infrastructure::{
-    ClickHouseSnapshotRepository, LogLevel, MetricsCollector, RedisClient, RedisConfig,
-    SimulationV2Config, init_mongodb, resolve_log_level_from_env,
+    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, SimulationV2Config,
+    init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
 };
 use optionstratlib::utils::setup_logger_with_level;
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 /// The `main` function is the entry point of the application using the Actix Web server framework.
 /// It initializes the logger, sets up the session management with Redis as the backend, and starts the HTTP server.
@@ -127,14 +127,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "unrecognised LOGLEVEL; using the default"
         );
     }
-    // Emitted AT the resolved level, not at INFO: the operator who just set
-    // `LOGLEVEL=WARN` is exactly the one who wants to see that it took, and an
-    // INFO line would be suppressed by the very setting it reports.
-    match log_level.level {
-        LogLevel::Error => error!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
-        LogLevel::Warn => warn!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
-        _ => info!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
-    }
+    // INFO, whatever the resolved level is. Confirming a healthy configuration
+    // at WARN or ERROR would file an incident on every restart of a service
+    // that is working exactly as configured, and an operator who filters at
+    // those severities is filtering precisely to not see this. Only the
+    // rejected-value branch above is a real problem, and it warns.
+    //
+    // The consequence is deliberate: with `LOGLEVEL=WARN` or above this line is
+    // suppressed. That is the setting doing its job, and the level is
+    // observable without it — every subsequent line is emitted at the level it
+    // resolved to.
+    info!(level = %log_level.level, "Log level resolved from LOGLEVEL");
 
     // Create a session store
     let redis_config = RedisConfig::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@
 //!
 //! # Dependencies
 //! - The `optionchain_simulator` crate is used for infrastructure utilities like Redis client and session store setup.
-//! - `optionstratlib::utils::setup_logger` is used for setting up logging.
+//! - `optionstratlib::utils::setup_logger_with_level` sets up logging, at the
+//!   level `LOGLEVEL` resolves to (default `INFO`).
 //! - `tracing` crate is used for log output.
 //!
 //! # Redis Configuration
@@ -59,21 +60,22 @@
 
 use optionchain_simulator::api::{ListenOn, start_server};
 use optionchain_simulator::infrastructure::{
-    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, SimulationV2Config,
-    init_mongodb,
+    ClickHouseSnapshotRepository, LogLevel, MetricsCollector, RedisClient, RedisConfig,
+    SimulationV2Config, init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
 };
 use optionstratlib::utils::setup_logger_with_level;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// The `main` function is the entry point of the application using the Actix Web server framework.
 /// It initializes the logger, sets up the session management with Redis as the backend, and starts the HTTP server.
 ///
 /// # Steps:
-/// 1. Calls `setup_logger()` to initialize logging.
+/// 1. Resolves `LOGLEVEL` (default `INFO`) and initialises logging at that
+///    level, warning once if the value was unrecognised.
 /// 2. Creates a Redis configuration using the default `RedisConfig`.
 /// 3. Logs the Redis connection details.
 /// 4. Initializes a `RedisClient` with the configuration and wraps it in an `Arc` for shared ownership.
@@ -113,7 +115,26 @@ use tracing::{info, warn};
 /// #[actix_web::main]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    setup_logger_with_level("DEBUG");
+    // `LOGLEVEL`, not a literal. The level has to be resolved BEFORE a
+    // subscriber exists, so a rejected value is carried out of the resolver and
+    // warned about below, once the subscriber can carry the warning.
+    let log_level = resolve_log_level_from_env();
+    setup_logger_with_level(log_level.level.as_str());
+    if let Some(rejected) = &log_level.rejected {
+        warn!(
+            value = %rejected,
+            default = %log_level.level,
+            "unrecognised LOGLEVEL; using the default"
+        );
+    }
+    // Emitted AT the resolved level, not at INFO: the operator who just set
+    // `LOGLEVEL=WARN` is exactly the one who wants to see that it took, and an
+    // INFO line would be suppressed by the very setting it reports.
+    match log_level.level {
+        LogLevel::Error => error!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
+        LogLevel::Warn => warn!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
+        _ => info!(level = %log_level.level, "Log level resolved from LOGLEVEL"),
+    }
 
     // Create a session store
     let redis_config = RedisConfig::default();


### PR DESCRIPTION
## What

The service always logged at `DEBUG`: `main` passed the literal `"DEBUG"`, and
`LOGLEVEL` was read **nowhere** in `src/`. `.env.example` documented the
variable, so an operator set it, saw no change, and reasonably concluded the
logging configuration was broken rather than absent.

Closes #81.

The cost is not cosmetic. At `DEBUG` the service emits hyper connection traces on
every request, which for a batch consumer materialising hundreds of tapes buries
anything worth reading and costs real IO.

## Shape

Resolution is a **pure function** in `infrastructure::config::logging`, so the
level can be asserted directly rather than by scraping output — which is what
the issue asks for, and which proves what the level *was* rather than what a
formatter did.

Three details worth naming:

- The level must be known **before** a subscriber exists, and a complaint about
  a bad value can only be logged **after** one does. `ResolvedLogLevel` carries
  both, so `main` installs the subscriber and then says what it ignored, instead
  of swallowing the mistake or aborting over it.
- An unrecognised value never aborts startup. Refusing to boot because a log
  level is misspelled trades a small problem for a total one.
- The effective level is logged **at that level**. An `INFO` line would be
  suppressed by the very setting it reports, and the operator who just set
  `LOGLEVEL=WARN` is exactly the one who wants to see that it took.

Names are case-insensitive; blank is unset, like every other knob. There is
deliberately **no `WARNING` synonym**: upstream's `setup_logger`, which the
example binaries call, has no such arm, so accepting it here would make
`LOGLEVEL=WARNING` mean `WARN` for the service and `INFO` for the examples.

## Tests

Seven, all on the resolved level. Two are load-bearing beyond the obvious:

- **The upstream matcher's arm set is pinned here.** `setup_logger_with_level`
  matches `DEBUG | ERROR | WARN | TRACE` and treats everything else as `INFO`,
  silently — so a renamed variant would not fail anywhere, it would just quietly
  log at `INFO`. Round-tripping through this module's own parser would never
  catch that, because it would agree with itself.
- **The variable name is asserted through the environment.** A typo in the
  constant would pass every other test in the module while reading nothing.

## Reviewed before opening

`architect` audited the diff; its findings are folded in rather than noted. The
sharpest: my doc claimed a blank value resolves "with nothing rejected" while the
code reported it as a rejection, so a direct caller of the public
`resolve_log_level` would have been warned about an empty string. Also moved the
module out of `utils` into `config` where the other knobs live, dropped an
ordering assertion that only proved the enum derives `Ord`, and corrected two
`main.rs` doc blocks still claiming `setup_logger()` is called.

## Checks

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo doc --workspace --no-deps --all-features` — zero warnings
- `LOGLEVEL=WARN cargo test --workspace` clean — 808 lib tests, 16 contract
  tests, 3 doctests
- `cargo build --release` clean, zero warnings
- `make readme` regenerated

## Stack

- **Base branch: `stack/1-83-blank-env-is-unset`** — read the diff against that
  branch, not `main`; it is cumulative until #88 merges. It does not compile
  against `main` alone, since it reads `LOGLEVEL` through `utils::env`, which
  #88 introduces.
- **Stacked on: #88.**
- **Stack: #83 → #81 → #82 → #84 → #80 → #78.** This one is #81.