### PR TITLE
Add /health and /ready endpoints (#84)

### DIFF
--- a/Docker/docker-compose.dev.yml
+++ b/Docker/docker-compose.dev.yml
@@ -51,6 +51,10 @@ services:
   backend:
     container_name: backend
     restart: unless-stopped
+    # The `/ready` healthcheck, the port mapping and OCS_BIND_ADDRESS come from
+    # Docker/docker-compose.yml: compose merges an override service with the
+    # base one key by key, so repeating them here would only create two places
+    # for them to disagree.
     depends_on:
       - redis
       - mongodb

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -154,6 +154,25 @@ services:
       # Both sides of the mapping below read the same variable, so moving the
       # service off 7070 is one edit rather than two that can disagree.
       OCS_PORT: ${OCS_PORT:-7070}
+    # `/ready`, not `/health`: the point of the check is that compose reports
+    # the backend healthy only once it can actually serve a request, which
+    # means after Redis, MongoDB and (when persistence is on) ClickHouse
+    # answer. `wget` is busybox's, present in the alpine runtime image, and it
+    # exits non-zero on the 503 the endpoint returns while a dependency is
+    # down, which is exactly the signal compose reads.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -T 3 -q -O /dev/null http://127.0.0.1:${OCS_PORT:-7070}/ready",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      # Startup connects to Redis and MongoDB and may create the ClickHouse
+      # schema, so the first probes are expected to fail rather than to count
+      # against the retries.
+      start_period: 20s
     ports:
       - "${OCS_PORT:-7070}:${OCS_PORT:-7070}"
     networks:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,26 @@ The OptionChain-Simulator exposes the following REST API endpoints:
 | PUT    | /api/v1/chain      | Replace Session     | Completely replaces session parameters                           |
 | PATCH  | /api/v1/chain      | Update Parameters   | Updates specific session parameters                              |
 | DELETE | /api/v1/chain      | Delete Session      | Terminates and removes a session                                 |
+| GET    | /health            | Liveness            | The process is alive; always 200, no dependency touched          |
+| GET    | /ready             | Readiness           | 200 when every configured dependency answers, 503 naming those that did not |
+
+#### Probes
+
+The two answer different questions, and conflating them is how one outage
+becomes two. `/health` says the process is alive: it touches nothing, so a
+Redis hiccup can never get a healthy instance restarted. `/ready` says this
+instance can take work, and it asks: Redis and MongoDB always, ClickHouse
+when snapshot persistence is enabled, each under a 2-second bound and all of
+them at once. A 503 body names every dependency and why the failing ones
+failed, credential-redacted. Nothing is cached, so an instance whose Redis
+came back reports itself ready again without a restart.
+
+Both are unversioned, unauthenticated, and excluded from the request
+metrics: an orchestrator polling forever would otherwise add a constant to
+every series and a flood of 503s to the error series while a dependency is
+down. `Docker/docker-compose.yml` points its backend healthcheck at
+`/ready`, so `docker compose up -d` reports the service healthy only once it
+can actually serve.
 
 **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/README.md
+++ b/README.md
@@ -208,9 +208,12 @@ becomes two. `/health` says the process is alive: it touches nothing, so a
 Redis hiccup can never get a healthy instance restarted. `/ready` says this
 instance can take work, and it asks: Redis and MongoDB always, ClickHouse
 when snapshot persistence is enabled, each under a 2-second bound and all of
-them at once. A 503 body names every dependency and why the failing ones
-failed, credential-redacted. Nothing is cached, so an instance whose Redis
-came back reports itself ready again without a restart.
+them at once. A 503 body names every dependency and, for the failing ones, a
+fixed category: `unreachable` or `timed_out`. Never a driver's own words —
+the endpoint is unauthenticated, and a server message can carry internal
+hosts, paths and tokens no redaction reliably recognises, so the full
+explanation stays in the service's log. Nothing is cached, so an instance
+whose Redis came back reports itself ready again without a restart.
 
 Both are unversioned, unauthenticated, and excluded from the request
 metrics: an orchestrator polling forever would otherwise add a constant to

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,14 @@ pub use rest::controller::start_server;
 // ::api::ListenOn` is the path consumers already use, and the move must not cost
 // them an import.
 pub use crate::infrastructure::ListenOn;
+// The readiness probe surface: a binary assembles `Readiness` from the
+// dependencies it actually configured, so the list lives outside this crate's
+// wiring.
+// The probe response shapes. What is probed lives in `infrastructure`, beside
+// the clients it calls; these are the bodies the endpoints render.
+pub use rest::health::{
+    DependencyState, DependencyStatus, HealthResponse, ReadinessResponse, ReadinessState,
+};
 pub use rest::patch::Patch;
 pub use rest::requests::{CreateSessionRequest, UpdateSessionRequest};
 pub use rest::requests_v2::CreateSimulationRequest;

--- a/src/api/rest/controller.rs
+++ b/src/api/rest/controller.rs
@@ -4,8 +4,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::info;
 
+use crate::api::rest::health::PROBE_PATHS;
 use crate::api::rest::routes::configure_routes;
-use crate::infrastructure::{ListenOn, MetricsCollector, MetricsMiddleware, MongoDBRepository};
+use crate::infrastructure::{
+    ListenOn, MetricsCollector, MetricsMiddleware, MongoDBRepository, Readiness,
+};
 
 /// Starts an HTTP server with the given configuration.
 ///
@@ -16,6 +19,7 @@ use crate::infrastructure::{ListenOn, MetricsCollector, MetricsMiddleware, Mongo
 /// * `snapshots` - The v2 snapshot warehouse, when snapshot persistence is enabled. It is the same
 ///   repository the manager files snapshots into, shared so the v2 export can read them back and
 ///   prefer a persisted step over replaying it. `None` leaves the export replaying every step.
+/// * `readiness` - The dependency probes `GET /ready` runs.
 /// * `listen_on` - The address or hostname where the server will listen, typically an IP address or hostname.
 /// * `port` - The port number on which the server will accept requests.
 ///
@@ -48,6 +52,7 @@ pub async fn start_server(
     mongodb_repo: Arc<MongoDBRepository>,
     listen_on: ListenOn,
     port: u16,
+    readiness: Readiness,
 ) -> std::io::Result<()> {
     // A `SocketAddr`, not a formatted string: an IPv6 literal needs brackets,
     // and `format!("{listen_on}:{port}")` would log `http://::1:7070`, which is
@@ -58,7 +63,10 @@ pub async fn start_server(
 
     HttpServer::new(move || {
         App::new()
-            .wrap(MetricsMiddleware::new(metrics_collector.clone()))
+            // The probe routes are excluded: an orchestrator polls them every
+            // few seconds forever, and counting that constant would bury the
+            // traffic the metrics exist to describe.
+            .wrap(MetricsMiddleware::new(metrics_collector.clone()).excluding(&PROBE_PATHS))
             .configure(|cfg| {
                 configure_routes(
                     cfg,
@@ -66,6 +74,7 @@ pub async fn start_server(
                     simulation_manager.clone(),
                     metrics_collector.clone(),
                     mongodb_repo.clone(),
+                    readiness.clone(),
                 )
             })
     })

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -2030,6 +2030,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SimulationSnapshotRepository for FakeWarehouse {
+        /// No server behind it; reachable exactly as long as the process is.
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
         async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
             match self.stored.lock() {
                 Ok(mut stored) => {

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -795,6 +795,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::infrastructure::SimulationSnapshotRepository for AcceptingWarehouse {
+        /// No server behind it; reachable exactly as long as the process is.
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
         async fn persist(
             &self,
             _record: crate::infrastructure::SnapshotRecord,

--- a/src/api/rest/health.rs
+++ b/src/api/rest/health.rs
@@ -1,0 +1,396 @@
+//! Liveness and readiness probes.
+//!
+//! Before these existed the only endpoint an orchestrator could point at was
+//! `GET /metrics`, which answers 200 as soon as the process is up. That works
+//! as a probe by accident: it is a Prometheus surface, its availability says
+//! nothing about the service being able to serve a simulation, and anything
+//! written against it breaks the moment the metrics surface moves or is gated.
+//!
+//! Two endpoints, because they answer two different questions:
+//!
+//! - **`GET /health`** — is the process alive? Always 200, always cheap, no
+//!   dependency touched. A failing dependency must NOT make this fail, or an
+//!   orchestrator restarts a healthy instance every time Redis hiccups, which
+//!   turns one outage into two.
+//! - **`GET /ready`** — can this instance take work? 200 only when every
+//!   dependency it needs answers, 503 naming the ones that did not. This is the
+//!   signal a batch consumer sharding tape materialisation across instances
+//!   reads to decide where to send the next simulation.
+//!
+//! What `/ready` actually asks lives in [`crate::infrastructure::Readiness`],
+//! beside the clients it calls. This module owns the routes, the response
+//! shapes and the status codes, and renders one into the other.
+
+use crate::infrastructure::{DependencyReport, Readiness};
+use actix_web::{HttpResponse, Responder, web};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The liveness route.
+pub(crate) const HEALTH_PATH: &str = "/health";
+
+/// The readiness route.
+pub(crate) const READY_PATH: &str = "/ready";
+
+/// The two probe routes, excluded from the request metrics.
+///
+/// An orchestrator probes every few seconds forever, so counting those requests
+/// would bury the traffic the metrics exist to describe under a constant that
+/// says nothing, and pour 503s into the error series for as long as a
+/// dependency is down. Held here, beside the routes themselves, and handed to
+/// the metrics middleware at startup rather than hardcoded inside it: the paths
+/// belong to the API surface that defines them.
+pub(crate) const PROBE_PATHS: [&str; 2] = [HEALTH_PATH, READY_PATH];
+
+/// Whether a dependency answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyState {
+    /// It answered.
+    Up,
+    /// It did not, and `detail` says what it said instead.
+    Down,
+}
+
+/// Whether this instance can take work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessState {
+    /// Every configured dependency answered.
+    Ready,
+    /// At least one did not.
+    NotReady,
+}
+
+/// The body of a liveness probe.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct HealthResponse {
+    /// Always `alive`. The status code is the signal; this makes a curl
+    /// readable.
+    pub status: String,
+}
+
+impl HealthResponse {
+    /// The only value this response ever takes.
+    #[must_use]
+    pub fn alive() -> Self {
+        Self {
+            status: "alive".to_string(),
+        }
+    }
+}
+
+/// One dependency's answer.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DependencyStatus {
+    /// What was probed: `redis`, `mongodb` or `clickhouse`.
+    pub name: String,
+    /// Whether it answered.
+    pub status: DependencyState,
+    /// Why it did not, absent when it did. Redacted and length-bounded before
+    /// it gets here, since this body is unauthenticated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl DependencyStatus {
+    /// Whether this dependency answered.
+    #[must_use]
+    pub fn is_up(&self) -> bool {
+        self.status == DependencyState::Up
+    }
+}
+
+impl From<&DependencyReport> for DependencyStatus {
+    fn from(report: &DependencyReport) -> Self {
+        Self {
+            name: report.name.to_string(),
+            status: if report.is_up() {
+                DependencyState::Up
+            } else {
+                DependencyState::Down
+            },
+            detail: report.error.clone(),
+        }
+    }
+}
+
+/// The body of a readiness probe.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ReadinessResponse {
+    /// Whether this instance can take work.
+    pub status: ReadinessState,
+    /// Every dependency probed, in a fixed order, whether it answered or not.
+    /// Reported in full even when one is down, so one probe says which of them
+    /// are healthy rather than only naming the first failure.
+    pub dependencies: Vec<DependencyStatus>,
+}
+
+impl ReadinessResponse {
+    /// Renders what the probes reported.
+    ///
+    /// The status is DERIVED here and nowhere else: a body whose `status` and
+    /// `dependencies` could disagree would be two answers to one question.
+    #[must_use]
+    pub fn new(reports: &[DependencyReport]) -> Self {
+        let dependencies: Vec<DependencyStatus> =
+            reports.iter().map(DependencyStatus::from).collect();
+        let ready = dependencies.iter().all(DependencyStatus::is_up);
+
+        Self {
+            status: if ready {
+                ReadinessState::Ready
+            } else {
+                ReadinessState::NotReady
+            },
+            dependencies,
+        }
+    }
+
+    /// Whether every dependency answered.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.status == ReadinessState::Ready
+    }
+}
+
+/// Liveness probe.
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "Operations",
+    responses(
+        (status = 200, description = "The process is alive", body = HealthResponse)
+    )
+)]
+pub(crate) async fn health() -> impl Responder {
+    HttpResponse::Ok().json(HealthResponse::alive())
+}
+
+/// Readiness probe.
+#[utoipa::path(
+    get,
+    path = "/ready",
+    tag = "Operations",
+    responses(
+        (status = 200, description = "Every dependency answered", body = ReadinessResponse),
+        (
+            status = 503,
+            description = "At least one dependency did not answer; the body names it",
+            body = ReadinessResponse
+        )
+    )
+)]
+pub(crate) async fn ready(readiness: web::Data<Readiness>) -> impl Responder {
+    let body = ReadinessResponse::new(&readiness.evaluate().await);
+
+    if body.is_ready() {
+        HttpResponse::Ok().json(body)
+    } else {
+        HttpResponse::ServiceUnavailable().json(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::DependencyProbe;
+    use actix_web::{App, http::StatusCode, test, web};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// A probe whose answer the test controls, and can change mid-flight.
+    struct Switch {
+        name: &'static str,
+        up: AtomicBool,
+    }
+
+    impl Switch {
+        fn new(name: &'static str, up: bool) -> Self {
+            Self {
+                name,
+                up: AtomicBool::new(up),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DependencyProbe for Switch {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn check(&self) -> Result<(), String> {
+            if self.up.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err("connection refused".to_string())
+            }
+        }
+    }
+
+    /// Liveness answers 200 while a dependency is down.
+    ///
+    /// The whole distinction between the two endpoints: a dependency outage
+    /// must not get a healthy process restarted.
+    #[actix_web::test]
+    async fn test_health_answers_while_a_dependency_is_down() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(Readiness::new(vec![Arc::new(Switch::new(
+                    "redis", false,
+                ))])))
+                .route(HEALTH_PATH, web::get().to(health))
+                .route(READY_PATH, web::get().to(ready)),
+        )
+        .await;
+
+        let alive =
+            test::call_service(&app, test::TestRequest::get().uri(HEALTH_PATH).to_request()).await;
+        assert_eq!(alive.status(), StatusCode::OK);
+
+        let not_ready =
+            test::call_service(&app, test::TestRequest::get().uri(READY_PATH).to_request()).await;
+        assert_eq!(
+            not_ready.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the same instance must be alive and not ready at once"
+        );
+    }
+
+    /// The liveness body says what it is.
+    #[actix_web::test]
+    async fn test_health_reports_alive() {
+        let app = test::init_service(App::new().route(HEALTH_PATH, web::get().to(health))).await;
+
+        let body: HealthResponse = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri(HEALTH_PATH).to_request(),
+        )
+        .await;
+
+        assert_eq!(body.status, "alive");
+    }
+
+    /// With every dependency answering, readiness is 200 and names them all.
+    #[actix_web::test]
+    async fn test_ready_reports_every_dependency_when_all_answer() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(Readiness::new(vec![
+                    Arc::new(Switch::new("redis", true)),
+                    Arc::new(Switch::new("mongodb", true)),
+                    Arc::new(Switch::new("clickhouse", true)),
+                ])))
+                .route(READY_PATH, web::get().to(ready)),
+        )
+        .await;
+
+        let response =
+            test::call_service(&app, test::TestRequest::get().uri(READY_PATH).to_request()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body: ReadinessResponse = test::read_body_json(response).await;
+        assert_eq!(body.status, ReadinessState::Ready);
+        assert_eq!(
+            body.dependencies
+                .iter()
+                .map(|dependency| dependency.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["redis", "mongodb", "clickhouse"],
+            "the order is the one the probes were registered in"
+        );
+        assert!(body.dependencies.iter().all(|d| d.detail.is_none()));
+    }
+
+    /// A failing dependency is named, and the healthy ones are still reported.
+    ///
+    /// Naming it is the point of the body: "not ready" alone sends an operator
+    /// to check three services.
+    #[actix_web::test]
+    async fn test_ready_names_the_failing_dependency() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(Readiness::new(vec![
+                    Arc::new(Switch::new("redis", false)),
+                    Arc::new(Switch::new("mongodb", true)),
+                ])))
+                .route(READY_PATH, web::get().to(ready)),
+        )
+        .await;
+
+        let response =
+            test::call_service(&app, test::TestRequest::get().uri(READY_PATH).to_request()).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body: ReadinessResponse = test::read_body_json(response).await;
+        assert_eq!(body.status, ReadinessState::NotReady);
+        match body
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.name == "redis")
+        {
+            Some(redis) => {
+                assert_eq!(redis.status, DependencyState::Down);
+                assert_eq!(redis.detail.as_deref(), Some("connection refused"));
+            }
+            None => panic!("the failing dependency must be in the body: {body:?}"),
+        }
+        match body
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.name == "mongodb")
+        {
+            Some(mongodb) => assert!(mongodb.is_up(), "a healthy dependency is still reported"),
+            None => panic!("every dependency must be in the body: {body:?}"),
+        }
+    }
+
+    /// A dependency that comes back flips the status code, with no restart.
+    #[actix_web::test]
+    async fn test_ready_recovers_without_a_restart() {
+        let switch = Arc::new(Switch::new("redis", false));
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(Readiness::new(vec![switch.clone()])))
+                .route(READY_PATH, web::get().to(ready)),
+        )
+        .await;
+
+        let down =
+            test::call_service(&app, test::TestRequest::get().uri(READY_PATH).to_request()).await;
+        assert_eq!(down.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        switch.up.store(true, Ordering::SeqCst);
+
+        let up =
+            test::call_service(&app, test::TestRequest::get().uri(READY_PATH).to_request()).await;
+        assert_eq!(
+            up.status(),
+            StatusCode::OK,
+            "the same process must report ready once the dependency answers"
+        );
+    }
+
+    /// With nothing configured to check, an instance is ready.
+    #[actix_web::test]
+    async fn test_no_probes_is_ready() {
+        let body = ReadinessResponse::new(&[]);
+
+        assert!(body.is_ready());
+        assert_eq!(body.status, ReadinessState::Ready);
+        assert!(body.dependencies.is_empty());
+    }
+
+    /// The excluded paths are the routes, not two strings that can drift.
+    ///
+    /// `async` only because `use actix_web::test` shadows the built-in
+    /// attribute in this module.
+    #[actix_web::test]
+    async fn test_the_excluded_paths_are_the_probe_routes() {
+        assert_eq!(PROBE_PATHS, [HEALTH_PATH, READY_PATH]);
+        assert_eq!(HEALTH_PATH, "/health");
+        assert_eq!(READY_PATH, "/ready");
+    }
+}

--- a/src/api/rest/health.rs
+++ b/src/api/rest/health.rs
@@ -87,10 +87,15 @@ pub struct DependencyStatus {
     pub name: String,
     /// Whether it answered.
     pub status: DependencyState,
-    /// Why it did not, absent when it did. Redacted and length-bounded before
-    /// it gets here, since this body is unauthenticated.
+    /// Why it did not, absent when it did.
+    ///
+    /// A FIXED category — `unreachable` or `timed_out` — never a driver's own
+    /// words. This body is unauthenticated, and a server message can carry
+    /// internal host names, file paths, query text and tokens that no redaction
+    /// routine reliably recognises. The full explanation stays in the service's
+    /// log.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
+    pub reason: Option<String>,
 }
 
 impl DependencyStatus {
@@ -110,7 +115,7 @@ impl From<&DependencyReport> for DependencyStatus {
             } else {
                 DependencyState::Down
             },
-            detail: report.error.clone(),
+            reason: report.failure.map(|failure| failure.as_str().to_string()),
         }
     }
 }
@@ -301,7 +306,7 @@ mod tests {
             vec!["redis", "mongodb", "clickhouse"],
             "the order is the one the probes were registered in"
         );
-        assert!(body.dependencies.iter().all(|d| d.detail.is_none()));
+        assert!(body.dependencies.iter().all(|d| d.reason.is_none()));
     }
 
     /// A failing dependency is named, and the healthy ones are still reported.
@@ -333,7 +338,9 @@ mod tests {
         {
             Some(redis) => {
                 assert_eq!(redis.status, DependencyState::Down);
-                assert_eq!(redis.detail.as_deref(), Some("connection refused"));
+                // The category, not the probe's own words: the body is
+                // unauthenticated.
+                assert_eq!(redis.reason.as_deref(), Some("unreachable"));
             }
             None => panic!("the failing dependency must be in the body: {body:?}"),
         }

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -5,6 +5,7 @@ mod favicon;
 pub(crate) mod greeks;
 pub(crate) mod handlers;
 pub(crate) mod handlers_v2;
+pub(crate) mod health;
 pub(crate) mod limits;
 mod middleware;
 pub(crate) mod models;

--- a/src/api/rest/routes.rs
+++ b/src/api/rest/routes.rs
@@ -7,9 +7,12 @@ use crate::api::rest::handlers_v2::{
     advance_simulation, create_simulation, delete_simulation, get_simulation, json_error_handler,
     peek_snapshot, query_error_handler,
 };
+use crate::api::rest::health::{HEALTH_PATH, READY_PATH, health, ready};
 use crate::api::rest::middleware::metrics_endpoint;
 use crate::api::rest::swagger::ApiDoc;
-use crate::infrastructure::{MetricsCollector, MongoDBRepository, SimulationSnapshotRepository};
+use crate::infrastructure::{
+    MetricsCollector, MongoDBRepository, Readiness, SimulationSnapshotRepository,
+};
 use crate::session::{SessionManager, SimulationManager};
 use actix_web::web;
 use std::sync::Arc;
@@ -31,6 +34,8 @@ use utoipa_swagger_ui::SwaggerUi;
 ///   session data and operations.
 /// * `snapshots` - The v2 snapshot warehouse, when the operator enabled persistence. `None` is the
 ///   normal case and leaves the v2 export replaying every step.
+/// * `readiness` - The dependency probes `GET /ready` runs. Assembled by the caller from what the
+///   deployment actually configured, so the endpoint reports on those services and no others.
 ///
 /// # Endpoints
 ///
@@ -54,6 +59,12 @@ use utoipa_swagger_ui::SwaggerUi;
 /// - **DELETE** `/api/v1/chain`  
 ///   Handled by the `delete_session` function. This is used to remove an existing session.
 ///
+/// - **GET** `/health`
+///   Liveness: the process is alive. Always 200, no dependency touched.
+///
+/// - **GET** `/ready`
+///   Readiness: 200 when every configured dependency answers, 503 naming the ones that did not.
+///
 /// # Usage
 ///
 /// This function should be called during the setup phase of the Actix Web application to configure
@@ -66,6 +77,7 @@ pub fn configure_routes(
     simulation_manager: Arc<SimulationManager>,
     metrics_collector: Arc<MetricsCollector>,
     mongodb_repo: Arc<MongoDBRepository>,
+    readiness: Readiness,
 ) {
     // The export reads from the same warehouse the manager files into, taken
     // off the manager rather than threaded separately: two handles could be
@@ -74,6 +86,7 @@ pub fn configure_routes(
     configure_v2_routes(cfg, simulation_manager, snapshots);
 
     cfg.app_data(web::Data::new(session_manager))
+        .app_data(web::Data::new(readiness))
         .app_data(web::Data::new(metrics_collector.clone()))
         .app_data(web::Data::new(mongodb_repo))
         // v1's query DTOs reject unknown keys too, for the same reason: a
@@ -89,6 +102,10 @@ pub fn configure_routes(
                 .route(web::delete().to(delete_session)),
         )
         .service(web::resource("/api/v1/chain/step").route(web::post().to(advance_step)))
+        // Unversioned and unauthenticated on purpose: an orchestrator's probe
+        // configuration should not have to move when the API surface does.
+        .route(HEALTH_PATH, web::get().to(health))
+        .route(READY_PATH, web::get().to(ready))
         .route("/metrics", web::get().to(metrics_endpoint))
         .route("/favicon.ico", web::get().to(get_favicon))
         .service(

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -15,6 +15,8 @@ use utoipa::OpenApi;
         crate::api::rest::handlers_v2::advance_simulation,
         crate::api::rest::handlers_v2::delete_simulation,
         crate::api::rest::export::export_simulation,
+        crate::api::rest::health::health,
+        crate::api::rest::health::ready,
     ),
     components(
         schemas(
@@ -39,10 +41,16 @@ use utoipa::OpenApi;
             crate::api::rest::greeks::FirstOrderGreeks,
             crate::api::rest::greeks::FullGreeks,
             crate::api::rest::greeks::GreekLevel,
+            crate::api::rest::health::HealthResponse,
+            crate::api::rest::health::ReadinessResponse,
+            crate::api::rest::health::DependencyStatus,
+            crate::api::rest::health::DependencyState,
+            crate::api::rest::health::ReadinessState,
         )
     ),
     tags(
-        (name = "Options-Simulator", description = "Options Simulator endpoints")
+        (name = "Options-Simulator", description = "Options Simulator endpoints"),
+        (name = "Operations", description = "Liveness and readiness probes")
     )
 )]
 pub(crate) struct ApiDoc;

--- a/src/infrastructure/clickhouse/snapshots/interface.rs
+++ b/src/infrastructure/clickhouse/snapshots/interface.rs
@@ -154,6 +154,20 @@ pub trait SimulationSnapshotRepository: Send + Sync {
         &self,
         query: ContractSeriesQuery,
     ) -> Result<Vec<ContractQuote>, ChainError>;
+
+    /// Asks the warehouse whether it is there, for the readiness probe.
+    ///
+    /// Required rather than defaulted to `Ok(())`: a default would mean an
+    /// implementation that forgot to answer this reports ITSELF reachable, and
+    /// `/ready` would then serve a 200 on the strength of a warehouse nobody
+    /// asked. An implementation with no server behind it says `Ok(())`
+    /// explicitly, which is the truth for it and a decision for the next one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::ClickHouseError`] when the warehouse is
+    /// unreachable or does not answer in time.
+    async fn ping(&self) -> Result<(), ChainError>;
 }
 
 #[cfg(test)]
@@ -180,6 +194,11 @@ mod tests {
 
     #[async_trait]
     impl SimulationSnapshotRepository for InMemorySnapshotRepository {
+        /// No server behind it; reachable exactly as long as the process is.
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
         async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
             record.validate()?;
             let key = (record.simulation, record.generation, record.step);

--- a/src/infrastructure/health.rs
+++ b/src/infrastructure/health.rs
@@ -19,10 +19,17 @@
 //!
 //! # What reaches the response body
 //!
-//! A probe's explanation is rendered into an unauthenticated 503 body, so it is
-//! redacted and length-bounded HERE, once, rather than in each probe: a
-//! contract that every implementor has to remember is one a future implementor
-//! will forget.
+//! A FIXED CATEGORY, and nothing else. `/ready` is unauthenticated, so a
+//! driver's own words must not reach it: a server message can carry internal
+//! host names, database paths, TLS file paths, query text and tokens in forms
+//! no redaction routine knows to look for, and redacting URL userinfo covers
+//! only the shape it was written for.
+//!
+//! A report therefore carries [`ProbeFailure`], which has exactly two values —
+//! the dependency did not answer, or it did not answer in time — and both are
+//! facts this module owns rather than text it parsed. The driver's explanation
+//! stays inside the process, credential-redacted and length-bounded, in the
+//! transition log.
 
 use crate::infrastructure::config::redact_userinfo;
 use crate::infrastructure::{MongoDBRepository, RedisClient, SimulationSnapshotRepository};
@@ -47,20 +54,45 @@ pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// payload.
 pub(crate) const MAX_DETAIL_CHARS: usize = 200;
 
+/// Why a dependency did not answer, in terms safe to publish.
+///
+/// An allowlist, deliberately small: each value is decided by WHICH branch of
+/// the probe fired, never by inspecting what a server said. Adding a value
+/// means deciding, once and in the open, that the new fact is safe to tell an
+/// unauthenticated caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeFailure {
+    /// It refused, failed, or could not be reached at all.
+    Unreachable,
+    /// It did not answer inside the probe's bound.
+    TimedOut,
+}
+
+impl ProbeFailure {
+    /// The public wording, which is the whole of what a caller learns.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProbeFailure::Unreachable => "unreachable",
+            ProbeFailure::TimedOut => "timed_out",
+        }
+    }
+}
+
 /// One dependency's answer.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DependencyReport {
     /// What was probed: `redis`, `mongodb` or `clickhouse`.
     pub name: &'static str,
-    /// Why it did not answer, absent when it did. Already redacted and bounded.
-    pub error: Option<String>,
+    /// Why it did not answer, absent when it did. A category, never a message.
+    pub failure: Option<ProbeFailure>,
 }
 
 impl DependencyReport {
     /// Whether this dependency answered.
     #[must_use]
     pub fn is_up(&self) -> bool {
-        self.error.is_none()
+        self.failure.is_none()
     }
 }
 
@@ -177,21 +209,31 @@ impl Readiness {
     /// Bounded: a hung dependency costs one timeout for the whole call, not one
     /// per dependency, and does not stop the others from being reported.
     pub async fn evaluate(&self) -> Vec<DependencyReport> {
-        let reports = join_all(self.probes.iter().map(|probe| async move {
+        let answers = join_all(self.probes.iter().map(|probe| async move {
             let name = probe.name();
-            let error = match tokio::time::timeout(PROBE_TIMEOUT, probe.check()).await {
-                Ok(Ok(())) => None,
-                Ok(Err(detail)) => Some(bound_detail(&redact_userinfo(&detail))),
-                Err(_) => Some(format!(
-                    "did not answer within {}s",
-                    PROBE_TIMEOUT.as_secs()
-                )),
-            };
-            DependencyReport { name, error }
+            // The category comes from which arm fired, and the driver's own
+            // words go no further than the internal log beside it.
+            match tokio::time::timeout(PROBE_TIMEOUT, probe.check()).await {
+                Ok(Ok(())) => (name, None, None),
+                Ok(Err(detail)) => (
+                    name,
+                    Some(ProbeFailure::Unreachable),
+                    Some(bound_detail(&redact_userinfo(&detail))),
+                ),
+                Err(_) => (name, Some(ProbeFailure::TimedOut), None),
+            }
         }))
         .await;
 
-        self.log_transition(&reports);
+        let reports: Vec<DependencyReport> = answers
+            .iter()
+            .map(|(name, failure, _)| DependencyReport {
+                name,
+                failure: *failure,
+            })
+            .collect();
+
+        self.log_transition(&answers);
         reports
     }
 
@@ -200,8 +242,8 @@ impl Readiness {
     /// The endpoint is polled forever by design, so logging every failure would
     /// emit a line per dependency every few seconds for as long as an outage
     /// lasts, which is what teaches an operator to filter the log.
-    fn log_transition(&self, reports: &[DependencyReport]) {
-        let ready = reports.iter().all(DependencyReport::is_up);
+    fn log_transition(&self, answers: &[(&'static str, Option<ProbeFailure>, Option<String>)]) {
+        let ready = answers.iter().all(|(_, failure, _)| failure.is_none());
         if self.last_logged_ready.swap(ready, Ordering::SeqCst) == ready {
             return;
         }
@@ -211,10 +253,13 @@ impl Readiness {
             return;
         }
 
-        for report in reports.iter().filter(|report| !report.is_up()) {
+        // The one place a driver's explanation is kept, and it never leaves the
+        // process. Redacted and bounded even here: logs get shipped.
+        for (name, failure, detail) in answers.iter().filter(|(_, failure, _)| failure.is_some()) {
             warn!(
-                dependency = report.name,
-                detail = report.error.as_deref().unwrap_or(""),
+                dependency = name,
+                reason = failure.map_or("", ProbeFailure::as_str),
+                detail = detail.as_deref().unwrap_or(""),
                 "a dependency stopped answering; this instance is not ready"
             );
         }
@@ -406,7 +451,7 @@ mod tests {
         let reports = readiness.evaluate().await;
 
         match reports.iter().find(|report| report.name == "redis") {
-            Some(redis) => assert_eq!(redis.error.as_deref(), Some("connection refused")),
+            Some(redis) => assert_eq!(redis.failure, Some(ProbeFailure::Unreachable)),
             None => panic!("the failing dependency must be reported: {reports:?}"),
         }
         match reports.iter().find(|report| report.name == "mongodb") {
@@ -439,8 +484,8 @@ mod tests {
 
         match reports.iter().find(|report| report.name == "stalled") {
             Some(stalled) => assert_eq!(
-                stalled.error.as_deref(),
-                Some("did not answer within 2s"),
+                stalled.failure,
+                Some(ProbeFailure::TimedOut),
                 "the report says it timed out, not that it refused"
             ),
             None => panic!("the hung dependency must be reported: {reports:?}"),
@@ -451,59 +496,54 @@ mod tests {
         }
     }
 
-    /// Credentials never reach a report, whatever a probe returns.
+    /// A driver's own words never reach a report, whatever a probe returns.
     ///
-    /// The 503 body is unauthenticated, and a driver error echoes the
-    /// connection URI it was given.
+    /// The report is what an unauthenticated 503 is rendered from, so the only
+    /// thing it may carry is the category. A server message can name internal
+    /// hosts, paths, queries and tokens that no redaction routine reliably
+    /// recognises, which is why none of it is published rather than published
+    /// after a scrub.
     #[tokio::test]
-    async fn test_a_failure_detail_is_redacted() {
-        let readiness = Readiness::new(vec![Arc::new(Switch::failing_with(
-            "redis",
+    async fn test_a_report_carries_no_driver_text() {
+        let leaky = "IO error: redis://admin:hunter2@10.0.0.7:6379/prod?tls_cert=/etc/ssl/k.pem";
+        let readiness = Readiness::new(vec![Arc::new(Switch::failing_with("redis", leaky))]);
+
+        let reports = readiness.evaluate().await;
+
+        assert_eq!(reports[0].failure, Some(ProbeFailure::Unreachable));
+        let rendered = format!("{reports:?}");
+        for secret in ["hunter2", "10.0.0.7", "/etc/ssl/k.pem", "prod"] {
+            assert!(
+                !rendered.contains(secret),
+                "the report leaked {secret:?}: {rendered}"
+            );
+        }
+    }
+
+    /// The two public categories are the whole vocabulary.
+    #[tokio::test]
+    async fn test_the_public_vocabulary_is_two_words() {
+        assert_eq!(ProbeFailure::Unreachable.as_str(), "unreachable");
+        assert_eq!(ProbeFailure::TimedOut.as_str(), "timed_out");
+    }
+
+    /// The internal detail is redacted and bounded before it is logged.
+    ///
+    /// It never reaches a response, but logs get shipped, so the sanitiser
+    /// still runs over it.
+    #[tokio::test]
+    async fn test_the_internal_detail_is_sanitised() {
+        let redacted = bound_detail(&crate::infrastructure::config::redact_userinfo(
             "IO error: redis://admin:hunter2@redis:6379 refused",
-        ))]);
+        ));
+        assert!(!redacted.contains("hunter2"), "the password survived");
+        assert!(redacted.contains("refused"), "the reason was lost");
 
-        let reports = readiness.evaluate().await;
+        let long = bound_detail(&"x".repeat(MAX_DETAIL_CHARS * 5));
+        assert_eq!(long.chars().count(), MAX_DETAIL_CHARS + 3);
+        assert!(long.ends_with("..."));
 
-        match reports[0].error.as_deref() {
-            Some(detail) => {
-                assert!(
-                    !detail.contains("hunter2"),
-                    "the password survived: {detail}"
-                );
-                assert!(detail.contains("refused"), "the reason was lost: {detail}");
-            }
-            None => panic!("the probe failed and must say so: {reports:?}"),
-        }
-    }
-
-    /// An unbounded server exception is trimmed before it becomes a body.
-    #[tokio::test]
-    async fn test_a_long_failure_detail_is_bounded() {
-        let readiness = Readiness::new(vec![Arc::new(Switch::failing_with(
-            "clickhouse",
-            &"x".repeat(MAX_DETAIL_CHARS * 5),
-        ))]);
-
-        let reports = readiness.evaluate().await;
-
-        match reports[0].error.as_deref() {
-            Some(detail) => {
-                assert_eq!(detail.chars().count(), MAX_DETAIL_CHARS + 3);
-                assert!(detail.ends_with("..."));
-            }
-            None => panic!("the probe failed and must say so: {reports:?}"),
-        }
-    }
-
-    /// A detail that fits is left exactly as it is.
-    #[tokio::test]
-    async fn test_a_short_failure_detail_is_untouched() {
-        let readiness = Readiness::new(vec![Arc::new(Switch::new("redis", false))]);
-
-        assert_eq!(
-            readiness.evaluate().await[0].error.as_deref(),
-            Some("connection refused")
-        );
+        assert_eq!(bound_detail("connection refused"), "connection refused");
     }
 
     /// With nothing configured to check, an instance is ready.

--- a/src/infrastructure/health.rs
+++ b/src/infrastructure/health.rs
@@ -1,0 +1,582 @@
+//! What the readiness endpoint asks, and of whom.
+//!
+//! The probes live here, beside the clients they call, rather than beside the
+//! handler that serves them: asking Redis whether it is there is infrastructure
+//! work, and putting it in `api` would have that layer reaching into this one's
+//! internals — the credential redaction, the driver error types — to do it.
+//! `api` keeps the routes, the response shape and the status codes, and this
+//! module answers the only question they need: which dependencies answered.
+//!
+//! # Bounded, concurrent, and never cached
+//!
+//! Every probe runs under a two-second bound and all of them run at once, so a
+//! single hung dependency can neither hold the probe open past that bound nor
+//! hide the state of the others. Nothing is cached: an instance whose Redis
+//! came back must report itself ready again WITHOUT a restart, which is exactly
+//! what a cached answer would prevent. The only thing remembered between calls
+//! is what was last LOGGED, so an outage costs one line rather than one line
+//! per probe per ten seconds forever.
+//!
+//! # What reaches the response body
+//!
+//! A probe's explanation is rendered into an unauthenticated 503 body, so it is
+//! redacted and length-bounded HERE, once, rather than in each probe: a
+//! contract that every implementor has to remember is one a future implementor
+//! will forget.
+
+use crate::infrastructure::config::redact_userinfo;
+use crate::infrastructure::{MongoDBRepository, RedisClient, SimulationSnapshotRepository};
+use async_trait::async_trait;
+use futures::future::join_all;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tracing::{info, warn};
+
+/// How long a single dependency has to answer.
+///
+/// Short on purpose. A probe is asked repeatedly and its answer is only useful
+/// while it is current, so a dependency that has not answered in this long is
+/// one this instance could not serve a request through either.
+pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How much of a failure explanation reaches the response body.
+///
+/// A driver error can be an unbounded server exception, and this one goes into
+/// an unauthenticated body. Enough to name the problem, not enough to be a
+/// payload.
+pub(crate) const MAX_DETAIL_CHARS: usize = 200;
+
+/// One dependency's answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyReport {
+    /// What was probed: `redis`, `mongodb` or `clickhouse`.
+    pub name: &'static str,
+    /// Why it did not answer, absent when it did. Already redacted and bounded.
+    pub error: Option<String>,
+}
+
+impl DependencyReport {
+    /// Whether this dependency answered.
+    #[must_use]
+    pub fn is_up(&self) -> bool {
+        self.error.is_none()
+    }
+}
+
+/// One thing readiness asks before reporting an instance able to take work.
+#[async_trait]
+pub trait DependencyProbe: Send + Sync {
+    /// The name this dependency is reported under.
+    fn name(&self) -> &'static str;
+
+    /// Asks it whether it is there.
+    ///
+    /// # Errors
+    ///
+    /// Returns a short explanation when it is not. The caller redacts and
+    /// bounds it before it reaches a response body, so an implementation may
+    /// return whatever the driver said.
+    async fn check(&self) -> Result<(), String>;
+}
+
+/// Redis, which every session and every v2 simulation is stored in.
+pub struct RedisProbe(Arc<RedisClient>);
+
+impl RedisProbe {
+    /// Probes the given client.
+    #[must_use]
+    pub fn new(client: Arc<RedisClient>) -> Self {
+        Self(client)
+    }
+}
+
+#[async_trait]
+impl DependencyProbe for RedisProbe {
+    fn name(&self) -> &'static str {
+        "redis"
+    }
+
+    async fn check(&self) -> Result<(), String> {
+        self.0.ping().await.map_err(|error| error.to_string())
+    }
+}
+
+/// MongoDB, which the v1 event log is written to.
+pub struct MongoDbProbe(Arc<MongoDBRepository>);
+
+impl MongoDbProbe {
+    /// Probes the given repository.
+    #[must_use]
+    pub fn new(repository: Arc<MongoDBRepository>) -> Self {
+        Self(repository)
+    }
+}
+
+#[async_trait]
+impl DependencyProbe for MongoDbProbe {
+    fn name(&self) -> &'static str {
+        "mongodb"
+    }
+
+    async fn check(&self) -> Result<(), String> {
+        self.0.ping().await.map_err(|error| error.to_string())
+    }
+}
+
+/// The ClickHouse snapshot warehouse, registered only when persistence is on.
+pub struct WarehouseProbe(Arc<dyn SimulationSnapshotRepository>);
+
+impl WarehouseProbe {
+    /// Probes the given warehouse.
+    #[must_use]
+    pub fn new(warehouse: Arc<dyn SimulationSnapshotRepository>) -> Self {
+        Self(warehouse)
+    }
+}
+
+#[async_trait]
+impl DependencyProbe for WarehouseProbe {
+    fn name(&self) -> &'static str {
+        "clickhouse"
+    }
+
+    async fn check(&self) -> Result<(), String> {
+        self.0.ping().await.map_err(|error| error.to_string())
+    }
+}
+
+/// What readiness checks.
+///
+/// Assembled once at startup from the dependencies the deployment actually
+/// configured, so an instance is never reported unready over a service it does
+/// not use, and never reported ready without one it does.
+#[derive(Clone, Default)]
+pub struct Readiness {
+    probes: Arc<Vec<Arc<dyn DependencyProbe>>>,
+    /// The last readiness that was LOGGED, so a state that has not changed is
+    /// not restated on every probe. Not a cached answer: it never decides what
+    /// [`Readiness::evaluate`] returns.
+    last_logged_ready: Arc<AtomicBool>,
+}
+
+impl Readiness {
+    /// Collects the probes to run, in the order they will be reported.
+    #[must_use]
+    pub fn new(probes: Vec<Arc<dyn DependencyProbe>>) -> Self {
+        Self {
+            probes: Arc::new(probes),
+            // Starts ready, so the first FAILURE is a transition worth a line
+            // and a healthy start is silent.
+            last_logged_ready: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Runs every probe at once and collects the answers.
+    ///
+    /// Bounded: a hung dependency costs one timeout for the whole call, not one
+    /// per dependency, and does not stop the others from being reported.
+    pub async fn evaluate(&self) -> Vec<DependencyReport> {
+        let reports = join_all(self.probes.iter().map(|probe| async move {
+            let name = probe.name();
+            let error = match tokio::time::timeout(PROBE_TIMEOUT, probe.check()).await {
+                Ok(Ok(())) => None,
+                Ok(Err(detail)) => Some(bound_detail(&redact_userinfo(&detail))),
+                Err(_) => Some(format!(
+                    "did not answer within {}s",
+                    PROBE_TIMEOUT.as_secs()
+                )),
+            };
+            DependencyReport { name, error }
+        }))
+        .await;
+
+        self.log_transition(&reports);
+        reports
+    }
+
+    /// Says something only when the answer CHANGED.
+    ///
+    /// The endpoint is polled forever by design, so logging every failure would
+    /// emit a line per dependency every few seconds for as long as an outage
+    /// lasts, which is what teaches an operator to filter the log.
+    fn log_transition(&self, reports: &[DependencyReport]) {
+        let ready = reports.iter().all(DependencyReport::is_up);
+        if self.last_logged_ready.swap(ready, Ordering::SeqCst) == ready {
+            return;
+        }
+
+        if ready {
+            info!("every dependency answered again; this instance is ready");
+            return;
+        }
+
+        for report in reports.iter().filter(|report| !report.is_up()) {
+            warn!(
+                dependency = report.name,
+                detail = report.error.as_deref().unwrap_or(""),
+                "a dependency stopped answering; this instance is not ready"
+            );
+        }
+    }
+}
+
+/// Trims a failure explanation to what a response body should carry.
+fn bound_detail(detail: &str) -> String {
+    if detail.chars().count() <= MAX_DETAIL_CHARS {
+        return detail.to_string();
+    }
+
+    let kept: String = detail.chars().take(MAX_DETAIL_CHARS).collect();
+    format!("{kept}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::clickhouse::snapshots::interface::ContractSeriesQuery;
+    use crate::infrastructure::{ContractQuote, SnapshotRecord};
+    use crate::utils::ChainError;
+    use uuid::Uuid;
+
+    /// A probe whose answer the test controls, and can change mid-flight.
+    struct Switch {
+        name: &'static str,
+        up: AtomicBool,
+        detail: String,
+    }
+
+    impl Switch {
+        fn new(name: &'static str, up: bool) -> Self {
+            Self {
+                name,
+                up: AtomicBool::new(up),
+                detail: "connection refused".to_string(),
+            }
+        }
+
+        fn failing_with(name: &'static str, detail: &str) -> Self {
+            Self {
+                name,
+                up: AtomicBool::new(false),
+                detail: detail.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DependencyProbe for Switch {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn check(&self) -> Result<(), String> {
+            if self.up.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err(self.detail.clone())
+            }
+        }
+    }
+
+    /// A probe that never answers, standing in for a hung dependency.
+    struct Hangs;
+
+    #[async_trait]
+    impl DependencyProbe for Hangs {
+        fn name(&self) -> &'static str {
+            "stalled"
+        }
+
+        async fn check(&self) -> Result<(), String> {
+            tokio::time::sleep(PROBE_TIMEOUT * 10).await;
+            Ok(())
+        }
+    }
+
+    /// A warehouse that is unreachable, for the shipped [`WarehouseProbe`].
+    struct UnreachableWarehouse;
+
+    #[async_trait]
+    impl SimulationSnapshotRepository for UnreachableWarehouse {
+        async fn ping(&self) -> Result<(), ChainError> {
+            Err(ChainError::ClickHouseError(
+                "connection refused by clickhouse:8123".to_string(),
+            ))
+        }
+
+        async fn persist(&self, _record: SnapshotRecord) -> Result<(), ChainError> {
+            Err(ChainError::ClickHouseError("unreachable".to_string()))
+        }
+
+        async fn get(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Err(ChainError::ClickHouseError("unreachable".to_string()))
+        }
+
+        async fn read_range(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _from_step: usize,
+            _to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            Err(ChainError::ClickHouseError("unreachable".to_string()))
+        }
+
+        async fn contract_series(
+            &self,
+            _query: ContractSeriesQuery,
+        ) -> Result<Vec<ContractQuote>, ChainError> {
+            Err(ChainError::ClickHouseError("unreachable".to_string()))
+        }
+    }
+
+    /// A warehouse with nothing behind it, which is reachable by construction.
+    #[derive(Default)]
+    struct LocalWarehouse;
+
+    #[async_trait]
+    impl SimulationSnapshotRepository for LocalWarehouse {
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
+        async fn persist(&self, _record: SnapshotRecord) -> Result<(), ChainError> {
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _step: usize,
+        ) -> Result<Option<SnapshotRecord>, ChainError> {
+            Ok(None)
+        }
+
+        async fn read_range(
+            &self,
+            _simulation: Uuid,
+            _generation: u64,
+            _from_step: usize,
+            _to_step: usize,
+        ) -> Result<Vec<SnapshotRecord>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn contract_series(
+            &self,
+            _query: ContractSeriesQuery,
+        ) -> Result<Vec<ContractQuote>, ChainError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Every probe is reported, in the order it was registered.
+    #[tokio::test]
+    async fn test_every_probe_is_reported_in_order() {
+        let readiness = Readiness::new(vec![
+            Arc::new(Switch::new("redis", true)),
+            Arc::new(Switch::new("mongodb", true)),
+            Arc::new(Switch::new("clickhouse", true)),
+        ]);
+
+        let reports = readiness.evaluate().await;
+
+        assert_eq!(
+            reports.iter().map(|report| report.name).collect::<Vec<_>>(),
+            vec!["redis", "mongodb", "clickhouse"]
+        );
+        assert!(reports.iter().all(DependencyReport::is_up));
+    }
+
+    /// A failing dependency carries its reason, and the healthy ones survive.
+    #[tokio::test]
+    async fn test_a_failure_is_named_beside_the_healthy_dependencies() {
+        let readiness = Readiness::new(vec![
+            Arc::new(Switch::new("redis", false)),
+            Arc::new(Switch::new("mongodb", true)),
+        ]);
+
+        let reports = readiness.evaluate().await;
+
+        match reports.iter().find(|report| report.name == "redis") {
+            Some(redis) => assert_eq!(redis.error.as_deref(), Some("connection refused")),
+            None => panic!("the failing dependency must be reported: {reports:?}"),
+        }
+        match reports.iter().find(|report| report.name == "mongodb") {
+            Some(mongodb) => assert!(mongodb.is_up()),
+            None => panic!("every dependency must be reported: {reports:?}"),
+        }
+    }
+
+    /// A dependency that comes back flips the answer, with no restart.
+    #[tokio::test]
+    async fn test_a_recovered_dependency_reports_up_again() {
+        let switch = Arc::new(Switch::new("redis", false));
+        let readiness = Readiness::new(vec![switch.clone()]);
+
+        assert!(!readiness.evaluate().await[0].is_up());
+        switch.up.store(true, Ordering::SeqCst);
+        assert!(
+            readiness.evaluate().await[0].is_up(),
+            "nothing may be cached across evaluations"
+        );
+    }
+
+    /// A hung dependency times out rather than hanging the probe, and does not
+    /// hold up the ones that answered.
+    #[tokio::test(start_paused = true)]
+    async fn test_a_hung_dependency_times_out() {
+        let readiness = Readiness::new(vec![Arc::new(Hangs), Arc::new(Switch::new("redis", true))]);
+
+        let reports = readiness.evaluate().await;
+
+        match reports.iter().find(|report| report.name == "stalled") {
+            Some(stalled) => assert_eq!(
+                stalled.error.as_deref(),
+                Some("did not answer within 2s"),
+                "the report says it timed out, not that it refused"
+            ),
+            None => panic!("the hung dependency must be reported: {reports:?}"),
+        }
+        match reports.iter().find(|report| report.name == "redis") {
+            Some(redis) => assert!(redis.is_up(), "the probes run at once"),
+            None => panic!("every dependency must be reported: {reports:?}"),
+        }
+    }
+
+    /// Credentials never reach a report, whatever a probe returns.
+    ///
+    /// The 503 body is unauthenticated, and a driver error echoes the
+    /// connection URI it was given.
+    #[tokio::test]
+    async fn test_a_failure_detail_is_redacted() {
+        let readiness = Readiness::new(vec![Arc::new(Switch::failing_with(
+            "redis",
+            "IO error: redis://admin:hunter2@redis:6379 refused",
+        ))]);
+
+        let reports = readiness.evaluate().await;
+
+        match reports[0].error.as_deref() {
+            Some(detail) => {
+                assert!(
+                    !detail.contains("hunter2"),
+                    "the password survived: {detail}"
+                );
+                assert!(detail.contains("refused"), "the reason was lost: {detail}");
+            }
+            None => panic!("the probe failed and must say so: {reports:?}"),
+        }
+    }
+
+    /// An unbounded server exception is trimmed before it becomes a body.
+    #[tokio::test]
+    async fn test_a_long_failure_detail_is_bounded() {
+        let readiness = Readiness::new(vec![Arc::new(Switch::failing_with(
+            "clickhouse",
+            &"x".repeat(MAX_DETAIL_CHARS * 5),
+        ))]);
+
+        let reports = readiness.evaluate().await;
+
+        match reports[0].error.as_deref() {
+            Some(detail) => {
+                assert_eq!(detail.chars().count(), MAX_DETAIL_CHARS + 3);
+                assert!(detail.ends_with("..."));
+            }
+            None => panic!("the probe failed and must say so: {reports:?}"),
+        }
+    }
+
+    /// A detail that fits is left exactly as it is.
+    #[tokio::test]
+    async fn test_a_short_failure_detail_is_untouched() {
+        let readiness = Readiness::new(vec![Arc::new(Switch::new("redis", false))]);
+
+        assert_eq!(
+            readiness.evaluate().await[0].error.as_deref(),
+            Some("connection refused")
+        );
+    }
+
+    /// With nothing configured to check, an instance is ready.
+    ///
+    /// Not degenerate: a deployment without snapshot persistence registers no
+    /// warehouse probe, and the same reasoning scales down.
+    #[tokio::test]
+    async fn test_no_probes_is_ready() {
+        assert!(Readiness::default().evaluate().await.is_empty());
+    }
+
+    /// The shipped warehouse probe reports the warehouse's own failure.
+    #[tokio::test]
+    async fn test_the_warehouse_probe_reports_an_unreachable_warehouse() {
+        let probe = WarehouseProbe::new(Arc::new(UnreachableWarehouse));
+
+        assert_eq!(probe.name(), "clickhouse");
+        match probe.check().await {
+            Ok(()) => panic!("an unreachable warehouse must not report up"),
+            Err(detail) => assert!(
+                detail.contains("connection refused"),
+                "the warehouse's reason must survive: {detail}"
+            ),
+        }
+    }
+
+    /// A warehouse with no server behind it answers, which is the truth.
+    #[tokio::test]
+    async fn test_the_warehouse_probe_accepts_a_local_warehouse() {
+        let probe = WarehouseProbe::new(Arc::new(LocalWarehouse));
+
+        match probe.check().await {
+            Ok(()) => {}
+            Err(detail) => panic!("a local warehouse is reachable: {detail}"),
+        }
+    }
+
+    /// The Redis probe answers against a live server.
+    ///
+    /// Opt-in (`cargo test -- --ignored`), like every other live-service test:
+    /// `docker run -d --rm -p 6379:6379 redis:8`.
+    #[tokio::test]
+    #[ignore = "requires a live Redis on localhost:6379"]
+    async fn test_the_redis_probe_answers_against_a_live_server() {
+        let client = match RedisClient::new(crate::infrastructure::RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("Redis must be reachable for this test: {error}"),
+        };
+        let probe = RedisProbe::new(client);
+
+        assert_eq!(probe.name(), "redis");
+        match probe.check().await {
+            Ok(()) => {}
+            Err(detail) => panic!("a live server must answer: {detail}"),
+        }
+    }
+
+    /// The MongoDB probe answers against a live server.
+    ///
+    /// Opt-in: `docker run -d --rm -p 27017:27017 mongo:7`.
+    #[tokio::test]
+    #[ignore = "requires a live MongoDB on localhost:27017"]
+    async fn test_the_mongodb_probe_answers_against_a_live_server() {
+        let repository = match crate::infrastructure::init_mongodb().await {
+            Ok(repository) => repository,
+            Err(error) => panic!("MongoDB must be reachable for this test: {error}"),
+        };
+        let probe = MongoDbProbe::new(repository);
+
+        assert_eq!(probe.name(), "mongodb");
+        match probe.check().await {
+            Ok(()) => {}
+            Err(detail) => panic!("a live server must answer: {detail}"),
+        }
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -36,7 +36,8 @@ pub use config::snapshot::{
     DEFAULT_SNAPSHOT_RETENTION_DAYS, SnapshotPersistenceConfig,
 };
 pub use health::{
-    DependencyProbe, DependencyReport, MongoDbProbe, Readiness, RedisProbe, WarehouseProbe,
+    DependencyProbe, DependencyReport, MongoDbProbe, ProbeFailure, Readiness, RedisProbe,
+    WarehouseProbe,
 };
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,5 +1,6 @@
 mod clickhouse;
 mod config;
+pub mod health;
 mod mongodb;
 mod redis;
 mod repositories;
@@ -33,6 +34,9 @@ pub use config::snapshot::{
     DEFAULT_SNAPSHOT_BATCH_ROWS, DEFAULT_SNAPSHOT_INSERT_TIMEOUT_SECS,
     DEFAULT_SNAPSHOT_MAX_READ_ROWS, DEFAULT_SNAPSHOT_PERSISTENCE_ENABLED,
     DEFAULT_SNAPSHOT_RETENTION_DAYS, SnapshotPersistenceConfig,
+};
+pub use health::{
+    DependencyProbe, DependencyReport, MongoDbProbe, Readiness, RedisProbe, WarehouseProbe,
 };
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;

--- a/src/infrastructure/mongodb/client.rs
+++ b/src/infrastructure/mongodb/client.rs
@@ -141,6 +141,35 @@ impl MongoDBClient {
         Ok(())
     }
 
+    /// Asks the server whether it is there.
+    ///
+    /// The same `{ping: 1}` the constructor runs: a no-auth, cheap command that
+    /// says the deployment answered, and nothing about any one collection.
+    ///
+    /// The mutex is released BEFORE the command is awaited. Held across it, a
+    /// probe against an unreachable server would pin the handle for the probe's
+    /// whole timeout, and every `save_step` and `save_event` on the request
+    /// path would block behind a health check that is polled on a timer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the command fails, with the
+    /// message passed through `redact_userinfo`: driver errors echo the
+    /// connection URI, and a readiness body is a public surface.
+    #[instrument(skip(self), level = "debug")]
+    pub async fn ping(&self) -> Result<(), ChainError> {
+        // `Database` is a cheap handle; cloning it costs a refcount and buys
+        // back the lock immediately.
+        let db = {
+            let guard = self.db.lock().await;
+            guard.clone()
+        };
+        db.run_command(doc! {"ping": 1}).await.map_err(|e| {
+            ChainError::Internal(redact_userinfo(&format!("Failed to ping MongoDB: {}", e)))
+        })?;
+        Ok(())
+    }
+
     /// Returns the MongoDB configuration
     pub fn get_config(&self) -> &MongoDBConfig {
         &self.config

--- a/src/infrastructure/redis/client.rs
+++ b/src/infrastructure/redis/client.rs
@@ -1,5 +1,6 @@
 use crate::infrastructure::config::redact_userinfo;
 use crate::infrastructure::config::redis::RedisConfig;
+use crate::utils::ChainError;
 use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::{AsyncCommands, Client, FromRedisValue, RedisError, RedisResult, ToSingleRedisArg};
 use std::time::Duration;
@@ -185,15 +186,26 @@ impl RedisClient {
     /// The connection manager reconnects on its own, so a probe that failed
     /// while Redis was down starts succeeding again without a restart.
     ///
+    /// `pub(crate)`, and on [`ChainError`] rather than the driver's own result
+    /// type: the driver error boundary stops here, at the adapter, so nothing
+    /// above infrastructure ever pattern-matches a `redis::RedisError`. The only
+    /// caller is the in-crate readiness probe.
+    ///
     /// # Errors
     ///
-    /// Returns the driver's error when the server is unreachable or does not
-    /// answer within [`RedisConfig::timeout`].
+    /// Returns [`ChainError::Internal`] when the server is unreachable or does
+    /// not answer within [`RedisConfig::timeout`], credential-redacted, since a
+    /// driver error can echo the connection URL back.
     #[instrument(skip(self), level = "debug")]
-    pub async fn ping(&self) -> RedisResult<()> {
+    pub(crate) async fn ping(&self) -> Result<(), ChainError> {
         let mut conn = self.manager.clone();
         debug!("Pinging Redis");
-        redis::cmd("PING").query_async::<()>(&mut conn).await
+        redis::cmd("PING")
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|error| {
+                ChainError::Internal(redact_userinfo(&format!("Failed to ping Redis: {error}")))
+            })
     }
 
     /// Returns the Redis configuration

--- a/src/infrastructure/redis/client.rs
+++ b/src/infrastructure/redis/client.rs
@@ -178,6 +178,24 @@ impl RedisClient {
         conn.exists(key).await
     }
 
+    /// Asks the server whether it is there.
+    ///
+    /// `PING` and nothing else: a readiness probe must cost the server less
+    /// than the requests it gates, and it must not depend on any key existing.
+    /// The connection manager reconnects on its own, so a probe that failed
+    /// while Redis was down starts succeeding again without a restart.
+    ///
+    /// # Errors
+    ///
+    /// Returns the driver's error when the server is unreachable or does not
+    /// answer within [`RedisConfig::timeout`].
+    #[instrument(skip(self), level = "debug")]
+    pub async fn ping(&self) -> RedisResult<()> {
+        let mut conn = self.manager.clone();
+        debug!("Pinging Redis");
+        redis::cmd("PING").query_async::<()>(&mut conn).await
+    }
+
     /// Returns the Redis configuration
     pub fn get_config(&self) -> &RedisConfig {
         &self.config

--- a/src/infrastructure/repositories/mongo_repo.rs
+++ b/src/infrastructure/repositories/mongo_repo.rs
@@ -21,6 +21,16 @@ impl MongoDBRepository {
         Self { client }
     }
 
+    /// Asks MongoDB whether it is there, for the readiness probe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the server does not answer; the
+    /// message is credential-redacted.
+    pub async fn ping(&self) -> Result<(), ChainError> {
+        self.client.ping().await
+    }
+
     /// Saves a chain response to the steps collection
     #[instrument(skip(self, chain_data, metrics), level = "debug")]
     pub async fn save_chain_step(

--- a/src/infrastructure/repositories/snapshot_repo.rs
+++ b/src/infrastructure/repositories/snapshot_repo.rs
@@ -665,6 +665,18 @@ impl SnapshotWriter for ClickHouseSnapshotRepository {
 
 #[async_trait]
 impl SimulationSnapshotRepository for ClickHouseSnapshotRepository {
+    /// `SELECT 1`, which touches no table.
+    ///
+    /// Deliberately not a query against the snapshot tables: a readiness probe
+    /// answers "can I reach the warehouse", and a table that does not exist yet
+    /// is a schema problem that already failed startup, not a reason to report
+    /// an otherwise healthy instance as unable to take work.
+    #[instrument(skip(self), level = "debug")]
+    async fn ping(&self) -> Result<(), ChainError> {
+        self.client.client.query("SELECT 1").execute().await?;
+        Ok(())
+    }
+
     #[instrument(
         skip(self, record),
         fields(

--- a/src/infrastructure/telemetry/middleware.rs
+++ b/src/infrastructure/telemetry/middleware.rs
@@ -27,6 +27,7 @@ use std::time::Instant;
 ///
 pub struct MetricsMiddleware {
     metrics: Arc<MetricsCollector>,
+    excluded_paths: &'static [&'static str],
 }
 
 impl MetricsMiddleware {
@@ -42,7 +43,26 @@ impl MetricsMiddleware {
     /// A new instance of the struct containing the provided `MetricsCollector`.
     ///
     pub fn new(metrics: Arc<MetricsCollector>) -> Self {
-        Self { metrics }
+        Self {
+            metrics,
+            excluded_paths: &[],
+        }
+    }
+
+    /// Stops these paths from being counted.
+    ///
+    /// For endpoints polled on a timer by something that is not a client: an
+    /// orchestrator probing readiness every few seconds forever adds a constant
+    /// to every request series and a flood of 503s to the error series while a
+    /// dependency is down, which describes the prober rather than the traffic.
+    ///
+    /// The paths are matched exactly, and are supplied by the API layer that
+    /// owns the routes rather than being hardcoded here: a middleware that knew
+    /// route strings would be a second place for them to drift.
+    #[must_use]
+    pub fn excluding(mut self, paths: &'static [&'static str]) -> Self {
+        self.excluded_paths = paths;
+        self
     }
 }
 
@@ -62,6 +82,7 @@ where
         ok(MetricsMiddlewareService {
             service,
             metrics: self.metrics.clone(),
+            excluded_paths: self.excluded_paths,
         })
     }
 }
@@ -69,6 +90,7 @@ where
 pub struct MetricsMiddlewareService<S> {
     service: S,
     metrics: Arc<MetricsCollector>,
+    excluded_paths: &'static [&'static str],
 }
 
 impl<S, B> Service<ServiceRequest> for MetricsMiddlewareService<S>
@@ -84,6 +106,14 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        // Excluded before anything is measured, not filtered at export: a probe
+        // must not even cost the timer, and a series that was never created
+        // cannot be mistaken for one that dropped to zero.
+        if self.excluded_paths.contains(&req.path()) {
+            let fut = self.service.call(req);
+            return Box::pin(fut);
+        }
+
         let metrics = self.metrics.clone();
         let path = req.path().to_string();
         let method = req.method().to_string();
@@ -122,6 +152,52 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::task::{Context, Poll};
     use std::time::Duration;
+
+    /// An excluded path is not counted, and everything else still is.
+    ///
+    /// Against the REAL middleware and a REAL collector, read back through the
+    /// same `export_metrics` the `/metrics` endpoint serves: the test-only
+    /// mirror further down cannot prove anything about the exclusion, since it
+    /// is a copy rather than the code that ships.
+    #[actix_web::test]
+    async fn test_an_excluded_path_is_not_counted() {
+        let collector = match MetricsCollector::new() {
+            Ok(collector) => Arc::new(collector),
+            Err(error) => panic!("the collector must build: {error}"),
+        };
+
+        let app = test::init_service(
+            App::new()
+                .wrap(MetricsMiddleware::new(Arc::clone(&collector)).excluding(&["/ready"]))
+                .route(
+                    "/ready",
+                    web::get().to(|| async { HttpResponse::ServiceUnavailable().finish() }),
+                )
+                .route(
+                    "/api/v1/chain",
+                    web::get().to(|| async { HttpResponse::Ok().finish() }),
+                ),
+        )
+        .await;
+
+        // The 503 matters: a probe failing while a dependency is down would
+        // otherwise pour into the error series too.
+        let probe = test::call_service(&app, TestRequest::get().uri("/ready").to_request()).await;
+        assert_eq!(probe.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let served =
+            test::call_service(&app, TestRequest::get().uri("/api/v1/chain").to_request()).await;
+        assert_eq!(served.status(), StatusCode::OK);
+
+        let exported = collector.export_metrics();
+        assert!(
+            !exported.contains("/ready"),
+            "the probe must not appear in the metrics: {exported}"
+        );
+        assert!(
+            exported.contains("/api/v1/chain"),
+            "ordinary traffic must still be counted: {exported}"
+        );
+    }
 
     // Tracking structure for test metrics
     #[derive(Default, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,12 @@
 //! Redis hiccup can never get a healthy instance restarted. `/ready` says this
 //! instance can take work, and it asks: Redis and MongoDB always, ClickHouse
 //! when snapshot persistence is enabled, each under a 2-second bound and all of
-//! them at once. A 503 body names every dependency and why the failing ones
-//! failed, credential-redacted. Nothing is cached, so an instance whose Redis
-//! came back reports itself ready again without a restart.
+//! them at once. A 503 body names every dependency and, for the failing ones, a
+//! fixed category: `unreachable` or `timed_out`. Never a driver's own words —
+//! the endpoint is unauthenticated, and a server message can carry internal
+//! hosts, paths and tokens no redaction reliably recognises, so the full
+//! explanation stays in the service's log. Nothing is cached, so an instance
+//! whose Redis came back reports itself ready again without a restart.
 //!
 //! Both are unversioned, unauthenticated, and excluded from the request
 //! metrics: an orchestrator polling forever would otherwise add a constant to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,26 @@
 //! | PUT    | /api/v1/chain      | Replace Session     | Completely replaces session parameters                           |
 //! | PATCH  | /api/v1/chain      | Update Parameters   | Updates specific session parameters                              |
 //! | DELETE | /api/v1/chain      | Delete Session      | Terminates and removes a session                                 |
+//! | GET    | /health            | Liveness            | The process is alive; always 200, no dependency touched          |
+//! | GET    | /ready             | Readiness           | 200 when every configured dependency answers, 503 naming those that did not |
+//!
+//! ### Probes
+//!
+//! The two answer different questions, and conflating them is how one outage
+//! becomes two. `/health` says the process is alive: it touches nothing, so a
+//! Redis hiccup can never get a healthy instance restarted. `/ready` says this
+//! instance can take work, and it asks: Redis and MongoDB always, ClickHouse
+//! when snapshot persistence is enabled, each under a 2-second bound and all of
+//! them at once. A 503 body names every dependency and why the failing ones
+//! failed, credential-redacted. Nothing is cached, so an instance whose Redis
+//! came back reports itself ready again without a restart.
+//!
+//! Both are unversioned, unauthenticated, and excluded from the request
+//! metrics: an orchestrator polling forever would otherwise add a constant to
+//! every series and a flood of 503s to the error series while a dependency is
+//! down. `Docker/docker-compose.yml` points its backend healthcheck at
+//! `/ready`, so `docker compose up -d` reports the service healthy only once it
+//! can actually serve.
 //!
 //! **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 //! of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,9 @@
 
 use optionchain_simulator::api::start_server;
 use optionchain_simulator::infrastructure::{
-    ClickHouseSnapshotRepository, MetricsCollector, RedisClient, RedisConfig, ServerConfig,
-    SimulationV2Config, init_mongodb, resolve_log_level_from_env,
+    ClickHouseSnapshotRepository, DependencyProbe, MetricsCollector, MongoDbProbe, Readiness,
+    RedisClient, RedisConfig, RedisProbe, ServerConfig, SimulationV2Config, WarehouseProbe,
+    init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
     InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
@@ -162,6 +163,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Connecting to Redis at {}", redis_config);
     let redis_client = Arc::new(RedisClient::new(redis_config).await?);
     let redis_client_v2 = Arc::clone(&redis_client);
+    let redis_client_probe = Arc::clone(&redis_client);
     let store = Arc::new(InRedisSessionStore::new(
         redis_client,
         Some("optionchain:session:".to_string()), // Custom key prefix
@@ -238,6 +240,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // What `GET /ready` will check: the services THIS process opened, so an
+    // instance is never reported unready over a dependency it does not use.
+    // Redis and MongoDB are always there — startup aborts without them — and
+    // the warehouse only when snapshot persistence is on.
+    let mut probes: Vec<Arc<dyn DependencyProbe>> = vec![
+        Arc::new(RedisProbe::new(redis_client_probe)),
+        Arc::new(MongoDbProbe::new(Arc::clone(&mongodb_repository))),
+    ];
+    if let Some(warehouse) = simulation_manager.warehouse() {
+        probes.push(Arc::new(WarehouseProbe::new(warehouse)));
+    }
+    let readiness = Readiness::new(probes);
+
     let listen_on = server.address;
     let port = server.port;
 
@@ -262,6 +277,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         mongodb_repository,
         listen_on,
         port,
+        readiness,
     )
     .await
     {

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -895,6 +895,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SimulationSnapshotRepository for RecordingWarehouse {
+        /// No server behind it; reachable exactly as long as the process is.
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
         async fn persist(&self, record: SnapshotRecord) -> Result<(), ChainError> {
             if self.fail {
                 return Err(ChainError::Internal("the warehouse is down".to_string()));
@@ -948,6 +953,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SimulationSnapshotRepository for StallingWarehouse {
+        /// No server behind it; reachable exactly as long as the process is.
+        async fn ping(&self) -> Result<(), ChainError> {
+            Ok(())
+        }
+
         async fn persist(&self, _record: SnapshotRecord) -> Result<(), ChainError> {
             self.started.fetch_add(1, Ordering::SeqCst);
             std::future::pending::<()>().await;


### PR DESCRIPTION
Closes #84

## Stack

- **Base branch:** `stack/3-82-configurable-bind`
- **Stacked on:** #90
- **Blocks:** #93
- **Stack:** #88 (#83) → #89 (#81) → #90 (#82) → **this** → #80 → #78

The diff against `main` is cumulative until the lower PRs merge; read it against the base branch.

## What changed

`GET /health` answers whether the process is alive: always 200, no dependency touched. `GET /ready` answers whether this instance can take work: Redis and MongoDB always, ClickHouse when snapshot persistence is enabled, 200 when they all answer and 503 naming the ones that did not.

Keeping them apart is the point. A failing dependency must not make `/health` fail, or an orchestrator restarts a healthy instance every time Redis hiccups and one outage becomes two. `/ready` is the signal a consumer sharding tape materialisation across instances reads to route work.

Probes run concurrently under a two-second bound, so one hung dependency can neither hold the probe open nor hide the state of the others. Nothing is cached: an instance whose Redis came back reports ready again without a restart. The only thing remembered between calls is what was last logged, so an outage costs one line instead of one per dependency every ten seconds forever.

## Where the code lives

What is probed sits in `infrastructure::health`, beside the clients it calls; `api::rest::health` keeps the routes, the bodies and the status codes and renders `DependencyReport` into the response DTOs. Putting the probes in `api` would have had that layer reaching into infrastructure's internals (the credential redaction, the driver error types) to do infrastructure work.

The handler holds a list of `DependencyProbe` trait objects rather than the three clients, which is what makes the endpoint testable with no servers running. The list is assembled in `main.rs` from what the process actually opened, so an instance is never reported unready over a service it does not use.

## Breaking

- `start_server` takes a `Readiness`. It is a public function, so the next release is a minor bump.
- `SimulationSnapshotRepository::ping` is **required**, not defaulted. A default `Ok(())` would mean a warehouse that forgot to answer reports itself reachable, and `/ready` would serve a 200 on the strength of it. Four in-crate test doubles implement it in three lines each. Free to tighten now, breaking to tighten later.

## Safety of the body

The 503 body is unauthenticated, so a failure detail is redacted and length-bounded (200 characters) in one place, in `Readiness::evaluate`, rather than in each probe: a contract every implementor has to remember is one the next implementor forgets. A test asserts a password in a driver error does not survive.

`MongoDBClient::ping` clones the `Database` handle and releases the mutex **before** awaiting the command. Held across it, a probe against an unreachable server would pin the handle for the whole timeout and block every `save_step` and `save_event` on the request path behind a health check polled on a timer.

## Metrics

Both routes are excluded through a new `MetricsMiddleware::excluding(&'static [&'static str])`, fed from `health::PROBE_PATHS` so the route strings have one home. Exclusion happens before the timer starts, not at export. A test drives the real middleware and the real collector and reads back `export_metrics`: `/ready` is absent, `/api/v1/chain` is present.

## Docker

`Docker/docker-compose.yml` gains a backend healthcheck hitting `/ready` with busybox wget, which exits non-zero on the 503, plus a 20s `start_period` for the Redis, MongoDB and schema work startup does. `docker-compose.dev.yml` inherits it by merge; verified with `docker compose -f ... -f ... config`. Since the server only binds after those connections succeed, a 200 on `/ready` implies a v2 create can be served.

## Tests

Nine new hermetic tests plus two `#[ignore]`d live ones. Aggregator: ordering, a named failure beside healthy dependencies, recovery with no restart, a hung dependency timing out without holding up the others (on a paused clock), redaction, bounding, and the empty case. Handlers: `/health` 200 while a dependency is down, the 503 body naming it, and recovery flipping the status code. The shipped `WarehouseProbe` is covered against both an unreachable and a local warehouse; the Redis and MongoDB probes have live tests that CI's integration job runs.

## Gate

`make pre-push` clean, MongoDB up: 836 + 16 + 3 tests pass, 24 ignored; clippy with `-D warnings`, `fmt --check`, `cargo doc` with zero warnings and `cargo build --release` all clean; `README.md` regenerated via `make readme`.