### PR TITLE
Make the HTTP bind address and port configurable (#82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@
 #
 # Two behaviours to know before editing:
 #
-#   * The v2 knobs (OCS_V2_*, OCS_MAX_CACHED_*) are VALIDATED AT STARTUP. An
+#   * The v2 knobs (OCS_V2_*, OCS_MAX_CACHED_*) and the server knobs
+#     (OCS_BIND_ADDRESS, OCS_PORT) are VALIDATED AT STARTUP. An
 #     invalid value fails the process with a message naming the variable,
 #     because silently reverting to a default would change how long simulations
 #     live or how much memory the service holds without anyone noticing.
@@ -43,6 +44,29 @@
 # a batch consumer materialising hundreds of tapes buries anything worth reading.
 # Values: TRACE | DEBUG | INFO | WARN | ERROR.  Default: INFO
 LOGLEVEL=INFO
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+
+# The interface to bind. Accepts an IP address, or the words `all` (0.0.0.0)
+# and `localhost` (127.0.0.1). Unlike the request caps, an unusable value here
+# FAILS STARTUP naming the variable: a service that quietly ignored it would
+# listen somewhere nobody asked for.
+#
+# The default is loopback, which is a CHANGE: the address used to be a constant
+# 0.0.0.0. This service has no authentication and no rate limiting, so being
+# reachable off the host is now a decision. A container must set 0.0.0.0 for
+# its published port to lead anywhere; Docker/docker-compose.yml does.
+# Default: localhost
+# OCS_BIND_ADDRESS=localhost
+
+# The port to bind, 1-65535. Also fails startup when unusable. 0 is refused
+# along with the rest: the operating system would pick a free port, which is
+# the opposite of what someone running several instances on known ports wants.
+# Default: 7070
+# OCS_PORT=7070
 
 
 # ---------------------------------------------------------------------------

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -31,6 +31,10 @@ WORKDIR /app
 
 COPY --from=builder /app/target/release/optionchain_simulator /app/
 
+# DEFAULT_PORT in src/infrastructure/config/server.rs. This is metadata, not a
+# binding: the compose file publishes ${OCS_PORT} explicitly, but a bare
+# `docker run -P` publishes what is declared here, so a custom OCS_PORT needs an
+# explicit `-p`.
 EXPOSE 7070
 
 CMD ["/app/optionchain_simulator"]

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -146,8 +146,16 @@ services:
       # non-numeric value, or when unset, warning as it does so.
       REDIS_TIMEOUT: ${REDIS_TIMEOUT:-30}
       REDIS_CONNECT_TIMEOUT: ${REDIS_CONNECT_TIMEOUT:-5}
+      # The service binds loopback when this is unset (src/infrastructure/config
+      # /server.rs), and loopback inside a container is reachable by nobody, so
+      # a published port would lead nowhere. A container has to say 0.0.0.0 out
+      # loud; the network boundary here is the published port, not the bind.
+      OCS_BIND_ADDRESS: ${OCS_BIND_ADDRESS:-0.0.0.0}
+      # Both sides of the mapping below read the same variable, so moving the
+      # service off 7070 is one edit rather than two that can disagree.
+      OCS_PORT: ${OCS_PORT:-7070}
     ports:
-      - "7070:7070"
+      - "${OCS_PORT:-7070}:${OCS_PORT:-7070}"
     networks:
       - optionchain-network
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,19 @@ deliberately different failure behaviour:
   silently reverting a cache bound would change the service's memory
   profile with nothing to show for it.
 
+**Where the server listens** — `OCS_BIND_ADDRESS` (an IP address, or the
+words `all` and `localhost`) and `OCS_PORT` (`1..=65535`) — is configurable
+and validated at startup like the second family: two instances quietly
+fighting over one port is worse than a refusal. The address now defaults to
+**loopback**, where it used to be a hardcoded `0.0.0.0`; this service has no
+authentication and no rate limiting, so reachability off the host is a
+decision. A deployment that relied on the old default must set
+`OCS_BIND_ADDRESS=0.0.0.0` — `Docker/docker-compose.yml` sets it and the dev
+override inherits it. Configuring
+the port is what makes it possible to shard tape materialisation across
+several instances on one host, which is embarrassingly parallel work: each
+simulation is independent and shares no state.
+
 **v2 retention is real time, not simulated time.** A simulation whose
 simulated clock spans three years is still walked one request at a time, so
 its idle window is an operational choice independent of the horizon. It

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,10 @@
 pub(crate) mod rest;
 
 pub use rest::controller::start_server;
-pub use rest::models::ListenOn;
+// Re-exported from `infrastructure`, where the type lives: `optionchain_simulator
+// ::api::ListenOn` is the path consumers already use, and the move must not cost
+// them an import.
+pub use crate::infrastructure::ListenOn;
 pub use rest::patch::Patch;
 pub use rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 pub use rest::requests_v2::CreateSimulationRequest;

--- a/src/api/rest/controller.rs
+++ b/src/api/rest/controller.rs
@@ -1,12 +1,11 @@
-use crate::api::rest::models::ListenOn;
-
 use crate::session::{SessionManager, SimulationManager};
 use actix_web::{App, HttpServer};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::info;
 
 use crate::api::rest::routes::configure_routes;
-use crate::infrastructure::{MetricsCollector, MetricsMiddleware, MongoDBRepository};
+use crate::infrastructure::{ListenOn, MetricsCollector, MetricsMiddleware, MongoDBRepository};
 
 /// Starts an HTTP server with the given configuration.
 ///
@@ -50,7 +49,10 @@ pub async fn start_server(
     listen_on: ListenOn,
     port: u16,
 ) -> std::io::Result<()> {
-    let bind_address = format!("{}:{}", listen_on, port);
+    // A `SocketAddr`, not a formatted string: an IPv6 literal needs brackets,
+    // and `format!("{listen_on}:{port}")` would log `http://::1:7070`, which is
+    // not an address anyone can paste anywhere.
+    let bind_address = SocketAddr::new(listen_on.ip(), port);
 
     info!("Starting server on {}", bind_address);
 

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -226,7 +226,7 @@ pub(crate) fn apply_update(
 /// Both are produced inside one admitted blocking job, serialisation included.
 /// `HttpResponse::json` would otherwise encode a large document on the Actix
 /// worker after the job returned, which is the stall the job exists to avoid.
-/// See [`crate::api::rest::greeks::admit_blocking`] for the bound v1 and v2
+/// See [`crate::api::rest::greeks::admit_render`] for the bound v1 and v2
 /// share.
 ///
 /// # Errors

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -68,7 +68,7 @@ pub(crate) struct SnapshotQuery {
 
 /// Renders a snapshot body, under the shared greek admission bound.
 ///
-/// See [`crate::api::rest::greeks::admit_blocking`]: above the default level
+/// See [`crate::api::rest::greeks::admit_render`]: above the default level
 /// the pricing AND the serialisation happen together in one admitted blocking
 /// job, and the handler writes the bytes it returns.
 ///

--- a/src/api/rest/models.rs
+++ b/src/api/rest/models.rs
@@ -12,38 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use utoipa::ToSchema;
 
-/// Represents address binding options for the server
-#[derive(Debug, Clone, Copy, Default)]
-pub enum ListenOn {
-    /// Binds to all network interfaces (0.0.0.0)
-    All,
-    /// Binds only to localhost (127.0.0.1)
-    #[default]
-    Localhost,
-}
-
-impl ListenOn {
-    /// Converts the enum variant to its corresponding IP address string
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ListenOn::All => "0.0.0.0",
-            ListenOn::Localhost => "127.0.0.1",
-        }
-    }
-}
-
-impl From<ListenOn> for String {
-    fn from(listen_on: ListenOn) -> Self {
-        listen_on.as_str().to_string()
-    }
-}
-
-impl fmt::Display for ListenOn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, ToSchema)]
 pub enum ApiTimeFrame {
     /// 1-microsecond data.

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -8,6 +8,8 @@ pub mod clickhouse;
 pub mod logging;
 pub mod mongo;
 pub mod redis;
+/// Where the HTTP server listens: `OCS_BIND_ADDRESS` and `OCS_PORT`.
+pub mod server;
 /// Operational configuration for v2 rolling simulations: retention, the
 /// cleanup cadence, and the domain-cache capacities.
 pub mod simulation_v2;

--- a/src/infrastructure/config/server.rs
+++ b/src/infrastructure/config/server.rs
@@ -1,0 +1,455 @@
+//! Where the HTTP server listens.
+//!
+//! Both the address and the port used to be compile-time constants, so the only
+//! ways to move the service off `0.0.0.0:7070` were patching `main.rs` or
+//! publishing a different host port through Docker.
+//!
+//! That blocks a concrete use case: **several instances on one host**. Tape
+//! materialisation is embarrassingly parallel — each simulation is independent
+//! and shares no state — so a batch consumer scales by sharding work across N
+//! instances. With a hardcoded port that needs N containers where N processes
+//! would do.
+//!
+//! # The default moved to loopback
+//!
+//! `ListenOn::All` was the old constant. The default is now `127.0.0.1`,
+//! because this service has no authentication and no rate limiting, so
+//! reachability off the host should be a decision rather than a default. **A
+//! deployment that relied on the implicit `0.0.0.0` must now set
+//! `OCS_BIND_ADDRESS=0.0.0.0`**; `Docker/docker-compose.yml` sets it and the
+//! dev override inherits it by merge.
+//!
+//! [`ListenOn`](crate::infrastructure::ListenOn) lives here rather than beside
+//! the request DTOs because it is
+//! not a DTO: it never crosses the wire, it is read from the environment, and
+//! putting it in `api` would leave this module importing a layer above it.
+
+use crate::utils::ChainError;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr};
+
+/// The interface the server binds to.
+///
+/// `All` and `Localhost` are named because they are the two an operator
+/// actually reaches for, and the difference between them matters: this service
+/// has no authentication and no rate limiting, so binding beyond loopback is a
+/// decision rather than a default. `Address` covers a specific interface, which
+/// is what a host running several instances behind a proxy needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum ListenOn {
+    /// Every interface, `0.0.0.0`.
+    All,
+    /// Loopback only, `127.0.0.1`. The default, deliberately: an unauthenticated
+    /// service should not be reachable off the host unless someone said so.
+    #[default]
+    Localhost,
+    /// One specific interface.
+    Address(IpAddr),
+}
+
+impl ListenOn {
+    /// The address to bind.
+    #[must_use]
+    pub fn ip(&self) -> IpAddr {
+        match self {
+            ListenOn::All => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            ListenOn::Localhost => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            ListenOn::Address(address) => *address,
+        }
+    }
+
+    /// Whether this binding is reachable from off the host.
+    ///
+    /// Used to say so once at startup: an unauthenticated service listening
+    /// beyond loopback is worth a line in the log, not a silent default.
+    #[must_use]
+    pub fn is_public(&self) -> bool {
+        !self.ip().is_loopback()
+    }
+
+    /// Parses a bind address.
+    ///
+    /// Accepts any IP literal, plus `localhost` and `all` as names for the two
+    /// common cases, so an operator can write either form.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming `field` when the value is not
+    /// a valid IP address, `localhost` or `all`. This is a SYNTAX check: an
+    /// address the host does not own parses here and fails later, at bind
+    /// time, with whatever the operating system says.
+    pub fn parse(raw: &str, field: &str) -> Result<Self, ChainError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "localhost" => return Ok(ListenOn::Localhost),
+            "all" => return Ok(ListenOn::All),
+            _ => {}
+        }
+
+        let address: IpAddr = raw.trim().parse().map_err(|_| ChainError::Validation {
+            field: field.to_string(),
+            reason: format!(
+                "must be an IP address, or `localhost` or `all`, got {:?}",
+                raw.trim()
+            ),
+        })?;
+
+        // Normalised so the two named forms and their literals compare equal,
+        // and so a log line reads the same either way.
+        Ok(match address {
+            address if address == IpAddr::V4(Ipv4Addr::UNSPECIFIED) => ListenOn::All,
+            address if address == IpAddr::V4(Ipv4Addr::LOCALHOST) => ListenOn::Localhost,
+            address => ListenOn::Address(address),
+        })
+    }
+}
+
+impl From<ListenOn> for String {
+    fn from(listen_on: ListenOn) -> Self {
+        listen_on.ip().to_string()
+    }
+}
+
+impl fmt::Display for ListenOn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.ip())
+    }
+}
+
+/// The environment variable naming the interface to bind.
+pub const BIND_ADDRESS_VAR: &str = "OCS_BIND_ADDRESS";
+
+/// The environment variable naming the port to bind.
+pub const PORT_VAR: &str = "OCS_PORT";
+
+/// The interface bound when `OCS_BIND_ADDRESS` is unset.
+pub const DEFAULT_BIND_ADDRESS: ListenOn = ListenOn::Localhost;
+
+/// The port bound when `OCS_PORT` is unset.
+pub const DEFAULT_PORT: u16 = 7070;
+
+/// Where the server listens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerConfig {
+    /// The interface to bind.
+    pub address: ListenOn,
+    /// The port to bind.
+    pub port: u16,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            address: DEFAULT_BIND_ADDRESS,
+            port: DEFAULT_PORT,
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Reads the configuration from the environment.
+    ///
+    /// Unlike the request caps, which warn and fall back, an unusable value
+    /// here FAILS STARTUP. A cap that falls back still serves requests; a
+    /// service that quietly ignored `OCS_PORT` would bind a port the operator
+    /// did not ask for, and a batch consumer sharding across instances would
+    /// find two of them fighting over one port. That matches how the v2 and
+    /// snapshot knobs already behave.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming the offending variable when
+    /// the address is not a valid IP address or name, or the port is not an
+    /// integer in `1..=65535`. Port `0` is refused: the operating system would
+    /// pick a free port, which is the opposite of what someone sharding across
+    /// known ports wants.
+    pub fn from_env() -> Result<Self, ChainError> {
+        let address = match super::read_var(BIND_ADDRESS_VAR) {
+            Some(raw) => ListenOn::parse(&raw, BIND_ADDRESS_VAR)?,
+            None => DEFAULT_BIND_ADDRESS,
+        };
+
+        let port = match super::read_var(PORT_VAR) {
+            Some(raw) => raw
+                .parse::<u16>()
+                .ok()
+                .filter(|port| *port > 0)
+                .ok_or_else(|| ChainError::Validation {
+                    field: PORT_VAR.to_string(),
+                    reason: format!("must be an integer between 1 and 65535, got {raw:?}"),
+                })?,
+            None => DEFAULT_PORT,
+        };
+
+        Ok(Self { address, port })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::net::{Ipv6Addr, SocketAddr};
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn set_var(name: &str, value: &str) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::set_var(name, value);
+        }
+    }
+
+    fn remove_var(name: &str) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            std::env::remove_var(name);
+        }
+    }
+
+    fn clear() {
+        remove_var(BIND_ADDRESS_VAR);
+        remove_var(PORT_VAR);
+    }
+
+    /// With neither variable set, the service binds loopback on 7070.
+    ///
+    /// The second half of that is a DEFAULT CHANGE: it used to be `0.0.0.0`.
+    #[test]
+    fn test_neither_variable_binds_loopback_on_the_default_port() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        clear();
+
+        let config = match ServerConfig::from_env() {
+            Ok(config) => config,
+            Err(error) => panic!("an empty environment must resolve: {error}"),
+        };
+
+        assert_eq!(config.address, ListenOn::Localhost);
+        assert_eq!(config.address.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(config.port, 7070);
+        assert!(
+            !config.address.is_public(),
+            "an unauthenticated service must not default to reachable"
+        );
+    }
+
+    /// Both variables are honoured, in either spelling.
+    #[test]
+    fn test_both_variables_are_honoured() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        for (raw, expected) in [
+            ("0.0.0.0", ListenOn::All),
+            ("all", ListenOn::All),
+            ("127.0.0.1", ListenOn::Localhost),
+            ("localhost", ListenOn::Localhost),
+            (
+                "10.1.2.3",
+                ListenOn::Address(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+            ),
+        ] {
+            set_var(BIND_ADDRESS_VAR, raw);
+            set_var(PORT_VAR, "9001");
+
+            match ServerConfig::from_env() {
+                Ok(config) => {
+                    assert_eq!(config.address, expected, "for {raw:?}");
+                    assert_eq!(config.port, 9001, "for {raw:?}");
+                }
+                Err(error) => panic!("{raw:?} must resolve: {error}"),
+            }
+        }
+        clear();
+    }
+
+    /// A blank value is an unset value, like every other knob.
+    #[test]
+    fn test_blank_variables_fall_back_to_the_defaults() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        set_var(BIND_ADDRESS_VAR, "  ");
+        set_var(PORT_VAR, "");
+
+        match ServerConfig::from_env() {
+            Ok(config) => assert_eq!(config, ServerConfig::default()),
+            Err(error) => panic!("a blank value is unset, not invalid: {error}"),
+        }
+        clear();
+    }
+
+    /// An unusable address fails startup, naming the variable.
+    ///
+    /// Naming it is the point: the operator set something, and an error that
+    /// says only "invalid configuration" sends them looking through all of it.
+    #[test]
+    fn test_an_unusable_address_names_the_variable() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var(PORT_VAR);
+
+        for raw in ["not-an-address", "999.1.1.1", "127.0.0.1:7070"] {
+            set_var(BIND_ADDRESS_VAR, raw);
+
+            match ServerConfig::from_env() {
+                Ok(config) => panic!("{raw:?} must not resolve, got {config:?}"),
+                Err(ChainError::Validation { field, reason }) => {
+                    assert_eq!(field, BIND_ADDRESS_VAR, "for {raw:?}");
+                    assert!(
+                        reason.contains(raw.trim()),
+                        "the reason must quote it: {reason}"
+                    );
+                }
+                Err(error) => panic!("expected a validation failure, got {error:?}"),
+            }
+        }
+        clear();
+    }
+
+    /// An unusable port fails startup, naming the variable.
+    ///
+    /// `0` is refused along with the rest: the operating system would pick a
+    /// free port, which is the opposite of what someone sharding work across
+    /// known ports wants.
+    #[test]
+    fn test_an_unusable_port_names_the_variable() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        remove_var(BIND_ADDRESS_VAR);
+
+        for raw in ["0", "-1", "70000", "http", "7070.5"] {
+            set_var(PORT_VAR, raw);
+
+            match ServerConfig::from_env() {
+                Ok(config) => panic!("{raw:?} must not resolve, got {config:?}"),
+                Err(ChainError::Validation { field, .. }) => {
+                    assert_eq!(field, PORT_VAR, "for {raw:?}");
+                }
+                Err(error) => panic!("expected a validation failure, got {error:?}"),
+            }
+        }
+        clear();
+    }
+
+    /// Every variant resolves to the address it says, and renders as it binds.
+    ///
+    /// `Display` and `From<ListenOn> for String` are what the bind string and
+    /// the startup log are built from, so what they render is what the service
+    /// actually listens on.
+    #[test]
+    fn test_every_variant_renders_as_the_address_it_binds() {
+        for (listen_on, expected) in [
+            (ListenOn::All, "0.0.0.0"),
+            (ListenOn::Localhost, "127.0.0.1"),
+            (
+                ListenOn::Address(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+                "10.1.2.3",
+            ),
+            (
+                ListenOn::Address(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+                "::1",
+            ),
+        ] {
+            assert_eq!(listen_on.ip().to_string(), expected);
+            assert_eq!(listen_on.to_string(), expected, "Display for {listen_on:?}");
+            assert_eq!(
+                String::from(listen_on),
+                expected,
+                "String::from for {listen_on:?}"
+            );
+        }
+    }
+
+    /// The bind string a resolved configuration produces.
+    ///
+    /// An IPv6 address has to come out bracketed: `::1:9001` is ambiguous, and
+    /// this is the string handed to the socket.
+    #[test]
+    fn test_the_resolved_configuration_produces_a_usable_bind_address() {
+        for (address, port, expected) in [
+            (ListenOn::All, 7070_u16, "0.0.0.0:7070"),
+            (ListenOn::Localhost, 9001, "127.0.0.1:9001"),
+            (
+                ListenOn::Address(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+                9001,
+                "[::1]:9001",
+            ),
+        ] {
+            let config = ServerConfig { address, port };
+            assert_eq!(
+                SocketAddr::new(config.address.ip(), config.port).to_string(),
+                expected
+            );
+        }
+    }
+
+    /// Only loopback reads as private.
+    ///
+    /// The startup warning hangs off this, and a warning that fires on the
+    /// default would be one an operator learns to ignore.
+    #[test]
+    fn test_only_loopback_is_not_public() {
+        assert!(!ListenOn::Localhost.is_public());
+        assert!(!ListenOn::Address(IpAddr::V6(Ipv6Addr::LOCALHOST)).is_public());
+        assert!(ListenOn::All.is_public());
+        assert!(ListenOn::Address(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))).is_public());
+    }
+
+    /// An IPv6 literal is accepted and kept as itself.
+    #[test]
+    fn test_an_ipv6_address_is_accepted() {
+        match ListenOn::parse("::1", BIND_ADDRESS_VAR) {
+            Ok(listen_on) => {
+                assert_eq!(
+                    listen_on,
+                    ListenOn::Address(IpAddr::V6(Ipv6Addr::LOCALHOST))
+                );
+                assert!(!listen_on.is_public());
+            }
+            Err(error) => panic!("an IPv6 literal must parse: {error}"),
+        }
+    }
+
+    /// Two instances configured for different ports do not collide.
+    ///
+    /// The whole point of the issue: sharding tape materialisation across
+    /// several instances on one host. Asserted on the resolved configuration,
+    /// since actually binding two sockets in a unit test would make it a port
+    /// availability test rather than a configuration one.
+    #[test]
+    fn test_two_instances_resolve_to_different_ports() {
+        let _guard = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        set_var(PORT_VAR, "7071");
+        let first = ServerConfig::from_env();
+        set_var(PORT_VAR, "7072");
+        let second = ServerConfig::from_env();
+        clear();
+
+        match (first, second) {
+            (Ok(first), Ok(second)) => {
+                assert_eq!(first.port, 7071);
+                assert_eq!(second.port, 7072);
+                assert_ne!(first, second, "two shards must not fight over one port");
+            }
+            other => panic!("both must resolve, got {other:?}"),
+        }
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -20,6 +20,9 @@ pub use config::logging::{
     resolve_log_level_from_env,
 };
 pub use config::redis::RedisConfig;
+pub use config::server::{
+    BIND_ADDRESS_VAR, DEFAULT_BIND_ADDRESS, DEFAULT_PORT, ListenOn, PORT_VAR, ServerConfig,
+};
 pub use config::simulation_v2::{
     DEFAULT_CLEANUP_INTERVAL_SECS, DEFAULT_MAX_CACHED_SNAPSHOT_CONTRACTS,
     DEFAULT_MAX_CACHED_SNAPSHOTS, DEFAULT_MAX_CACHED_TAPES, DEFAULT_MAX_EXPORT_ROWS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,19 @@
 //!   silently reverting a cache bound would change the service's memory
 //!   profile with nothing to show for it.
 //!
+//! **Where the server listens** — `OCS_BIND_ADDRESS` (an IP address, or the
+//! words `all` and `localhost`) and `OCS_PORT` (`1..=65535`) — is configurable
+//! and validated at startup like the second family: two instances quietly
+//! fighting over one port is worse than a refusal. The address now defaults to
+//! **loopback**, where it used to be a hardcoded `0.0.0.0`; this service has no
+//! authentication and no rate limiting, so reachability off the host is a
+//! decision. A deployment that relied on the old default must set
+//! `OCS_BIND_ADDRESS=0.0.0.0` — `Docker/docker-compose.yml` sets it and the dev
+//! override inherits it. Configuring
+//! the port is what makes it possible to shard tape materialisation across
+//! several instances on one host, which is embarrassingly parallel work: each
+//! simulation is independent and shares no state.
+//!
 //! **v2 retention is real time, not simulated time.** A simulation whose
 //! simulated clock spans three years is still walked one request at a time, so
 //! its idle window is an operational choice independent of the horizon. It

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,9 @@
 //! 4. Creates an `InRedisSessionStore` for managing session data, using the Redis client,
 //!    with a custom Redis key prefix (`optionchain:session:`) and a TTL of 1 hour.
 //! 5. Constructs a `SessionManager` to manage user sessions by wrapping the session store.
-//! 6. Starts an HTTP server using `start_server`, listening on all available interfaces (`ListenOn::All`)
-//!    at port `7070`.
+//! 6. Reads where to listen from `OCS_BIND_ADDRESS` and `OCS_PORT`, refusing to
+//!    start when either is unusable, and starts an HTTP server there using
+//!    `start_server`.
 //!
 //! # Returns
 //! - On success, returns `Ok(())`.
@@ -29,8 +30,14 @@
 //! - The TTL (time-to-live) for session keys in the Redis store is 3600 seconds (1 hour).
 //!
 //! # HTTP Server Details
-//! - Listening Address: `0.0.0.0` (all interfaces).
-//! - Port: `7070`.
+//! - Listening Address: `OCS_BIND_ADDRESS`, an IP address or the words `all`
+//!   and `localhost`. Default: `127.0.0.1`. It used to be a hardcoded
+//!   `0.0.0.0`, so a deployment that relied on being reachable off the host has
+//!   to ask for it now; a container must set `0.0.0.0` for its published port
+//!   to lead anywhere.
+//! - Port: `OCS_PORT`, `1..=65535`. Default: `7070`.
+//! - An unusable value in either FAILS STARTUP naming the variable, rather than
+//!   binding somewhere nobody asked for.
 //!
 //! # Example
 //! ```
@@ -58,15 +65,16 @@
 //! # Author
 //! - Generated and maintained by the developers of `optionchain_simulator`.
 
-use optionchain_simulator::api::{ListenOn, start_server};
+use optionchain_simulator::api::start_server;
 use optionchain_simulator::infrastructure::{
-    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, SimulationV2Config,
-    init_mongodb, resolve_log_level_from_env,
+    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, ServerConfig,
+    SimulationV2Config, init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
 };
 use optionstratlib::utils::setup_logger_with_level;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::{info, warn};
 
@@ -83,7 +91,8 @@ use tracing::{info, warn};
 ///    - An optional custom key prefix (`optionchain:session:`).
 ///    - An optional TTL (time-to-live) of 1 hour for the session keys.
 /// 6. Wraps the session store in an `Arc` for shared ownership and constructs a `SessionManager` instance.
-/// 7. Defines the listening IP/host (`ListenOn::All`, meaning all available interfaces) and the server port (7070).
+/// 7. Resolves the listening IP/host and port from `OCS_BIND_ADDRESS` and `OCS_PORT`, defaulting to
+///    `127.0.0.1:7070` and failing startup when either value is unusable.
 /// 8. Logs the server's starting information.
 /// 9. Calls `start_server` to start the HTTP server with the session manager, listen address, and port:
 ///    - On success, the server runs as expected, and `Ok(())` is returned.
@@ -98,19 +107,21 @@ use tracing::{info, warn};
 /// - `RedisClient`: Redis client for communicating with the Redis database.
 /// - `InRedisSessionStore`: Manages session persistence in Redis.
 /// - `SessionManager`: Manages session lifecycle and retrieval for the web application.
-/// - `ListenOn`: Enum to specify the server's listening IP/host.
+/// - `ServerConfig`: Where to listen, read from `OCS_BIND_ADDRESS` and `OCS_PORT`.
 /// - `start_server`: Function to start the Actix Web server with the provided session manager,
 ///    host, and port.
 ///
 /// # Notes:
 /// - Make sure that the Redis server is running and accessible at the address specified in `RedisConfig`.
 /// - Ensure the Actix-Web dependencies are properly configured with the required features for `#[actix_web::main]`.
-/// - The server listens on all interfaces (`0.0.0.0`) and port 7070 by default.
+/// - The server listens on `127.0.0.1:7070` by default; `OCS_BIND_ADDRESS=0.0.0.0` is what makes it
+///   reachable off the host, which this service leaves to the operator because it has no
+///   authentication and no rate limiting.
 ///
 /// # Example Log Output:
 /// ```text
 /// [INFO] Connecting to Redis at default://127.0.0.1:6379
-/// [INFO] Starting HTTP server at http://0.0.0.0:7070
+/// [INFO] Starting HTTP server at http://127.0.0.1:7070
 /// ```
 /// #[actix_web::main]
 #[tokio::main]
@@ -138,6 +149,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // observable without it — every subsequent line is emitted at the level it
     // resolved to.
     info!(level = %log_level.level, "Log level resolved from LOGLEVEL");
+
+    // `OCS_BIND_ADDRESS` and `OCS_PORT`, not constants, and read HERE — before
+    // Redis, MongoDB and ClickHouse are dialled. A typo in a port should cost a
+    // refusal, not three connections and a schema migration first. An unusable
+    // value fails startup naming the variable rather than binding something
+    // nobody asked for: two shards quietly fighting over one port is worse.
+    let server = ServerConfig::from_env()?;
 
     // Create a session store
     let redis_config = RedisConfig::default();
@@ -219,10 +237,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
-    let listen_on = ListenOn::All;
-    let port = 7070;
-    // Start HTTP server
-    info!("Starting HTTP server at http://{}:{}", listen_on, port);
+
+    let listen_on = server.address;
+    let port = server.port;
+
+    // Through `SocketAddr` so an IPv6 literal is bracketed: `http://::1:7070`
+    // is not something an operator can paste anywhere.
+    info!(
+        "Starting HTTP server at http://{}",
+        SocketAddr::new(listen_on.ip(), port)
+    );
+    if listen_on.is_public() {
+        // Said once, out loud: this service has no authentication and no rate
+        // limiting, so reaching it off the host is a decision.
+        warn!(
+            address = %listen_on,
+            "Listening beyond loopback; the service has no authentication"
+        );
+    }
     match start_server(
         session_manager,
         simulation_manager,


### PR DESCRIPTION
Closes #82

## Stack

- **Base branch:** `stack/2-81-honour-loglevel`
- **Stacked on:** #89
- **Blocks:** #92
- **Stack:** #88 (#83) → #89 (#81) → **this** → #84 → #80 → #78

The diff shown against `main` is cumulative until #88 and #89 merge; read it against the base branch. The three lower PRs are logically independent of one another: they are stacked because they touch the same `main.rs` and `Cargo.toml` lines, not because one needs another.

## What changed

The server bound `0.0.0.0:7070` from two constants in `main.rs`, so moving it meant patching the binary or publishing a different host port. `OCS_BIND_ADDRESS` and `OCS_PORT` now decide it, which is what makes it possible to run several instances on one host and shard tape materialisation across them.

Both are validated at startup and an unusable value fails the process naming the variable, matching the v2 and snapshot knobs rather than the request caps that warn and fall back. A cap that falls back still serves requests; a service that quietly ignored `OCS_PORT` would leave two shards fighting over one port. Port `0` is refused with the rest: letting the operating system pick a free port is the opposite of what sharding across known ports wants. Blank is unset, as everywhere else.

The read was also hoisted above the Redis, MongoDB and ClickHouse connects, so a typo in a port costs a refusal rather than three connections and a schema migration first.

## Breaking: the default address is now loopback

It was a hardcoded `0.0.0.0`. This service has no authentication and no rate limiting, so being reachable off the host is now something an operator asks for. **A deployment that relied on the old default must set `OCS_BIND_ADDRESS=0.0.0.0`**; `Docker/docker-compose.yml` does, and the dev override inherits it by merge. Binding beyond loopback logs a warning once at startup.

Both sides of the compose port mapping now read `${OCS_PORT:-7070}`, so moving the port is one edit rather than two that can disagree.

## Semver: the next release is 0.3.0, not 0.2.1

Two breaking changes to the public surface, both on `ListenOn`:

- `ListenOn::as_str` is **removed**. No in-repo callers remained, and IronCondor mirrors the DTOs locally rather than linking the crate, so the blast radius is external crates.io consumers.
- A new `Address(IpAddr)` variant on a public enum breaks any downstream exhaustive `match`. It is now `#[non_exhaustive]`, so this is the last time that particular break costs anything.

Under cargo's 0.x rules both break `^0.2`. No version bump here; that is the release flow's job, but it should be a minor one.

## Layering: `ListenOn` moved down

`ListenOn` was in `api::rest::models` beside the f64 wire mirrors, but it is not a DTO: it never crosses the wire, it is not `Serialize`, and it is read from the environment. Leaving it there while `ServerConfig` read it would have made `infrastructure` import `api`, which is a red in this repo's module boundaries. It now lives in `infrastructure::config::server` next to the configuration that reads it, and `api::ListenOn` still resolves through a re-export so no consumer path changes.

The bind string and the startup log go through `SocketAddr`, so an IPv6 literal comes out as `[::1]:7070` rather than the unusable `::1:7070`.

## Also in this diff

Two pre-existing broken intra-doc links to `greeks::admit_blocking` (which moved to `utils::admission` in #88's predecessor) are repointed at `greeks::admit_render`, so the doc gate stays clean.

## Tests

Four new cases beyond the six on `ServerConfig::from_env`: every variant renders as the address it binds, a resolved configuration produces a usable bind string including the bracketed IPv6 form, only loopback reads as private, and an IPv6 literal parses and stays itself.

## Gate

`make pre-push` clean, MongoDB up: 818 + 16 + 3 tests pass, 22 ignored; clippy with `-D warnings`, `fmt --check`, `cargo doc` with zero warnings and `cargo build --release` all clean; `README.md` regenerated via `make readme`.