### PR TITLE
Emit a per-contract spread instead of one constant across the chain (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,59 @@ snapshot per cursor position.
 | POST   | /api/v2/simulations/{id}/step    | Serve the current snapshot, then advance once |
 | DELETE | /api/v2/simulations/{id}         | Delete it and evict its cached state |
 
+#### The bid-ask spread is per contract
+
+A v2 chain used to be quoted with one spread applied to every contract,
+which is not what an option market looks like: a dear in-the-money call and
+a five-cent far wing do not carry the same absolute bid-ask, and the wing's
+spread is a far larger fraction of its price. A consumer valuing a position
+at the touch takes its whole cost of trading from that number.
+
+The spread is now a small parametric model, evaluated per contract:
+
+```
+spread(contract) = max(
+    spread_tick,
+    spread
+      + spread_proportional       * mid
+      + spread_moneyness_widening * |ln(strike / underlying)|
+      + spread_tenor_widening     * sqrt(days_to_expiration / 365)
+)
+```
+
+Every coefficient is an optional create-request field, echoed back in the
+simulation response so a run can be replayed, and every widening term
+defaults to zero. A request that carries only the legacy `spread` therefore
+quotes exactly as it did: the scalar IS the floor term, and the arithmetic
+for every quote is unchanged.
+
+**A quote is never withdrawn.** Upstream's `apply_spread` sets bid, ask AND
+mid to `None` when `mid <= spread`, so the cheap wings vanished from the
+chain exactly as they decayed — the moment a consumer most wants to know
+what closing them costs. A contract that has a mid now always has a
+two-sided quote, with the bid floored at `spread_tick` or at the mid,
+whichever is lower: a contract worth less than a tick is quoted `0.00/0.01`
+rather than being marked up to a penny it is not worth.
+
+**Two things a legacy request sees change**, both consequences of that fix:
+
+- **The chain is longer.** Upstream stopped extending the strike ladder at
+  the first pair of strikes with no price, and that condition WAS the
+  erasure. With nothing erased the ladder runs to the full
+  `2 * chain_size + 1`: at spot 5000, 30 days and `chain_size = 30`, 45
+  strikes become 61. Response payloads, export rows and warehouse rows grow
+  with it, inside the same configured caps.
+- **A spread below the tick is raised to it.** `spread: 0.005` now widens by
+  half a cent each way rather than a quarter. At or above the tick — every
+  request that took the documented default — the quotes are unchanged.
+
+Persisted snapshots are therefore a new tape: `CURRENT_SNAPSHOT_GENERATION`
+is `3`, so rows written by an older binary stay addressable under generation
+`2` and are never mixed with these.
+
+`/api/v1/chain` is untouched, model and all: it is frozen, and its chains
+come from a different upstream path.
+
 **Serve-then-advance**, as in v1: a simulation with `steps = N` serves
 indices `0..N-1` over `N` calls to `/step`, and any call after that returns
 `410 Gone`. `expected_step` on the advance is a precondition — a mismatch is

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -474,7 +474,9 @@ Invariants a reviewer can check:
 > **time frame**, **timezone**, **calendar version**, **IANA tzdb version**,
 > **normalised schedules**, and market and chain parameters (`symbol`, `steps`,
 > `initial_price`, `volatility`, `risk_free_rate`, `dividend_yield`, `method`,
-> `chain_size`, `strike_interval`, `skew_slope`, `smile_curve`, `spread`).
+> `chain_size`, `strike_interval`, `skew_slope`, `smile_curve`, and the spread
+> model: `spread`, `spread_proportional`, `spread_moneyness_widening`,
+> `spread_tenor_widening`, `spread_tick`).
 
 That list is exhaustive and is meant to be checkable. All of it is resolved once
 at creation, persisted, and echoed in the creation and session responses — so a
@@ -1037,6 +1039,10 @@ last-Friday monthlies, all expiring at 17:00 America/New_York.
   "skew_slope": -0.2,
   "smile_curve": 0.4,
   "spread": 0.02,
+  "spread_proportional": 0.01,
+  "spread_moneyness_widening": 0.5,
+  "spread_tenor_widening": 0.1,
+  "spread_tick": 0.01,
   "seed": 42
 }
 ```
@@ -1075,7 +1081,11 @@ last-Friday monthlies, all expiring at 17:00 America/New_York.
     "strike_interval": 25.0,
     "skew_slope": -0.2,
     "smile_curve": 0.4,
-    "spread": 0.02
+    "spread": 0.02,
+    "spread_proportional": 0.01,
+    "spread_moneyness_widening": 0.5,
+    "spread_tenor_widening": 0.1,
+    "spread_tick": 0.01
   }
 }
 ```

--- a/doc/requests/create_simulation_v2.json
+++ b/doc/requests/create_simulation_v2.json
@@ -42,5 +42,9 @@
   "skew_slope": -0.2,
   "smile_curve": 0.4,
   "spread": 0.02,
+  "spread_proportional": 0.01,
+  "spread_moneyness_widening": 0.5,
+  "spread_tenor_widening": 0.1,
+  "spread_tick": 0.01,
   "seed": 42
 }

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -915,6 +915,79 @@ mod tests {
         );
     }
 
+    /// The spread model is accepted over HTTP and echoed back verbatim.
+    ///
+    /// Both halves matter: `CreateSimulationRequest` denies unknown fields, so
+    /// this is what proves the new coefficients are actually part of the wire
+    /// contract, and the echo is what lets a client replay a run.
+    #[actix_web::test]
+    async fn test_the_spread_model_is_accepted_and_echoed() {
+        let app = v2_service!();
+
+        let mut request_body = reference_body();
+        match request_body.as_object_mut() {
+            Some(map) => {
+                map.insert("spread_proportional".to_string(), json!(0.02));
+                map.insert("spread_moneyness_widening".to_string(), json!(0.5));
+                map.insert("spread_tenor_widening".to_string(), json!(0.1));
+                map.insert("spread_tick".to_string(), json!(0.05));
+            }
+            None => panic!("the reference body must be an object"),
+        }
+
+        let request = actix_test::TestRequest::post()
+            .uri("/api/v2/simulations")
+            .set_json(request_body)
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body: Value = actix_test::read_body_json(response).await;
+        let parameters = match body.get("parameters") {
+            Some(parameters) => parameters,
+            None => panic!("the response must echo its parameters: {body}"),
+        };
+        for (field, expected) in [
+            ("spread", json!(0.02)),
+            ("spread_proportional", json!(0.02)),
+            ("spread_moneyness_widening", json!(0.5)),
+            ("spread_tenor_widening", json!(0.1)),
+            ("spread_tick", json!(0.05)),
+        ] {
+            assert_eq!(
+                parameters.get(field),
+                Some(&expected),
+                "the echo must carry {field}: {parameters}"
+            );
+        }
+    }
+
+    /// A spread coefficient outside its range is a typed 400 naming the field.
+    #[actix_web::test]
+    async fn test_an_out_of_range_spread_coefficient_is_a_typed_400() {
+        let app = v2_service!();
+
+        let mut request_body = reference_body();
+        match request_body.as_object_mut() {
+            Some(map) => map.insert("spread_proportional".to_string(), json!(-0.01)),
+            None => panic!("the reference body must be an object"),
+        };
+
+        let request = actix_test::TestRequest::post()
+            .uri("/api/v2/simulations")
+            .set_json(request_body)
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(
+            body.get("field"),
+            Some(&json!("spread_proportional")),
+            "the rejection must name the field: {body}"
+        );
+    }
+
     /// The echoed schedules are normalised — ordered by rule id.
     #[actix_web::test]
     async fn test_the_echoed_schedules_are_normalised() {

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -93,9 +93,33 @@ pub struct CreateSimulationRequest {
     /// Curvature of the volatility smile.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smile_curve: Option<f64>,
-    /// Bid-ask spread factor.
+    /// The constant term of the spread model, applied to every contract. On
+    /// its own — which is how every request that predates the model reads — it
+    /// IS the whole model, exactly as before: one absolute bid-ask spread. A
+    /// value below `spread_tick` is raised to it, since a width narrower than
+    /// the smallest quotable increment cannot be quoted. Default: `0.01`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spread: Option<f64>,
+    /// How much of a contract's mid price is added to its spread, so a dearer
+    /// contract costs more to cross in absolute terms and a cheap wing more in
+    /// relative terms. Must not be negative. Default: `0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_proportional: Option<f64>,
+    /// How fast the spread widens away from the money, per unit of
+    /// `|ln(strike / underlying)|`. Logarithmic so a dollar of distance means
+    /// the same at a strike of 20 and of 2000. Must not be negative.
+    /// Default: `0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_moneyness_widening: Option<f64>,
+    /// How fast the spread widens with time to expiry, per `sqrt(years)`. Must
+    /// not be negative. Default: `0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tenor_widening: Option<f64>,
+    /// The smallest quotable increment. Every bid is floored at it rather than
+    /// withdrawn, so a contract that has a mid always has a two-sided quote.
+    /// Must be greater than zero. Default: `0.01`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tick: Option<f64>,
     /// RNG seed. When omitted one is generated and returned as the effective
     /// seed, exactly as in v1.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -134,9 +134,21 @@ pub struct SimulationParametersResponse {
     /// Curvature of the volatility smile.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smile_curve: Option<f64>,
-    /// Bid-ask spread factor.
+    /// The constant term of the spread model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spread: Option<f64>,
+    /// The proportional term of the spread model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_proportional: Option<f64>,
+    /// The moneyness term of the spread model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_moneyness_widening: Option<f64>,
+    /// The tenor term of the spread model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tenor_widening: Option<f64>,
+    /// The tick every quote is rounded and floored to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tick: Option<f64>,
 }
 
 /// A simulation's metadata, with no market data attached.
@@ -338,6 +350,16 @@ impl From<&SessionV2> for SimulationParametersResponse {
             skew_slope: parameters.skew_slope.and_then(|value| value.to_f64()),
             smile_curve: parameters.smile_curve.and_then(|value| value.to_f64()),
             spread: parameters.spread.map(|value| value.to_f64()),
+            spread_proportional: parameters
+                .spread_proportional
+                .and_then(|value| value.to_f64()),
+            spread_moneyness_widening: parameters
+                .spread_moneyness_widening
+                .and_then(|value| value.to_f64()),
+            spread_tenor_widening: parameters
+                .spread_tenor_widening
+                .and_then(|value| value.to_f64()),
+            spread_tick: parameters.spread_tick.map(|value| value.to_f64()),
         }
     }
 }

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -70,9 +70,8 @@
 //! is pinned by a test. ADR 0001 §8 records the contract.
 
 use crate::domain::Walker;
-use crate::domain::simulator::{
-    DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE, DEFAULT_SPREAD,
-};
+use crate::domain::simulator::{DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE};
+use crate::domain::spread::SpreadModel;
 use crate::session::{SimulationMethod, SimulationParametersV2};
 use crate::utils::ChainError;
 use chrono::{DateTime, Utc};
@@ -942,9 +941,7 @@ fn at_step(step: Option<usize>) -> String {
 ///
 /// # Errors
 ///
-/// Returns [`ChainError::Internal`] when the default spread is not a valid
-/// `Positive` — unreachable, it is a compile-time constant — or when upstream
-/// cannot build the chain.
+/// Returns [`ChainError::Internal`] when upstream cannot build the chain.
 pub(crate) fn build_chain(
     parameters: &SimulationParametersV2,
     spot: Positive,
@@ -955,12 +952,22 @@ pub(crate) fn build_chain(
     let chain_size = parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE);
     let skew_slope = parameters.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);
     let smile_curve = parameters.smile_curve.unwrap_or(DEFAULT_SMILE_CURVE);
-    let spread = match parameters.spread {
-        Some(spread) => spread,
-        None => Positive::new_decimal(DEFAULT_SPREAD).map_err(|e| {
-            ChainError::Internal(format!("the default spread is not a valid Positive: {e}"))
-        })?,
-    };
+    // The spread model, not one scalar. Read once per chain: every coefficient
+    // is fixed for a simulation's lifetime, and only the contract varies.
+    let spread_model = SpreadModel::from_parameters(parameters);
+    // Propagated, not defaulted: this now feeds a PRICED quantity (the tenor
+    // term), and silently reading zero days would narrow every spread to its
+    // floor. It is infallible for the `Days` variant every caller passes, and
+    // the `DateTime` variant reads the wall clock, which a served quote must
+    // not depend on.
+    let days_to_expiration = expiration
+        .get_days()
+        .map_err(|e| {
+            ChainError::Internal(format!(
+                "the chain's days to expiration are unavailable: {e}"
+            ))
+        })?
+        .to_dec();
 
     let price_params = OptionDataPriceParams::new(
         Some(Box::new(spot)),
@@ -991,15 +998,25 @@ pub(crate) fn build_chain(
         parameters.strike_interval,
         skew_slope,
         smile_curve,
-        spread,
+        // ZERO, and the widening happens below instead. Upstream's
+        // `apply_spread` sets bid, ask AND mid to `None` when `mid <= spread`
+        // (OptionStratLib#439, fixed upstream but not in the published 0.20
+        // this builds against), so handing it the real spread would erase the
+        // cheap wings before anything here could quote them. With no spread it
+        // leaves each mid alone, which is what the model needs to work from.
+        Positive::ZERO,
         2,
         price_params,
         volatility,
     )
     .with_greek_snapshots(greek_snapshots);
 
-    OptionChain::build_chain(&build_params)
-        .map_err(|e| ChainError::Internal(format!("Failed to build the option chain: {e}")))
+    let mut chain = OptionChain::build_chain(&build_params)
+        .map_err(|e| ChainError::Internal(format!("Failed to build the option chain: {e}")))?;
+
+    spread_model.apply(&mut chain, days_to_expiration);
+
+    Ok(chain)
 }
 
 /// Builds the single option chain that seeds the walk.
@@ -1066,6 +1083,10 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         }
     }
@@ -1404,6 +1425,279 @@ mod tests {
             chain.iter().count() > 0,
             "the lowest volatility above the floor must still quote a strike"
         );
+    }
+
+    // ---- the per-contract spread model (issue #80) ------------------------
+
+    /// Two contracts of one chain carry DIFFERENT absolute spreads.
+    ///
+    /// The property a single scalar cannot express, and the reason the model
+    /// exists: a dear in-the-money call and a five-cent wing do not cost the
+    /// same to cross.
+    #[test]
+    fn test_two_contracts_of_one_chain_carry_different_spreads() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(12);
+        request.spread = Some(0.02);
+        request.spread_proportional = Some(0.02);
+        request.spread_moneyness_widening = Some(0.5);
+        let chain = built_chain(&parameters(request));
+
+        let spreads: Vec<Decimal> = chain
+            .iter()
+            .filter_map(|contract| match (contract.call_bid, contract.call_ask) {
+                (Some(bid), Some(ask)) => Some(ask.to_dec() - bid.to_dec()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(spreads.len() > 2, "the chain must quote several strikes");
+        let first = spreads[0];
+        assert!(
+            spreads.iter().any(|spread| *spread != first),
+            "every contract carries the same spread: {spreads:?}"
+        );
+    }
+
+    /// Contracts cheaper than the spread are quoted, where they used to vanish.
+    ///
+    /// The assertion is on the COUNT, deliberately. "Every contract with a mid
+    /// has a bid" passes on the old code too, because the old code cleared the
+    /// mid along with the quote: the erased contracts were skipped rather than
+    /// caught. What actually moved is how many contracts are quoted at all.
+    #[test]
+    fn test_contracts_cheaper_than_the_spread_are_quoted() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(30);
+        // A spread far above the cheap wings' mid, which is the configuration
+        // that used to erase them.
+        request.spread = Some(5.0);
+        let chain = built_chain(&parameters(request));
+
+        let quoted = chain
+            .iter()
+            .filter(|contract| contract.call_bid.is_some() && contract.call_ask.is_some())
+            .count();
+        // What the old path would have kept: only the contracts worth strictly
+        // more than the whole spread.
+        let above_the_spread = chain
+            .iter()
+            .filter(|contract| {
+                contract
+                    .call_middle
+                    .is_some_and(|mid| mid.to_dec() > dec!(5))
+            })
+            .count();
+
+        assert!(above_the_spread > 0, "the chain must quote dear contracts");
+        assert!(
+            quoted > above_the_spread,
+            "the cheap wings must be quoted too: {quoted} quoted, {above_the_spread} above the spread"
+        );
+
+        for contract in chain.iter() {
+            if contract.call_middle.is_some() {
+                assert!(
+                    contract.call_bid.is_some() && contract.call_ask.is_some(),
+                    "a call with a mid must be quoted: {contract:?}"
+                );
+            }
+            if contract.put_middle.is_some() {
+                assert!(
+                    contract.put_bid.is_some() && contract.put_ask.is_some(),
+                    "a put with a mid must be quoted: {contract:?}"
+                );
+            }
+        }
+    }
+
+    /// A far out-of-the-money wing at one day to expiry is still quoted.
+    ///
+    /// The exact case that broke: at 1 DTE the far wings are worth cents, so a
+    /// two-cent spread erased them. The furthest strike of all can be worth
+    /// less than a tick, and it is quoted `0.00 / 0.01` rather than bid a penny
+    /// it is not worth — marking a worthless wing at the tick is the same bias,
+    /// in the same direction, that the model exists to remove.
+    #[test]
+    fn test_a_far_wing_at_one_day_is_still_quoted() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(40);
+        request.spread = Some(0.02);
+        let parameters = parameters(request);
+        let chain = match build_chain(
+            &parameters,
+            pos_or_panic!(5000.0),
+            pos_or_panic!(0.2),
+            ExpirationDate::Days(pos_or_panic!(1.0)),
+            false,
+        ) {
+            Ok(chain) => chain,
+            Err(error) => panic!("a one-day chain must build: {error}"),
+        };
+
+        // The LAST strike of the chain, not the last one that happens to carry
+        // a mid: picking the latter would select a contract the old code kept
+        // anyway, and the test would pass without the fix.
+        let wing = match chain.iter().last() {
+            Some(contract) => contract,
+            None => panic!("the chain must carry a highest strike"),
+        };
+
+        assert!(
+            wing.call_middle.is_some(),
+            "the furthest strike must still be priced: {wing:?}"
+        );
+        match (wing.call_bid, wing.call_ask, wing.call_middle) {
+            (Some(bid), Some(ask), Some(mid)) => {
+                assert!(
+                    ask >= pos_or_panic!(0.01),
+                    "the wing must be offered at or above the tick, got {ask}"
+                );
+                assert!(bid <= ask, "and the book must not be crossed");
+                assert!(
+                    bid.to_dec() <= mid.to_dec().round_dp(2),
+                    "a wing must not be bid above what it is worth: {bid} for a mid of {mid}"
+                );
+            }
+            other => panic!("the far wing must still be quoted, got {other:?}"),
+        }
+
+        // Every wing still worth a tick IS bid a tick: only sub-tick contracts
+        // quote a zero bid, and they quote it rather than disappearing.
+        for contract in chain.iter() {
+            let (Some(mid), Some(bid)) = (contract.call_middle, contract.call_bid) else {
+                continue;
+            };
+            if mid.to_dec() >= dec!(0.01) {
+                assert!(
+                    bid >= pos_or_panic!(0.01),
+                    "a contract worth {mid} must be bid at least a tick, got {bid}"
+                );
+            }
+        }
+    }
+
+    /// A cheap contract's spread is a LARGER fraction of its price than a dear
+    /// contract's, once the proportional term is on.
+    #[test]
+    fn test_a_cheap_contract_pays_more_in_relative_terms() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(20);
+        request.spread = Some(0.02);
+        request.spread_proportional = Some(0.05);
+        let chain = built_chain(&parameters(request));
+
+        let mut quotes: Vec<(Decimal, Decimal)> = chain
+            .iter()
+            .filter_map(|contract| {
+                match (contract.call_bid, contract.call_ask, contract.call_middle) {
+                    (Some(bid), Some(ask), Some(mid)) if mid.to_dec() > Decimal::ZERO => {
+                        Some((mid.to_dec(), ask.to_dec() - bid.to_dec()))
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+        quotes.sort_by_key(|quote| quote.0);
+        assert!(
+            quotes.len() > 1,
+            "the chain must quote at least two contracts"
+        );
+
+        let (cheap_mid, cheap_spread) = quotes[0];
+        let (dear_mid, dear_spread) = quotes[quotes.len() - 1];
+
+        assert!(
+            dear_spread > cheap_spread,
+            "the dear contract costs more to cross in absolute terms"
+        );
+        assert!(
+            cheap_spread / cheap_mid > dear_spread / dear_mid,
+            "and the cheap one more in relative terms: {cheap_spread}/{cheap_mid} vs {dear_spread}/{dear_mid}"
+        );
+    }
+
+    /// A request carrying only the legacy scalar quotes exactly as it did.
+    ///
+    /// "As it did" means, for every contract upstream would have kept, the
+    /// arithmetic upstream applied: half the spread each way around the mid,
+    /// rounded to two places. The contracts upstream would have ERASED are the
+    /// documented divergence and are asserted separately.
+    #[test]
+    fn test_the_legacy_scalar_reproduces_the_old_quotes() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(20);
+        request.spread = Some(0.02);
+        let chain = built_chain(&parameters(request));
+
+        let spread = dec!(0.02);
+        let half = spread / Decimal::TWO;
+        let mut compared = 0;
+
+        for contract in chain.iter() {
+            let (Some(mid), Some(bid), Some(ask)) =
+                (contract.call_middle, contract.call_bid, contract.call_ask)
+            else {
+                continue;
+            };
+            // Upstream keeps a quote only above the full spread; below it the
+            // service now floors the bid instead of withdrawing.
+            if mid.to_dec() <= spread {
+                continue;
+            }
+
+            assert_eq!(
+                ask.to_dec(),
+                (mid.to_dec() + half).round_dp(2),
+                "the ask must be upstream's, at strike {}",
+                contract.strike_price
+            );
+            assert_eq!(
+                bid.to_dec(),
+                (mid.to_dec() - half).round_dp(2),
+                "the bid must be upstream's, at strike {}",
+                contract.strike_price
+            );
+            compared += 1;
+        }
+
+        assert!(compared > 0, "the chain must contain a comparable quote");
+    }
+
+    /// The same parameters and seed still produce the same quotes.
+    ///
+    /// The model is a pure function of the contract, so it cannot move the
+    /// tape; this pins that it does not move the CHAIN either.
+    #[test]
+    fn test_the_model_is_deterministic() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(10);
+        request.spread_proportional = Some(0.03);
+        request.spread_moneyness_widening = Some(0.4);
+        request.spread_tenor_widening = Some(0.1);
+        let parameters = parameters(request);
+
+        let first = built_chain(&parameters);
+        let second = built_chain(&parameters);
+
+        assert_eq!(
+            first.options, second.options,
+            "two builds of one configuration must quote identically"
+        );
+    }
+
+    /// Builds a chain at the reference spot, volatility and tenor.
+    fn built_chain(parameters: &SimulationParametersV2) -> OptionChain {
+        match build_chain(
+            parameters,
+            pos_or_panic!(5000.0),
+            pos_or_panic!(0.2),
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            false,
+        ) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the chain must build: {error}"),
+        }
     }
 
     fn parameters(request: CreateSimulationRequest) -> SimulationParametersV2 {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod expiry;
 pub(crate) mod factors;
 pub(crate) mod series;
 pub(crate) mod simulator;
+pub(crate) mod spread;
 mod walker;
 
 pub use simulator::Simulator;

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -643,6 +643,10 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         }
     }

--- a/src/domain/simulator.rs
+++ b/src/domain/simulator.rs
@@ -18,7 +18,7 @@ use optionstratlib::{
         steps::{Step, Xstep, Ystep},
     },
 };
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rust_decimal::Decimal;
@@ -42,8 +42,21 @@ pub(crate) const DEFAULT_SKEW_SLOPE: Decimal = dec!(-0.2);
 /// Default curvature of the volatility smile.
 pub(crate) const DEFAULT_SMILE_CURVE: Decimal = dec!(0.4);
 
-/// Default bid-ask spread factor.
+/// Default bid-ask spread factor for v1.
+///
+/// v2 reads its floor term from [`crate::domain::spread::DEFAULT_SPREAD_FLOOR`],
+/// which carries the same value: v1 applies one scalar to a whole chain and v2
+/// evaluates a model per contract, so they no longer share a constant even
+/// though they still agree on what silence means.
 pub(crate) const DEFAULT_SPREAD: Decimal = dec!(0.01);
+
+/// [`DEFAULT_SPREAD`] as a `Positive`, built once.
+///
+/// Converted here rather than at the call site so the fallback exists in one
+/// place and is not a value a hundred times too large: a one-dollar spread
+/// across a whole v1 chain would be far worse than the penny it replaces.
+static DEFAULT_SPREAD_POSITIVE: LazyLock<Positive> =
+    LazyLock::new(|| Positive::new_decimal(DEFAULT_SPREAD).unwrap_or(Positive::ZERO));
 
 /// Default upper bound on the number of random walks held in the simulation cache.
 const DEFAULT_MAX_CACHED_WALKS: usize = 1000;
@@ -473,7 +486,9 @@ impl Simulator {
         let strike_interval = params.strike_interval;
         let skew_slope = params.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);
         let smile_curve = params.smile_curve.unwrap_or(DEFAULT_SMILE_CURVE);
-        let spread = params.spread.unwrap_or(pos_or_panic!(0.01));
+        // The v1 scalar, from the one constant that documents it rather than
+        // a literal repeated at the call site.
+        let spread = params.spread.unwrap_or(*DEFAULT_SPREAD_POSITIVE);
 
         // Create option data price parameters
         let price_params = OptionDataPriceParams::new(
@@ -835,6 +850,10 @@ mod tests {
             skew_slope: Some(-0.2),
             smile_curve: Some(0.5),
             spread: Some(0.01),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(SEED),
         };
         let parameters = match SimulationParametersV2::try_from(request) {

--- a/src/domain/spread.rs
+++ b/src/domain/spread.rs
@@ -1,0 +1,607 @@
+//! What a quote costs to cross, per contract.
+//!
+//! A chain used to be built with ONE spread applied to every contract, which is
+//! not what an option market looks like: a twelve-dollar in-the-money call and
+//! a five-cent far wing do not carry the same absolute bid-ask, and the wing's
+//! spread is a far larger fraction of its price. A consumer valuing a position
+//! at the touch gets its entire cost of trading from this number, so a single
+//! constant makes cheap wings unrealistically cheap to trade and expensive
+//! contracts unrealistically expensive — and it does so in the direction that
+//! flatters defined-risk structures.
+//!
+//! # The model
+//!
+//! Parametric, small, and every coefficient a create-request field:
+//!
+//! ```text
+//! spread(contract) = max(
+//!     tick,
+//!     absolute_floor
+//!       + proportional        * mid
+//!       + moneyness_widening  * |ln(strike / underlying)|
+//!       + tenor_widening      * sqrt(days_to_expiration / 365)
+//! )
+//! ```
+//!
+//! Every widening term defaults to zero, so a request that says nothing about
+//! spreads gets `max(tick, absolute_floor)` on every contract, which is the
+//! single scalar the service applied before. The legacy `spread` field is
+//! exactly the floor term, so it keeps meaning what it meant.
+//!
+//! # A quote is never withdrawn
+//!
+//! Upstream's `OptionData::apply_spread` sets bid, ask AND mid to `None` when
+//! `mid <= spread`, so cheap wings vanish from the chain exactly as they decay
+//! — the moment a consumer most wants to see what closing them costs. That is
+//! tracked upstream (joaquinbejar/OptionStratLib#439) and fixed on their main
+//! branch, but the published 0.20 this crate builds against still erases.
+//!
+//! This module therefore does the widening itself, from a chain built with a
+//! zero spread so nothing is erased before it gets here, and floors the bid at
+//! the tick or at the mid, whichever is lower: a contract that has a mid has a
+//! bid and an ask. For every quote upstream would have kept, the arithmetic is
+//! upstream's, term for term.
+//!
+//! # What a legacy request sees change
+//!
+//! Two things, both consequences of the erasure fix rather than of the model:
+//!
+//! - **The chain is longer.** Upstream stops extending the strike grid at the
+//!   first pair of strikes with no price (`chain.rs`, `some_price_is_none`),
+//!   and that condition was the erasure. With nothing erased the ladder runs to
+//!   the full `2 * chain_size + 1`: at spot 5000, 30 DTE and `chain_size = 30`,
+//!   45 strikes become 61. Response payloads, export rows and warehouse rows
+//!   grow with it, within the same configured caps.
+//! - **A spread below the tick is raised to it.** `spread: 0.005` used to widen
+//!   by a quarter cent each way; it now widens by half a cent. For any spread
+//!   at or above the tick — every request that took the documented default —
+//!   the quotes are unchanged.
+//!
+//! One residual erasure is upstream's and stays: a mid of exactly zero, which
+//! happens when the pricing CDF underflows, is still dropped by
+//! `apply_spread`. Such a contract has no mid either, so nothing is quoted
+//! one-sided; it simply is not in the chain.
+
+use crate::session::SimulationParametersV2;
+use optionstratlib::chains::OptionData;
+use optionstratlib::chains::chain::OptionChain;
+use positive::Positive;
+use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal_macros::dec;
+use std::sync::LazyLock;
+
+/// The spread applied when a request says nothing: one cent.
+///
+/// The same value the service applied before the model existed, so silence
+/// means what it always meant.
+pub(crate) const DEFAULT_SPREAD_FLOOR: Decimal = dec!(0.01);
+
+/// The smallest quotable increment, and the lowest a bid may go.
+///
+/// A penny, matching the two decimal places every quote in this service is
+/// rounded to. A bid below it would not be a price anyone could act on.
+pub(crate) const DEFAULT_TICK: Decimal = dec!(0.01);
+
+/// [`DEFAULT_TICK`] as a `Positive`, built once.
+///
+/// Built here rather than at every call site so the conversion has exactly one
+/// fallback, and so that fallback is not a value 100 times too large: a tick of
+/// one dollar under every bid would be far worse than the penny it replaces.
+static DEFAULT_TICK_POSITIVE: LazyLock<Positive> =
+    LazyLock::new(|| Positive::new_decimal(DEFAULT_TICK).unwrap_or(Positive::ZERO));
+
+/// The widest each coefficient may be set to.
+///
+/// Economic, not arbitrary. A `proportional` of 1 means the spread IS the mid,
+/// which is already a market nobody can trade; the two widening rates reach the
+/// same absurdity long before 10, since `|ln(K/S)|` is about 0.7 at a strike
+/// twice the spot and `sqrt(years)` is 1 at a year. Bounding them also keeps
+/// the arithmetic below `Decimal`'s range for any price a chain can carry.
+pub(crate) const MAX_PROPORTIONAL: f64 = 1.0;
+
+/// The widest the two widening rates may be set to. See [`MAX_PROPORTIONAL`].
+pub(crate) const MAX_WIDENING: f64 = 10.0;
+
+/// The largest quotable increment. A tick above this is not a tick.
+pub(crate) const MAX_TICK: f64 = 10.0;
+
+/// Days in the year used to scale the tenor term.
+const DAYS_PER_YEAR: Decimal = dec!(365);
+
+/// The decimal places quotes are rounded to, matching what upstream's chain
+/// builder is given.
+const QUOTE_DECIMALS: u32 = 2;
+
+/// A parametric bid-ask model, evaluated per contract.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SpreadModel {
+    /// The constant term, and the whole model when the rest are zero.
+    floor: Decimal,
+    /// How much of the mid price is added to the spread.
+    proportional: Decimal,
+    /// How fast the spread widens away from the money, in `|ln(K/S)|`.
+    moneyness_widening: Decimal,
+    /// How fast the spread widens with time to expiry, in `sqrt(years)`.
+    tenor_widening: Decimal,
+    /// The smallest quotable increment, and the floor under every bid.
+    tick: Positive,
+}
+
+impl SpreadModel {
+    /// Reads the model a simulation was created with.
+    ///
+    /// Every term has a documented default, and the defaults reproduce the
+    /// single-scalar behaviour, so this never fails and never needs the caller
+    /// to decide anything.
+    #[must_use]
+    pub(crate) fn from_parameters(parameters: &SimulationParametersV2) -> Self {
+        Self {
+            floor: parameters
+                .spread
+                .map_or(DEFAULT_SPREAD_FLOOR, |spread| spread.to_dec()),
+            proportional: parameters.spread_proportional.unwrap_or(Decimal::ZERO),
+            moneyness_widening: parameters
+                .spread_moneyness_widening
+                .unwrap_or(Decimal::ZERO),
+            tenor_widening: parameters.spread_tenor_widening.unwrap_or(Decimal::ZERO),
+            tick: parameters.spread_tick.unwrap_or(*DEFAULT_TICK_POSITIVE),
+        }
+    }
+
+    /// The spread one contract carries.
+    ///
+    /// `mid`, `strike` and `underlying` are prices; `days_to_expiration` is what
+    /// the snapshot says, so two contracts of the same chain differ only by
+    /// their own moneyness and price.
+    ///
+    /// The moneyness term uses `|ln(K/S)|` rather than `|K - S|` because a
+    /// dollar of distance means something different at a strike of 20 and at a
+    /// strike of 2000. A logarithm that cannot be taken contributes nothing
+    /// rather than failing the chain: a missing widening term is a narrower
+    /// quote, not a broken one.
+    #[must_use]
+    pub(crate) fn spread_for(
+        &self,
+        mid: Positive,
+        strike: Positive,
+        underlying: Positive,
+        days_to_expiration: Decimal,
+    ) -> Positive {
+        // Checked throughout. `Decimal`'s `Mul` and `Add` PANIC on overflow,
+        // and both operands here are client input: a coefficient at its cap
+        // against a mid near `Decimal`'s range would take the request down.
+        // The coefficients are bounded at validation so this is unreachable for
+        // any price a chain can carry, but a panic on the serving path is not
+        // something to leave resting on a bound elsewhere. An unrepresentable
+        // width is not a market, so it degrades to the tick.
+        let Some(mut spread) = self
+            .proportional
+            .checked_mul(mid.to_dec())
+            .and_then(|scaled| self.floor.checked_add(scaled))
+        else {
+            return self.tick;
+        };
+
+        if !self.moneyness_widening.is_zero() {
+            let Some(widened) = self
+                .moneyness_widening
+                .checked_mul(log_moneyness(strike, underlying))
+                .and_then(|term| spread.checked_add(term))
+            else {
+                return self.tick;
+            };
+            spread = widened;
+        }
+
+        if !self.tenor_widening.is_zero() && days_to_expiration > Decimal::ZERO {
+            let years = days_to_expiration / DAYS_PER_YEAR;
+            let Some(widened) = years
+                .sqrt()
+                .and_then(|root| self.tenor_widening.checked_mul(root))
+                .and_then(|term| spread.checked_add(term))
+            else {
+                return self.tick;
+            };
+            spread = widened;
+        }
+
+        Positive::new_decimal(spread)
+            .unwrap_or(self.tick)
+            .max(self.tick)
+    }
+
+    /// Widens every quote in a chain around its mid.
+    ///
+    /// The chain must have been built with a zero spread, so the mids are the
+    /// theoretical prices and nothing has been erased yet. `OptionChain` stores
+    /// its contracts in a `BTreeSet` keyed by strike, and this rewrites values
+    /// rather than keys, so the set is rebuilt in place and its order is
+    /// unchanged.
+    pub(crate) fn apply(&self, chain: &mut OptionChain, days_to_expiration: Decimal) {
+        let underlying = chain.underlying_price;
+
+        // Taken and moved back rather than cloned: a snapshot can carry tens of
+        // thousands of contracts, each holding a boxed option set, and this
+        // rewrites four `Option<Positive>` fields on each.
+        let contracts = std::mem::take(&mut chain.options);
+        chain.options = contracts
+            .into_iter()
+            .map(|mut contract| {
+                self.widen(&mut contract, underlying, days_to_expiration);
+                contract
+            })
+            .collect();
+    }
+
+    /// Widens one contract's two sides.
+    fn widen(&self, contract: &mut OptionData, underlying: Positive, days: Decimal) {
+        let strike = contract.strike_price;
+
+        if let Some(mid) = contract.call_middle {
+            let spread = self.spread_for(mid, strike, underlying, days);
+            let (bid, ask) = self.quote_around(mid, spread);
+            contract.call_bid = Some(bid);
+            contract.call_ask = Some(ask);
+        }
+
+        if let Some(mid) = contract.put_middle {
+            let spread = self.spread_for(mid, strike, underlying, days);
+            let (bid, ask) = self.quote_around(mid, spread);
+            contract.put_bid = Some(bid);
+            contract.put_ask = Some(ask);
+        }
+    }
+
+    /// Places a two-sided quote around a mid.
+    ///
+    /// Half the spread each way, rounded the way upstream rounds, and the quote
+    /// is never withdrawn: a contract with a mid always comes back with a bid
+    /// and an ask.
+    ///
+    /// The bid is floored at the tick OR at the mid, whichever is lower. The
+    /// distinction matters: flooring unconditionally at the tick would let a
+    /// contract worth a third of a cent be sold for a penny, which flatters
+    /// short-wing structures — the exact bias this model exists to remove. A
+    /// contract worth less than a tick is therefore quoted `0.00 / 0.01`:
+    /// present, and worth what it is worth.
+    #[must_use]
+    fn quote_around(&self, mid: Positive, spread: Positive) -> (Positive, Positive) {
+        let half = spread.to_dec() / Decimal::TWO;
+        let mid = mid.to_dec();
+
+        // Checked, for the same reason `spread_for` is: both terms are derived
+        // from client input, and `Add` panics on overflow. An unquotable price
+        // keeps the mid it had rather than taking the request down.
+        let ask = match mid.checked_add(half) {
+            Some(value) => round_quote(value).max(self.tick),
+            None => round_quote(mid).max(self.tick),
+        };
+        let floor = self.tick.min(round_quote(mid));
+        let bid = round_quote((mid - half).max(Decimal::ZERO))
+            .max(floor)
+            .min(ask);
+
+        (bid, ask)
+    }
+}
+
+/// `|ln(strike / underlying)|`, or zero when the ratio cannot be logged.
+///
+/// Checked division: `Positive` admits ZERO, so an underlying of zero is a type
+/// the signature accepts even though upstream refuses to price one. A ratio
+/// that cannot be divided or logged contributes nothing, which is a narrower
+/// quote rather than a failed chain.
+#[must_use]
+fn log_moneyness(strike: Positive, underlying: Positive) -> Decimal {
+    strike
+        .to_dec()
+        .checked_div(underlying.to_dec())
+        .and_then(|ratio| ratio.checked_ln())
+        .map_or(Decimal::ZERO, |value| value.abs())
+}
+
+/// Rounds a price the way every other quote in this service is rounded.
+#[must_use]
+fn round_quote(value: Decimal) -> Positive {
+    Positive::new_decimal(value.round_dp(QUOTE_DECIMALS)).unwrap_or(Positive::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::session::{ExpiryRule, ExpiryRuleKind};
+    use chrono::{TimeZone, Utc};
+    use positive::pos_or_panic;
+
+    /// Effective parameters from a request, so the tests exercise the same
+    /// conversion a client goes through rather than a hand-built struct that
+    /// could hold a combination the request path rejects.
+    fn parameters() -> SimulationParametersV2 {
+        let start_at = match Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        };
+        let rule = match ExpiryRule::new("zero_dte", ExpiryRuleKind::Daily, 1) {
+            Ok(rule) => rule,
+            Err(error) => panic!("the test rule must be valid: {error}"),
+        };
+
+        let request = CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 3,
+            start_at: Some(start_at),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: None,
+            expiration_time: "17:00".to_string(),
+            schedules: vec![rule],
+            initial_price: 100.0,
+            volatility: 0.2,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.0,
+            method: ApiWalkType::Brownian {
+                dt: 1.0 / 252.0,
+                drift: 0.0,
+                volatility: 0.2,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(3),
+            strike_interval: Some(5.0),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
+            seed: Some(42),
+        };
+
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the request must convert: {error}"),
+        }
+    }
+
+    /// A request that says nothing carries the scalar the service always used.
+    #[test]
+    fn test_the_default_model_is_the_old_scalar() {
+        let mut params = parameters();
+        params.spread = None;
+        let model = SpreadModel::from_parameters(&params);
+
+        for (mid, strike) in [
+            (pos_or_panic!(12.0), pos_or_panic!(90.0)),
+            (pos_or_panic!(0.05), pos_or_panic!(150.0)),
+        ] {
+            assert_eq!(
+                model.spread_for(mid, strike, pos_or_panic!(100.0), dec!(30)),
+                pos_or_panic!(0.01),
+                "no widening term is set, so every contract carries the floor"
+            );
+        }
+    }
+
+    /// The legacy scalar is the floor term, and nothing else.
+    #[test]
+    fn test_the_legacy_scalar_is_the_floor() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.25));
+        let model = SpreadModel::from_parameters(&params);
+
+        assert_eq!(
+            model.spread_for(
+                pos_or_panic!(3.0),
+                pos_or_panic!(100.0),
+                pos_or_panic!(100.0),
+                dec!(30)
+            ),
+            pos_or_panic!(0.25)
+        );
+    }
+
+    /// The proportional term makes an expensive contract cost more to cross in
+    /// absolute terms, and a cheap one more in relative terms.
+    ///
+    /// That relative inversion is the property a single scalar cannot express,
+    /// and the whole reason the model exists.
+    #[test]
+    fn test_a_cheap_contract_has_the_wider_relative_spread() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.02));
+        params.spread_proportional = Some(dec!(0.01));
+        let model = SpreadModel::from_parameters(&params);
+
+        let expensive = model.spread_for(
+            pos_or_panic!(12.0),
+            pos_or_panic!(90.0),
+            pos_or_panic!(100.0),
+            dec!(30),
+        );
+        let cheap = model.spread_for(
+            pos_or_panic!(0.05),
+            pos_or_panic!(130.0),
+            pos_or_panic!(100.0),
+            dec!(30),
+        );
+
+        assert!(
+            expensive > cheap,
+            "the dearer contract carries the wider absolute spread: {expensive} vs {cheap}"
+        );
+        assert!(
+            cheap.to_dec() / dec!(0.05) > expensive.to_dec() / dec!(12.0),
+            "and the cheaper one the wider relative spread"
+        );
+    }
+
+    /// Moneyness widens the quote, symmetrically in log space.
+    #[test]
+    fn test_the_moneyness_term_widens_away_from_the_money() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.02));
+        params.spread_moneyness_widening = Some(dec!(0.5));
+        let model = SpreadModel::from_parameters(&params);
+
+        let atm = model.spread_for(
+            pos_or_panic!(5.0),
+            pos_or_panic!(100.0),
+            pos_or_panic!(100.0),
+            dec!(30),
+        );
+        let wing = model.spread_for(
+            pos_or_panic!(5.0),
+            pos_or_panic!(150.0),
+            pos_or_panic!(100.0),
+            dec!(30),
+        );
+        // 100 / 1.5, the mirror of 150 in log space.
+        let mirrored_strike = match Positive::new_decimal(dec!(100) / dec!(1.5)) {
+            Ok(strike) => strike,
+            Err(error) => panic!("the mirrored strike must be positive: {error}"),
+        };
+        let mirrored = model.spread_for(
+            pos_or_panic!(5.0),
+            mirrored_strike,
+            pos_or_panic!(100.0),
+            dec!(30),
+        );
+
+        assert!(
+            wing > atm,
+            "a wing is wider than the money: {wing} vs {atm}"
+        );
+        assert!(
+            (wing.to_dec() - mirrored.to_dec()).abs() < dec!(0.0000001),
+            "the term is symmetric in log space: {wing} vs {mirrored}"
+        );
+    }
+
+    /// Tenor widens the quote, and does so in the square root of time.
+    #[test]
+    fn test_the_tenor_term_widens_with_time_to_expiry() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.02));
+        params.spread_tenor_widening = Some(dec!(0.10));
+        let model = SpreadModel::from_parameters(&params);
+
+        let near = model.spread_for(
+            pos_or_panic!(5.0),
+            pos_or_panic!(100.0),
+            pos_or_panic!(100.0),
+            dec!(1),
+        );
+        let far = model.spread_for(
+            pos_or_panic!(5.0),
+            pos_or_panic!(100.0),
+            pos_or_panic!(100.0),
+            dec!(365),
+        );
+
+        assert!(far > near, "a year is wider than a day: {far} vs {near}");
+        // sqrt(1/365) is about 0.0523, so the near term adds about half a cent
+        // to the floor rather than the ten cents the far one adds.
+        assert!(near < pos_or_panic!(0.03), "the near term is small: {near}");
+        assert_eq!(far, pos_or_panic!(0.12), "a full year adds the coefficient");
+    }
+
+    /// The tick is a floor, not a suggestion.
+    #[test]
+    fn test_the_spread_never_falls_below_the_tick() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.0001));
+        let model = SpreadModel::from_parameters(&params);
+
+        assert_eq!(
+            model.spread_for(
+                pos_or_panic!(0.02),
+                pos_or_panic!(100.0),
+                pos_or_panic!(100.0),
+                dec!(7)
+            ),
+            pos_or_panic!(0.01),
+            "a spread below one tick is not a quotable width"
+        );
+    }
+
+    /// A quote is placed half a spread each way, and rounds like every other.
+    #[test]
+    fn test_a_quote_is_centred_on_the_mid() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.40));
+        let model = SpreadModel::from_parameters(&params);
+
+        let (bid, ask) = model.quote_around(pos_or_panic!(3.00), pos_or_panic!(0.40));
+
+        assert_eq!(bid, pos_or_panic!(2.80));
+        assert_eq!(ask, pos_or_panic!(3.20));
+    }
+
+    /// The cheap wing that used to vanish is still quoted, at the tick.
+    ///
+    /// This is the exact case the old behaviour erased: a mid at or under the
+    /// spread took bid, ask AND mid with it.
+    #[test]
+    fn test_a_wing_cheaper_than_the_spread_is_still_quoted() {
+        let mut params = parameters();
+        params.spread = Some(pos_or_panic!(0.10));
+        let model = SpreadModel::from_parameters(&params);
+
+        let (bid, ask) = model.quote_around(pos_or_panic!(0.03), pos_or_panic!(0.10));
+
+        assert_eq!(bid, pos_or_panic!(0.01), "the bid is floored at the tick");
+        assert_eq!(ask, pos_or_panic!(0.08));
+        assert!(bid <= ask, "and the book is never crossed");
+    }
+
+    /// A mid of zero is quoted `0.00 / 0.01`, not withdrawn and not marked up.
+    ///
+    /// A worthless contract must still appear — that is the erasure fix — but
+    /// it must not acquire a penny of value on the way, which is what a bid
+    /// floored unconditionally at the tick would do.
+    #[test]
+    fn test_a_zero_mid_is_quoted_without_being_marked_up() {
+        let model = SpreadModel::from_parameters(&parameters());
+
+        let (bid, ask) = model.quote_around(Positive::ZERO, pos_or_panic!(0.01));
+
+        assert_eq!(bid, Positive::ZERO, "nothing is worth nothing");
+        assert_eq!(ask, pos_or_panic!(0.01));
+        assert!(bid <= ask);
+    }
+
+    /// A sub-tick mid is never bid above itself.
+    #[test]
+    fn test_a_sub_tick_mid_is_not_bid_above_its_value() {
+        let model = SpreadModel::from_parameters(&parameters());
+
+        let (bid, ask) = model.quote_around(pos_or_panic!(0.003), pos_or_panic!(0.01));
+
+        assert_eq!(bid, Positive::ZERO, "a third of a cent is not worth a cent");
+        assert!(ask >= pos_or_panic!(0.01));
+    }
+
+    /// An absurd coefficient degrades to the tick instead of panicking.
+    ///
+    /// `Decimal` multiplication panics on overflow, and both operands come from
+    /// a client: the coefficient from the request, the mid from the price.
+    #[test]
+    fn test_an_unrepresentable_spread_degrades_to_the_tick() {
+        let mut params = parameters();
+        params.spread_proportional = Some(Decimal::MAX);
+        let model = SpreadModel::from_parameters(&params);
+
+        assert_eq!(
+            model.spread_for(
+                pos_or_panic!(1000.0),
+                pos_or_panic!(100.0),
+                pos_or_panic!(100.0),
+                dec!(30)
+            ),
+            pos_or_panic!(0.01),
+            "an unrepresentable width is not a market"
+        );
+    }
+}

--- a/src/domain/spread.rs
+++ b/src/domain/spread.rs
@@ -194,7 +194,14 @@ impl SpreadModel {
         }
 
         if !self.tenor_widening.is_zero() && days_to_expiration > Decimal::ZERO {
-            let years = days_to_expiration / DAYS_PER_YEAR;
+            // `checked_div`, like every other operator on this path. `Decimal`
+            // division keeps the full precision it can and rounds the result at
+            // 28 significant digits, which is far below the two decimal places
+            // a quote is finally rounded to, so the policy here is simply "do
+            // not lose the term to a panic".
+            let Some(years) = days_to_expiration.checked_div(DAYS_PER_YEAR) else {
+                return self.tick;
+            };
             let Some(widened) = years
                 .sqrt()
                 .and_then(|root| self.tenor_widening.checked_mul(root))
@@ -266,20 +273,30 @@ impl SpreadModel {
     /// present, and worth what it is worth.
     #[must_use]
     fn quote_around(&self, mid: Positive, spread: Positive) -> (Positive, Positive) {
-        let half = spread.to_dec() / Decimal::TWO;
         let mid = mid.to_dec();
 
-        // Checked, for the same reason `spread_for` is: both terms are derived
-        // from client input, and `Add` panics on overflow. An unquotable price
-        // keeps the mid it had rather than taking the request down.
+        // Every operator on this path is checked, and every one of them can be
+        // reached from a request: the spread carries a client coefficient and
+        // the mid carries a client price. Halving is exact for any
+        // representable spread — dividing by two adds one digit, and `Decimal`
+        // carries 28 — so the rounding policy is the one the whole module
+        // already states: nothing is rounded until `round_quote` takes the
+        // quote to two places. A term that cannot be computed degrades to the
+        // untouched mid rather than taking the request down.
+        let half = spread
+            .to_dec()
+            .checked_div(Decimal::TWO)
+            .unwrap_or(Decimal::ZERO);
+
         let ask = match mid.checked_add(half) {
             Some(value) => round_quote(value).max(self.tick),
             None => round_quote(mid).max(self.tick),
         };
         let floor = self.tick.min(round_quote(mid));
-        let bid = round_quote((mid - half).max(Decimal::ZERO))
-            .max(floor)
-            .min(ask);
+        let bid = match mid.checked_sub(half) {
+            Some(value) => round_quote(value.max(Decimal::ZERO)).max(floor).min(ask),
+            None => floor.min(ask),
+        };
 
         (bid, ask)
     }
@@ -581,6 +598,31 @@ mod tests {
 
         assert_eq!(bid, Positive::ZERO, "a third of a cent is not worth a cent");
         assert!(ask >= pos_or_panic!(0.01));
+    }
+
+    /// A quote is placed without a raw operator anywhere on the path.
+    ///
+    /// The mid and the spread both come from a request, and every `Decimal`
+    /// operator panics on overflow, so the extremes have to produce a quote
+    /// rather than a crash.
+    #[test]
+    fn test_an_extreme_quote_does_not_panic() {
+        let model = SpreadModel::from_parameters(&parameters());
+
+        for (mid, spread) in [
+            (Positive::ZERO, pos_or_panic!(0.01)),
+            (pos_or_panic!(0.003), pos_or_panic!(0.01)),
+            (
+                match Positive::new_decimal(Decimal::MAX) {
+                    Ok(mid) => mid,
+                    Err(error) => panic!("the fixture must be positive: {error}"),
+                },
+                pos_or_panic!(0.5),
+            ),
+        ] {
+            let (bid, ask) = model.quote_around(mid, spread);
+            assert!(bid <= ask, "the book must never cross: {bid} / {ask}");
+        }
     }
 
     /// An absurd coefficient degrades to the tick instead of panicking.

--- a/src/infrastructure/clickhouse/snapshots/record.rs
+++ b/src/infrastructure/clickhouse/snapshots/record.rs
@@ -62,7 +62,14 @@ use uuid::Uuid;
 ///   simulation are not, so its rows are a different tape under the same
 ///   coordinates. Generation 1 rows stay in place until their retention expires
 ///   and are simply not read by this build.
-pub const CURRENT_SNAPSHOT_GENERATION: u64 = 2;
+/// - `3` — the bid-ask spread is a per-contract model rather than one scalar
+///   across the chain, and a quote is no longer withdrawn when its mid falls
+///   below the spread. Two things move under the same coordinates: the quotes
+///   themselves, and the STRIKE SET, because upstream stopped extending the
+///   grid at the strike where the wings had been erased and now runs to the
+///   full ladder. A simulation half-filed by an older binary would otherwise
+///   hold two different tapes under one generation.
+pub const CURRENT_SNAPSHOT_GENERATION: u64 = 3;
 
 /// The namespace every deterministic `snapshot_id` is derived under.
 ///
@@ -582,7 +589,9 @@ mod tests {
     fn test_the_current_generation_is_addressable() {
         let simulation = Uuid::from_u128(7);
 
-        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 2);
+        // Pinned so a bump is a deliberate edit here as well as there: the
+        // generation is what keeps two tapes from sharing one coordinate.
+        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 3);
         assert_eq!(
             record(simulation, CURRENT_SNAPSHOT_GENERATION, 0).snapshot_id(),
             snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,59 @@
 //! | POST   | /api/v2/simulations/{id}/step    | Serve the current snapshot, then advance once |
 //! | DELETE | /api/v2/simulations/{id}         | Delete it and evict its cached state |
 //!
+//! ### The bid-ask spread is per contract
+//!
+//! A v2 chain used to be quoted with one spread applied to every contract,
+//! which is not what an option market looks like: a dear in-the-money call and
+//! a five-cent far wing do not carry the same absolute bid-ask, and the wing's
+//! spread is a far larger fraction of its price. A consumer valuing a position
+//! at the touch takes its whole cost of trading from that number.
+//!
+//! The spread is now a small parametric model, evaluated per contract:
+//!
+//! ```text
+//! spread(contract) = max(
+//!     spread_tick,
+//!     spread
+//!       + spread_proportional       * mid
+//!       + spread_moneyness_widening * |ln(strike / underlying)|
+//!       + spread_tenor_widening     * sqrt(days_to_expiration / 365)
+//! )
+//! ```
+//!
+//! Every coefficient is an optional create-request field, echoed back in the
+//! simulation response so a run can be replayed, and every widening term
+//! defaults to zero. A request that carries only the legacy `spread` therefore
+//! quotes exactly as it did: the scalar IS the floor term, and the arithmetic
+//! for every quote is unchanged.
+//!
+//! **A quote is never withdrawn.** Upstream's `apply_spread` sets bid, ask AND
+//! mid to `None` when `mid <= spread`, so the cheap wings vanished from the
+//! chain exactly as they decayed — the moment a consumer most wants to know
+//! what closing them costs. A contract that has a mid now always has a
+//! two-sided quote, with the bid floored at `spread_tick` or at the mid,
+//! whichever is lower: a contract worth less than a tick is quoted `0.00/0.01`
+//! rather than being marked up to a penny it is not worth.
+//!
+//! **Two things a legacy request sees change**, both consequences of that fix:
+//!
+//! - **The chain is longer.** Upstream stopped extending the strike ladder at
+//!   the first pair of strikes with no price, and that condition WAS the
+//!   erasure. With nothing erased the ladder runs to the full
+//!   `2 * chain_size + 1`: at spot 5000, 30 days and `chain_size = 30`, 45
+//!   strikes become 61. Response payloads, export rows and warehouse rows grow
+//!   with it, inside the same configured caps.
+//! - **A spread below the tick is raised to it.** `spread: 0.005` now widens by
+//!   half a cent each way rather than a quarter. At or above the tick — every
+//!   request that took the documented default — the quotes are unchanged.
+//!
+//! Persisted snapshots are therefore a new tape: `CURRENT_SNAPSHOT_GENERATION`
+//! is `3`, so rows written by an older binary stay addressable under generation
+//! `2` and are never mixed with these.
+//!
+//! `/api/v1/chain` is untouched, model and all: it is frozen, and its chains
+//! come from a different upstream path.
+//!
 //! **Serve-then-advance**, as in v1: a simulation with `steps = N` serves
 //! indices `0..N-1` over `N` calls to `/step`, and any call after that returns
 //! `410 Gone`. `expected_step` on the advance is a precondition — a mismatch is

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -842,6 +842,10 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         }
     }

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -22,10 +22,12 @@ use crate::api::rest::limits::{MAX_CHAIN_SIZE, MAX_STEPS, strikes_per_chain};
 use crate::api::rest::models::validate_walk_type;
 use crate::api::rest::requests_v2::CreateSimulationRequest;
 use crate::api::rest::validation::{
-    decimal_field, positive_field, strictly_positive_field, symbol_field, time_frame_field,
+    bounded_decimal_field, decimal_field, positive_field, strictly_positive_field, symbol_field,
+    time_frame_field,
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
+use crate::domain::spread::{MAX_PROPORTIONAL, MAX_TICK, MAX_WIDENING};
 use crate::infrastructure::max_snapshot_contracts;
 use crate::session::model::{SessionState, SimulationMethod};
 use crate::utils::ChainError;
@@ -243,8 +245,26 @@ pub struct SimulationParametersV2 {
     pub skew_slope: Option<Decimal>,
     /// Curvature of the volatility smile.
     pub smile_curve: Option<Decimal>,
-    /// Bid-ask spread factor.
+    /// The constant term of the spread model, and the whole of it when no
+    /// widening coefficient is set. The field predates the model and keeps its
+    /// meaning: one absolute spread, applied to every contract.
     pub spread: Option<Positive>,
+    /// How much of a contract's mid price is added to its spread. Zero when
+    /// absent, which is what makes an untouched request behave as it did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_proportional: Option<Decimal>,
+    /// How fast the spread widens away from the money, per unit of
+    /// `|ln(strike / underlying)|`. Zero when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_moneyness_widening: Option<Decimal>,
+    /// How fast the spread widens with time to expiry, per `sqrt(years)`. Zero
+    /// when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tenor_widening: Option<Decimal>,
+    /// The smallest quotable increment, and the floor under every bid. One cent
+    /// when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spread_tick: Option<Positive>,
     /// The effective RNG seed. Non-optional: a v2 simulation is always
     /// reproducible, so the seed is resolved at conversion and never `None`.
     pub seed: u64,
@@ -285,6 +305,14 @@ struct SimulationParametersV2Wire {
     skew_slope: Option<Decimal>,
     smile_curve: Option<Decimal>,
     spread: Option<Positive>,
+    #[serde(default)]
+    spread_proportional: Option<Decimal>,
+    #[serde(default)]
+    spread_moneyness_widening: Option<Decimal>,
+    #[serde(default)]
+    spread_tenor_widening: Option<Decimal>,
+    #[serde(default)]
+    spread_tick: Option<Positive>,
     seed: u64,
 }
 
@@ -310,6 +338,10 @@ impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
             skew_slope: wire.skew_slope,
             smile_curve: wire.smile_curve,
             spread: wire.spread,
+            spread_proportional: wire.spread_proportional,
+            spread_moneyness_widening: wire.spread_moneyness_widening,
+            spread_tenor_widening: wire.spread_tenor_widening,
+            spread_tick: wire.spread_tick,
             seed: wire.seed,
         };
         parameters.validate()?;
@@ -376,6 +408,27 @@ impl SimulationParametersV2 {
         }
         if let Some(strike_interval) = self.strike_interval {
             reject_zero("strike_interval", strike_interval)?;
+        }
+        // The spread model, for the same reason: a stored `spread_tick` of zero
+        // silently disables the floor that keeps a wing quotable, and a stored
+        // negative coefficient — which `Decimal` admits and the request path
+        // refuses — would narrow a quote away from the money.
+        if let Some(tick) = self.spread_tick {
+            reject_zero("spread_tick", tick)?;
+        }
+        for (field, value) in [
+            ("spread_proportional", self.spread_proportional),
+            ("spread_moneyness_widening", self.spread_moneyness_widening),
+            ("spread_tenor_widening", self.spread_tenor_widening),
+        ] {
+            if let Some(value) = value
+                && value < Decimal::ZERO
+            {
+                return Err(ChainError::Validation {
+                    field: field.to_string(),
+                    reason: format!("must not be negative, got {value}"),
+                });
+            }
         }
         validate_walk_type(&self.method)?;
 
@@ -626,6 +679,48 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
             spread: request
                 .spread
                 .map(|value| positive_field("spread", value))
+                .transpose()?,
+            // The widening coefficients are rates, not prices: zero is the
+            // documented default and a negative one would NARROW a quote away
+            // from the money, which is not a market anyone trades.
+            // Bounded above as well as below. The caps are economic — a
+            // proportional term of 1 means the spread IS the mid — and they
+            // also keep the model's arithmetic inside `Decimal`'s range for any
+            // price a chain can carry, which matters because `Decimal`
+            // multiplication panics on overflow.
+            spread_proportional: request
+                .spread_proportional
+                .map(|value| {
+                    bounded_decimal_field("spread_proportional", value, 0.0, MAX_PROPORTIONAL)
+                })
+                .transpose()?,
+            spread_moneyness_widening: request
+                .spread_moneyness_widening
+                .map(|value| {
+                    bounded_decimal_field("spread_moneyness_widening", value, 0.0, MAX_WIDENING)
+                })
+                .transpose()?,
+            spread_tenor_widening: request
+                .spread_tenor_widening
+                .map(|value| {
+                    bounded_decimal_field("spread_tenor_widening", value, 0.0, MAX_WIDENING)
+                })
+                .transpose()?,
+            // Strictly positive: a tick of zero is not an increment, and it is
+            // the floor every bid is held above. Bounded above for the same
+            // reason a tick of a thousand dollars is not a tick.
+            spread_tick: request
+                .spread_tick
+                .map(|value| {
+                    let tick = strictly_positive_field("spread_tick", value)?;
+                    if value > MAX_TICK {
+                        return Err(ChainError::Validation {
+                            field: "spread_tick".to_string(),
+                            reason: format!("must not exceed {MAX_TICK}, got {value}"),
+                        });
+                    }
+                    Ok(tick)
+                })
                 .transpose()?,
             seed: request.seed.unwrap_or_else(|| rand::rng().random()),
         };
@@ -948,6 +1043,10 @@ mod tests {
             skew_slope: Some(-0.2),
             smile_curve: Some(0.4),
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         }
     }
@@ -1303,6 +1402,138 @@ mod tests {
         match serde_json::from_str::<SimulationParametersV2>(&json) {
             Ok(round_tripped) => assert_eq!(round_tripped, parameters),
             Err(error) => panic!("must deserialize: {error}"),
+        }
+    }
+
+    /// A simulation created WITH a spread model round-trips through the store.
+    ///
+    /// The outer fields skip serializing when absent and the wire struct denies
+    /// unknown ones, so a field present on one and missing from the other would
+    /// produce a document that writes fine and can never be read back. With the
+    /// reference request every coefficient is `None`, which is exactly the case
+    /// that would not catch it.
+    #[test]
+    fn test_stored_parameters_keep_the_spread_model() {
+        let mut request = reference_request();
+        request.spread = Some(0.03);
+        request.spread_proportional = Some(0.02);
+        request.spread_moneyness_widening = Some(0.5);
+        request.spread_tenor_widening = Some(0.1);
+        request.spread_tick = Some(0.05);
+        let parameters = parameters(request);
+
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SimulationParametersV2>(&json) {
+            Ok(loaded) => {
+                assert_eq!(loaded, parameters);
+                assert_eq!(loaded.spread_proportional, Some(dec!(0.02)));
+                assert_eq!(loaded.spread_tick, Some(pos_or_panic!(0.05)));
+            }
+            Err(error) => panic!("a simulation with a spread model must reload: {error}"),
+        }
+    }
+
+    /// A stored document with an impossible spread model is refused on load.
+    ///
+    /// Redis is an outer layer: a hand-edited `spread_tick` of zero would
+    /// silently disable the floor that keeps a wing quotable.
+    #[test]
+    fn test_stored_parameters_reject_an_impossible_spread_model() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                map.insert("spread_tick".to_string(), serde_json::json!("0"));
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => panic!("a zero tick must be refused, got {loaded:?}"),
+            Err(error) => assert!(
+                error.to_string().contains("spread_tick"),
+                "the failure must name the field: {error}"
+            ),
+        }
+    }
+
+    /// A document written before the spread model still loads.
+    ///
+    /// The four coefficients are `#[serde(default)]`, so a simulation stored by
+    /// an older binary keeps deserializing and reads as the single scalar it
+    /// was created with. Losing that would strand every live simulation on a
+    /// deploy.
+    #[test]
+    fn test_stored_parameters_without_the_spread_model_still_load() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                for field in [
+                    "spread_proportional",
+                    "spread_moneyness_widening",
+                    "spread_tenor_widening",
+                    "spread_tick",
+                ] {
+                    map.remove(field);
+                }
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => {
+                assert_eq!(loaded.spread, parameters.spread, "the scalar survives");
+                assert_eq!(loaded.spread_proportional, None);
+                assert_eq!(loaded.spread_moneyness_widening, None);
+                assert_eq!(loaded.spread_tenor_widening, None);
+                assert_eq!(loaded.spread_tick, None);
+            }
+            Err(error) => panic!("an older document must still load: {error}"),
+        }
+    }
+
+    /// The spread coefficients are bounded at the boundary, both ways.
+    ///
+    /// A negative widening term would NARROW a quote away from the money, a
+    /// tick of zero is not an increment, and an unbounded coefficient would
+    /// reach `Decimal`'s range against a large mid.
+    #[test]
+    fn test_an_out_of_range_spread_coefficient_is_refused() {
+        for (field, mutate) in [
+            (
+                "spread_proportional",
+                (|request: &mut CreateSimulationRequest| request.spread_proportional = Some(-0.01))
+                    as fn(&mut CreateSimulationRequest),
+            ),
+            ("spread_moneyness_widening", |request| {
+                request.spread_moneyness_widening = Some(-0.5)
+            }),
+            ("spread_tenor_widening", |request| {
+                request.spread_tenor_widening = Some(-0.2)
+            }),
+            ("spread_tick", |request| request.spread_tick = Some(0.0)),
+            ("spread_proportional", |request| {
+                request.spread_proportional = Some(MAX_PROPORTIONAL + 1.0)
+            }),
+            ("spread_moneyness_widening", |request| {
+                request.spread_moneyness_widening = Some(MAX_WIDENING + 1.0)
+            }),
+            ("spread_tick", |request| {
+                request.spread_tick = Some(MAX_TICK + 1.0)
+            }),
+        ] {
+            let mut request = reference_request();
+            mutate(&mut request);
+
+            match SimulationParametersV2::try_from(request) {
+                Ok(parameters) => panic!("{field} must be refused, got {parameters:?}"),
+                Err(ChainError::Validation { field: named, .. }) => assert_eq!(named, field),
+                Err(error) => panic!("expected a validation failure for {field}, got {error:?}"),
+            }
         }
     }
 

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -147,6 +147,30 @@ fn reject_zero(field: &str, value: Positive) -> Result<(), ChainError> {
     Ok(())
 }
 
+/// Rejects a spread coefficient above the cap the request path applies.
+///
+/// The cap is declared as an `f64` beside the model, so it is converted here
+/// rather than duplicated as a `Decimal`: one definition, and a conversion that
+/// cannot silently disagree with it.
+fn reject_above_cap(field: &str, value: Decimal, maximum: f64) -> Result<(), ChainError> {
+    let Ok(maximum) = Decimal::try_from(maximum) else {
+        // Unreachable: every cap is a small literal. A cap that cannot be
+        // represented is not a bound anything can be checked against, so the
+        // value is refused rather than admitted unchecked.
+        return Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: "the configured maximum is not representable".to_string(),
+        });
+    };
+    if value > maximum {
+        return Err(ChainError::Validation {
+            field: field.to_string(),
+            reason: format!("must not exceed {maximum}, got {value}"),
+        });
+    }
+    Ok(())
+}
+
 /// Validates an explicitly-supplied step interval.
 fn validate_step_interval_seconds(seconds: u64) -> Result<u64, ChainError> {
     if !(MIN_STEP_INTERVAL_SECONDS..=MAX_STEP_INTERVAL_SECONDS).contains(&seconds) {
@@ -409,26 +433,44 @@ impl SimulationParametersV2 {
         if let Some(strike_interval) = self.strike_interval {
             reject_zero("strike_interval", strike_interval)?;
         }
-        // The spread model, for the same reason: a stored `spread_tick` of zero
-        // silently disables the floor that keeps a wing quotable, and a stored
-        // negative coefficient — which `Decimal` admits and the request path
-        // refuses — would narrow a quote away from the money.
+        // The spread model, BOTH bounds, exactly as the request path applies
+        // them. A stored `spread_tick` of zero silently disables the floor that
+        // keeps a wing quotable; a stored negative coefficient — which
+        // `Decimal` admits — would narrow a quote away from the money; and a
+        // stored coefficient above its cap would price a chain the REST
+        // boundary refuses to create. Redis is an outer layer, so a document
+        // that never passed through a request must clear the same bar.
         if let Some(tick) = self.spread_tick {
             reject_zero("spread_tick", tick)?;
+            reject_above_cap("spread_tick", tick.to_dec(), MAX_TICK)?;
         }
-        for (field, value) in [
-            ("spread_proportional", self.spread_proportional),
-            ("spread_moneyness_widening", self.spread_moneyness_widening),
-            ("spread_tenor_widening", self.spread_tenor_widening),
+        for (field, value, maximum) in [
+            (
+                "spread_proportional",
+                self.spread_proportional,
+                MAX_PROPORTIONAL,
+            ),
+            (
+                "spread_moneyness_widening",
+                self.spread_moneyness_widening,
+                MAX_WIDENING,
+            ),
+            (
+                "spread_tenor_widening",
+                self.spread_tenor_widening,
+                MAX_WIDENING,
+            ),
         ] {
-            if let Some(value) = value
-                && value < Decimal::ZERO
-            {
+            let Some(value) = value else {
+                continue;
+            };
+            if value < Decimal::ZERO {
                 return Err(ChainError::Validation {
                     field: field.to_string(),
                     reason: format!("must not be negative, got {value}"),
                 });
             }
+            reject_above_cap(field, value, maximum)?;
         }
         validate_walk_type(&self.method)?;
 
@@ -1457,6 +1499,61 @@ mod tests {
                 error.to_string().contains("spread_tick"),
                 "the failure must name the field: {error}"
             ),
+        }
+    }
+
+    /// A stored coefficient above its cap is refused on load.
+    ///
+    /// Redis is an outer layer: a document that never passed through a request
+    /// must clear the same bar, or a hand-edited one prices a chain the REST
+    /// boundary would refuse to create.
+    #[test]
+    fn test_stored_parameters_reject_a_coefficient_above_its_cap() {
+        let parameters = parameters(reference_request());
+
+        for (field, over_cap) in [
+            ("spread_proportional", MAX_PROPORTIONAL + 1.0),
+            ("spread_moneyness_widening", MAX_WIDENING + 1.0),
+            ("spread_tenor_widening", MAX_WIDENING + 1.0),
+            ("spread_tick", MAX_TICK + 1.0),
+        ] {
+            let json = match serde_json::to_value(&parameters) {
+                Ok(serde_json::Value::Object(mut map)) => {
+                    map.insert(field.to_string(), serde_json::json!(over_cap.to_string()));
+                    serde_json::Value::Object(map)
+                }
+                other => panic!("the parameters must serialize to an object, got {other:?}"),
+            };
+
+            match serde_json::from_value::<SimulationParametersV2>(json) {
+                Ok(loaded) => panic!("{field} above its cap must be refused, got {loaded:?}"),
+                Err(error) => assert!(
+                    error.to_string().contains(field),
+                    "the failure must name {field}: {error}"
+                ),
+            }
+        }
+    }
+
+    /// A coefficient exactly at its cap still loads.
+    ///
+    /// The bound is inclusive on both paths, so the stored check cannot be
+    /// stricter than the request that produced the document.
+    #[test]
+    fn test_stored_parameters_accept_a_coefficient_at_its_cap() {
+        let mut request = reference_request();
+        request.spread_proportional = Some(MAX_PROPORTIONAL);
+        request.spread_moneyness_widening = Some(MAX_WIDENING);
+        request.spread_tick = Some(MAX_TICK);
+        let parameters = parameters(request);
+
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SimulationParametersV2>(&json) {
+            Ok(loaded) => assert_eq!(loaded, parameters),
+            Err(error) => panic!("a document at the cap must load: {error}"),
         }
     }
 

--- a/src/session/snapshot_record.rs
+++ b/src/session/snapshot_record.rs
@@ -158,6 +158,10 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         };
 

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -214,6 +214,10 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(42),
         }
     }

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -549,6 +549,10 @@ mod live_tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
             seed: Some(seed),
         };
 


### PR DESCRIPTION
Closes #80

## Stack

- **Base branch:** `stack/4-84-health-ready`
- **Stacked on:** #92
- **Blocks:** #94
- **Stack:** #88 (#83) → #89 (#81) → #90 (#82) → #92 (#84) → **this** → #78

The diff against `main` is cumulative until the lower PRs merge; read it against the base branch.

## The model

```
spread(contract) = max(
    spread_tick,
    spread
      + spread_proportional       * mid
      + spread_moneyness_widening * |ln(strike / underlying)|
      + spread_tenor_widening     * sqrt(days_to_expiration / 365)
)
```

Every coefficient is an optional v2 create-request field with a documented default of zero, echoed back in the simulation response so a run can be replayed. The legacy `spread` is the floor term, so a request that carries only it means what it always meant. The moneyness term is logarithmic because a dollar of distance means something different at a strike of 20 and at a strike of 2000.

Coefficients are bounded at the boundary, not merely non-negative: a `proportional` of 1 already means the spread IS the mid, and unbounded input reaches `Decimal`'s range against a large mid, where multiplication panics. The model's own arithmetic is checked as well, so an unrepresentable width degrades to the tick instead of taking a request down.

## A quote is never withdrawn

Upstream's `apply_spread` sets bid, ask AND mid to `None` when `mid <= spread` (joaquinbejar/OptionStratLib#439, fixed upstream but **not** in the published 0.20 this builds against; verified in the vendored registry source). Cheap wings vanished exactly as they decayed, which is when a consumer most wants to know what closing them costs.

The chain is therefore built with a zero spread, so nothing is erased before the model runs, and the model widens each quote itself. The bid is floored at the tick **or at the mid, whichever is lower**: a contract worth a third of a cent is quoted `0.00 / 0.01` rather than bid a penny it is not worth. Marking worthless wings at a penny would flatter short-wing structures, which is the same bias, in the same direction, that this issue exists to remove. This is a deliberate deviation from the issue's literal wording ("a bid at or above the tick"): every contract worth at least one tick IS bid at least one tick, and a test asserts it.

## Two things a legacy request sees change

Both are consequences of the erasure fix rather than of the model:

1. **The chain is longer.** Upstream stops extending the strike ladder at the first pair of strikes with no price, and that condition WAS the erasure. With nothing erased the ladder runs to the full `2 * chain_size + 1`. Measured at spot 5000, vol 0.2: 30 DTE with `chain_size = 30` goes from 45 strikes to 61; 1 DTE with `chain_size = 40` from 65 to 81. Response payloads, export rows and warehouse rows grow with it, inside the same configured caps, since `validate_snapshot_work` already bounds on the theoretical grid.
2. **A spread below the tick is raised to it.** `spread: 0.005` now widens by half a cent each way rather than a quarter. At or above the tick, which is every request that took the documented default, quotes are unchanged term for term.

The issue's "byte-identical for a legacy scalar" criterion therefore holds for the quotes but not for the strike set, and that is stated in the crate docs, the module docs and here rather than glossed.

## Snapshot generation → 3

The same `(simulation, generation, step)` coordinate now produces different values and a different strike set, so `CURRENT_SNAPSHOT_GENERATION` goes to `3`. Rows an older binary filed stay addressable under `2` and are never half-overwritten by a replay that no longer agrees with them.

## Two scope decisions

**No new export columns and no per-contract `spread` field.** The issue asks for "the per-contract spread, **or** the bid and ask it produced". Both surfaces already carry bid and ask, and the spread is exactly `ask - bid`, recoverable losslessly. Adding a column would also change the export header that #78 is about to extend, and break the property that each greek level's header is a prefix of the next.

**v1 is untouched.** `/api/v1/chain` is frozen on rendered values, not only shapes (ADR §12.1), so changing its spread model would be a violation rather than merely out of scope. Its chains also come from upstream's `generator_optionchain`, not from this path.

## Tests

Nine model-level tests (defaults reproduce the old scalar, the legacy scalar is the floor, each widening term behaves, the tick floors, a sub-tick mid is not bid above itself, an absurd coefficient degrades rather than panicking) and six chain-level ones. The two erasure tests assert on the **count** of quoted contracts against the count worth more than the whole spread, because "every contract with a mid has a bid" passes on the old code too: the old code cleared the mid alongside the quote.

Also covered: the legacy-scalar quotes are upstream's arithmetic term for term, the model is deterministic across two builds, a stored simulation round-trips **with** the model set, a stored document without it still loads, a stored zero tick is refused on load, and the HTTP surface accepts and echoes the four coefficients and rejects an out-of-range one as a typed 400.

Both required reviewers ran over this diff: `reproducibility-reviewer` (walk path untouched, model pure, `BTreeSet` rebuild order-preserving, old documents load) and `architect`.

## Gate

`make pre-push` clean, MongoDB up: 859 + 16 + 3 tests pass, 24 ignored; clippy with `-D warnings`, `fmt --check`, `cargo doc` with zero warnings and `cargo build --release` all clean; `README.md` regenerated via `make readme`. ADR 0001 §8, §14.1, §14.2 and `doc/requests/create_simulation_v2.json` updated, since the coefficients are replay inputs and §8 says its list is exhaustive.