### PR TITLE
Serve the export tape in binary: Arrow IPC and a packed columnar format (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,20 @@ LOGLEVEL=INFO
 
 
 # ---------------------------------------------------------------------------
+# Binary exports
+# ---------------------------------------------------------------------------
+
+# Rows per block in the `arrow` and `packed` export encodings. Both are
+# columnar, so a column cannot be written until its last row is known: rows are
+# buffered a block at a time, and this is what an export's memory is a function
+# of rather than the number of steps. Wider blocks amortise the per-block
+# overhead; narrower ones lower the memory floor. An invalid value warns and
+# falls back.
+# Default: 4096
+# OCS_EXPORT_BLOCK_ROWS=4096
+
+
+# ---------------------------------------------------------------------------
 # Request caps (v1 and v2)
 # ---------------------------------------------------------------------------
 # These bound what a single request may ask for, so a pathological one cannot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - run: cargo test --workspace
         env:
           LOGLEVEL: WARN
+      # The optional `arrow` export encoding. A separate step, so a failure says
+      # which build broke: the default one ships without the feature, and its
+      # cross-format equality tests only exist when the feature is on.
+      - run: cargo test --workspace --features arrow-export
+        env:
+          LOGLEVEL: WARN
 
   integration_live_services:
     name: Integration (live services)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ homepage = "https://github.com/joaquinbejar/OptionChain-Simulator"
 keywords = ["finance", "options", "trading"]
 categories = ["finance", "data-structures"]
 
+[features]
+# The Arrow IPC export encoding. Off by default; see `arrow` in
+# [workspace.dependencies]. `cargo test --all-features` covers it, and CI's lint
+# job builds with it.
+arrow-export = ["dep:arrow"]
+
 [dependencies]
+arrow = { workspace = true, optional = true }
 optionstratlib = { workspace = true }
 positive = { workspace = true }
 tracing = { workspace = true }
@@ -90,3 +97,9 @@ mongodb = "3.8"
 mockall = "0.15"
 tempfile = "3.27"
 once_cell = "1.21"
+# Apache Arrow, for the `arrow` export encoding (issue #78). OPTIONAL and off by
+# default: it is a large tree, and a deployment that never exports — or a
+# crates.io consumer using this as a library — must not pay for it.
+# `default-features = false` and the version match IronCondor, which consumes
+# the stream and writes Parquet.
+arrow = { version = "59.2", default-features = false, features = ["ipc"] }

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ deliberately different failure behaviour:
 
 - **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
   `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CONCURRENT_PRICING_JOBS`,
-  `OCS_MAX_CACHED_WALKS` — warn and fall back
+  `OCS_MAX_CACHED_WALKS`, `OCS_EXPORT_BLOCK_ROWS` — warn and fall back
   to their defaults when set to something invalid. A bad value there
   degrades one request.
 - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
@@ -435,7 +435,7 @@ has walked, every step is replayed. Either source renders the same bytes.
 | Parameter | Values |
 |-----------|--------|
 | `dataset` | `underlying` \| `volatility` \| `option_chains` |
-| `format`  | `json` \| `csv` |
+| `format`  | `json` \| `csv` \| `arrow` \| `packed` |
 | `from_step`, `to_step` | inclusive bounds; default to the whole tape |
 | `greeks` | `none` (default) \| `first` \| `all` — `option_chains` only |
 
@@ -471,6 +471,77 @@ Measured on a 5 996-row export, release build:
 `first` and `all` cost the same to compute — upstream builds the snapshot
 whole and the level only decides what is written — so the step from `first`
 to `all` is paid in bytes, not in time.
+
+#### The binary encodings
+
+`json` and `csv` are text, so every consumer pays a parse, and for the two
+that matter that parse IS the bottleneck: a browser materialising a whole
+tape spends hundreds of milliseconds in `JSON.parse` and allocates an object
+per row, and a Rust consumer writing Parquet re-parses text this service
+already held in typed form.
+
+- **`arrow`** — an Arrow IPC **stream**, one record batch per block.
+  `Content-Type: application/vnd.apache.arrow.stream`, extension `arrow`.
+  Available only when the service is built with the **`arrow-export`**
+  feature, which is off by default because the `arrow` crate is a large tree
+  and a deployment that never exports should not carry it. Asking for
+  `format=arrow` without it is a typed `400` naming the format, never a 500
+  and never a silent fallback.
+- **`packed`** — a dependency-free columnar block format for the browser.
+  `Content-Type: application/octet-stream`, extension `ocsp`.
+
+Both carry the **same column names in the same order as the CSV header**, so
+a reader moves between encodings without a mapping table, and both are
+`f64` for every numeric column — exactly what `json` and `csv` render.
+Binary is a faster route to the same numbers, NOT a route to the underlying
+`Decimal(38, 28)` precision.
+
+**Both stream, in blocks.** A columnar encoding cannot emit a column until
+its last row is known, so rows are buffered `OCS_EXPORT_BLOCK_ROWS` at a
+time (default 4096) and written a block at a time. An export's memory is
+therefore a function of the block width and not of the number of steps.
+
+The `packed` layout, little-endian throughout:
+
+```
+file        := header block*
+header      := "OCSP" u32:version u32:block_rows
+               u32:dictionary_count dictionary_entry*
+               u32:column_count column_desc*
+               pad to 8
+dict_entry  := u32:len utf8:value             (the symbol, then the rule ids)
+column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
+block       := u32:row_count pad to 8 column_payload*
+payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+```
+
+Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
+the epoch, `3` = an index into the header dictionary, `4` = a **label
+bitmask**, one bit per dictionary entry. Every payload starts on an 8-byte
+boundary, which is the whole point: it is what lets a browser do
+`new Float64Array(buffer, offset, count)` with no copy, and an unaligned
+offset would make that constructor throw. Validity bitmaps follow Arrow's
+convention — LSB-first, `1` = valid — so one decoder serves both formats,
+and a null is a cleared bit rather than a sentinel or a NaN, which are
+values a chain can legitimately hold.
+
+Keeping the text columns out of the blocks is what the dictionary is for:
+the symbol is fixed for a simulation and the schedule's rule ids are fixed
+by its parameters, so both are known before the first row. `labels` is a
+bitmask over those rule ids, and joining the bits it sets reproduces the
+`csv` column character for character, since both orders are lexicographic.
+A simulation is capped at 16 schedule rules at creation, well inside the 63
+a mask carries, and a compile-time assertion keeps the two from drifting
+apart.
+
+Measured on the reference fixture at `greeks=all`, release build:
+
+| Format | Bytes | Wall time |
+|--------|-------|-----------|
+| `json` | 79 888 | 9.7 ms |
+| `csv` | 46 819 | 7.8 ms |
+| `arrow` | 29 640 | 6.5 ms |
+| `packed` | 22 808 | 6.1 ms |
 
 **Deterministic.** Repeating an export is byte-identical: every value is a
 function of the effective parameters and the cursor, timestamps render as

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ therefore a function of the block width and not of the number of steps.
 The `packed` layout, little-endian throughout:
 
 ```
-file        := header block*
+file        := header block* footer
 header      := "OCSP" u32:version u32:block_rows
                u32:dictionary_count dictionary_entry*
                u32:column_count column_desc*
@@ -513,7 +513,16 @@ dict_entry  := u32:len utf8:value             (the symbol, then the rule ids)
 column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
 block       := u32:row_count pad to 8 column_payload*
 payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+footer      := u32:0xFFFFFFFF pad to 8 u64:total_rows
 ```
+
+**The footer is required, and a decoder must check it.** No block can carry
+`0xFFFFFFFF` rows, so that value is what says the blocks have ended, and the
+`u64` after it is the total the writer emitted. A document that ends without
+it was truncated and must be REJECTED rather than read as a shorter tape:
+the response is a 200 whose header goes out before the first byte is
+produced, so a dropped connection is otherwise indistinguishable from a
+smaller export. A total that disagrees with the blocks is the same error.
 
 Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
 the epoch, `3` = an index into the header dictionary, `4` = a **label

--- a/src/api/rest/arrow_export.rs
+++ b/src/api/rest/arrow_export.rs
@@ -117,20 +117,34 @@ impl ArrowWriter {
         Ok(self.drain())
     }
 
-    /// Buffers rows, returning the encoded batches they completed.
+    /// Buffers ONE row, returning a batch only when that row completed one.
+    ///
+    /// Row at a time, like the packed writer and for the same reasons: the
+    /// footprint stays one batch whatever a step carries, and a finished batch
+    /// reaches the client before the next one is encoded.
     ///
     /// # Errors
     ///
     /// Returns [`ChainError::Internal`] when a batch cannot be built or
     /// written.
-    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
-        self.buffered.extend(rows);
+    pub(super) fn push_row(&mut self, row: Vec<Cell>) -> Result<Option<Vec<u8>>, ChainError> {
+        self.buffered.push(row);
+        if self.buffered.len() < self.block_rows {
+            return Ok(None);
+        }
 
+        let block = std::mem::take(&mut self.buffered);
+        Ok(Some(self.write_batch(&block)?))
+    }
+
+    /// The same, for a batch of rows. Test-only, as in the packed writer.
+    #[cfg(test)]
+    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
         let mut chunks = Vec::new();
-        while self.buffered.len() >= self.block_rows {
-            let rest = self.buffered.split_off(self.block_rows);
-            let block = std::mem::replace(&mut self.buffered, rest);
-            chunks.push(self.write_batch(&block)?);
+        for row in rows {
+            if let Some(chunk) = self.push_row(row)? {
+                chunks.push(chunk);
+            }
         }
         Ok(chunks)
     }

--- a/src/api/rest/arrow_export.rs
+++ b/src/api/rest/arrow_export.rs
@@ -1,0 +1,460 @@
+//! The Arrow IPC stream encoding, behind the `arrow-export` feature.
+//!
+//! For consumers that already speak Arrow: IronCondor materialises simulator
+//! tapes to Parquet and already pins `arrow`, so an Arrow IPC stream removes a
+//! whole conversion stage, and it carries schema, types and nulls with no
+//! private convention to agree on.
+//!
+//! **Feature-gated, off by default.** The `arrow` crate is a large dependency
+//! tree, and a deployment that never exports — or a crates.io consumer using
+//! this crate as a library — should not pay for it. A request for
+//! `format=arrow` on a build without the feature is a typed `400` naming the
+//! unavailable format, never a 500 and never a silent fallback to another
+//! encoding.
+//!
+//! # Streaming, and determinism
+//!
+//! The IPC **stream** format (not the file format) is a sequence of record
+//! batches, which is exactly the block shape the export needs: one batch per
+//! `OCS_EXPORT_BLOCK_ROWS` rows, so memory is a function of the block width and
+//! not of the number of steps.
+//!
+//! The schema carries no metadata at all — no build identifier, no timestamp,
+//! no map with a non-deterministic iteration order — because the endpoint
+//! promises byte-identical output on repeat. Column names and order are the
+//! CSV header's, so a reader moves between encodings without a mapping table.
+//!
+//! `labels` is a `Utf8` column here rather than the bitmask `packed` uses:
+//! Arrow carries variable-length data natively, and matching the text
+//! encodings exactly is worth more to an Arrow consumer than a fixed width.
+
+use crate::api::rest::binary::{BinarySchema, Cell, CellType};
+use crate::utils::ChainError;
+use arrow::array::{ArrayRef, Float64Builder, Int64Array, StringArray, TimestampNanosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::RecordBatch;
+use std::sync::Arc;
+
+/// Encodes Arrow IPC record batches.
+///
+/// Holds at most one block of rows, like the `packed` writer, and owns the
+/// `StreamWriter` so the schema message is written exactly once, at the front.
+pub(super) struct ArrowWriter {
+    schema: BinarySchema,
+    arrow_schema: Arc<Schema>,
+    block_rows: usize,
+    buffered: Vec<Vec<Cell>>,
+    writer: Option<StreamWriter<Vec<u8>>>,
+}
+
+impl ArrowWriter {
+    /// Creates a writer for a schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the IPC stream's schema message
+    /// cannot be written.
+    pub(super) fn new(schema: BinarySchema, block_rows: usize) -> Result<Self, ChainError> {
+        let fields: Vec<Field> = schema
+            .names
+            .iter()
+            .zip(&schema.types)
+            .map(|(name, cell_type)| {
+                Field::new(
+                    (*name).to_string(),
+                    match cell_type {
+                        CellType::F64 => DataType::Float64,
+                        CellType::I64 => DataType::Int64,
+                        CellType::Timestamp => {
+                            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
+                        }
+                        // The text columns as text: an Arrow consumer reads the
+                        // same values the CSV carries, with no dictionary of
+                        // ours to decode.
+                        CellType::Dictionary | CellType::LabelMask => DataType::Utf8,
+                    },
+                    cell_type.nullable(),
+                )
+            })
+            .collect();
+
+        let arrow_schema = Arc::new(Schema::new(fields));
+        let writer = StreamWriter::try_new(Vec::new(), &arrow_schema).map_err(|error| {
+            ChainError::Internal(format!("failed to open an Arrow stream: {error}"))
+        })?;
+
+        Ok(Self {
+            schema,
+            arrow_schema,
+            block_rows: block_rows.max(1),
+            buffered: Vec::new(),
+            writer: Some(writer),
+        })
+    }
+
+    /// The schema this writer encodes.
+    #[must_use]
+    pub(super) fn schema(&self) -> &BinarySchema {
+        &self.schema
+    }
+
+    /// The bytes written so far, taken out of the stream writer's buffer.
+    fn drain(&mut self) -> Vec<u8> {
+        match self.writer.as_mut() {
+            Some(writer) => std::mem::take(writer.get_mut()),
+            None => Vec::new(),
+        }
+    }
+
+    /// The IPC schema message, which opens the stream.
+    ///
+    /// # Errors
+    ///
+    /// Never fails today; fallible for symmetry with the other writers, whose
+    /// prologue can.
+    pub(super) fn header(&mut self) -> Result<Vec<u8>, ChainError> {
+        Ok(self.drain())
+    }
+
+    /// Buffers rows, returning the encoded batches they completed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when a batch cannot be built or
+    /// written.
+    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
+        self.buffered.extend(rows);
+
+        let mut chunks = Vec::new();
+        while self.buffered.len() >= self.block_rows {
+            let rest = self.buffered.split_off(self.block_rows);
+            let block = std::mem::replace(&mut self.buffered, rest);
+            chunks.push(self.write_batch(&block)?);
+        }
+        Ok(chunks)
+    }
+
+    /// The final batch and the stream's end-of-stream marker.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the last batch cannot be written
+    /// or the stream cannot be finished.
+    pub(super) fn finish(&mut self) -> Result<Option<Vec<u8>>, ChainError> {
+        // The last batch's bytes are part of the answer, not a side effect:
+        // `write_batch` drains the stream writer's buffer, so dropping what it
+        // returns would silently truncate every export whose row count is under
+        // one block.
+        let mut out = if self.buffered.is_empty() {
+            Vec::new()
+        } else {
+            let block = std::mem::take(&mut self.buffered);
+            self.write_batch(&block)?
+        };
+
+        let Some(mut writer) = self.writer.take() else {
+            return Ok(if out.is_empty() { None } else { Some(out) });
+        };
+        writer.finish().map_err(|error| {
+            ChainError::Internal(format!("failed to close an Arrow stream: {error}"))
+        })?;
+        let buffer = writer.into_inner().map_err(|error| {
+            ChainError::Internal(format!("failed to close an Arrow stream: {error}"))
+        })?;
+
+        out.extend(buffer);
+        if out.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(out))
+    }
+
+    /// Builds and writes one record batch, returning the bytes it produced.
+    fn write_batch(&mut self, rows: &[Vec<Cell>]) -> Result<Vec<u8>, ChainError> {
+        let columns = self.columns(rows)?;
+        let batch =
+            RecordBatch::try_new(Arc::clone(&self.arrow_schema), columns).map_err(|error| {
+                ChainError::Internal(format!("failed to build an Arrow batch: {error}"))
+            })?;
+
+        match self.writer.as_mut() {
+            Some(writer) => writer.write(&batch).map_err(|error| {
+                ChainError::Internal(format!("failed to write an Arrow batch: {error}"))
+            })?,
+            None => {
+                return Err(ChainError::Internal(
+                    "the Arrow stream was already closed".to_string(),
+                ));
+            }
+        }
+        Ok(self.drain())
+    }
+
+    /// Builds one array per column, in schema order.
+    fn columns(&self, rows: &[Vec<Cell>]) -> Result<Vec<ArrayRef>, ChainError> {
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.schema.types.len());
+
+        for (index, cell_type) in self.schema.types.iter().enumerate() {
+            let array: ArrayRef = match cell_type {
+                CellType::F64 => {
+                    let mut builder = Float64Builder::with_capacity(rows.len());
+                    for row in rows {
+                        match row.get(index) {
+                            // A null is a null: an unset validity bit, never a
+                            // sentinel and never a NaN, which is a value a
+                            // chain can legitimately hold.
+                            Some(Cell::F64(Some(value))) => builder.append_value(*value),
+                            _ => builder.append_null(),
+                        }
+                    }
+                    Arc::new(builder.finish()) as ArrayRef
+                }
+                CellType::I64 => Arc::new(Int64Array::from(
+                    rows.iter()
+                        .map(|row| match row.get(index) {
+                            Some(Cell::I64(value)) => *value,
+                            _ => 0,
+                        })
+                        .collect::<Vec<i64>>(),
+                )) as ArrayRef,
+                CellType::Timestamp => Arc::new(
+                    TimestampNanosecondArray::from(
+                        rows.iter()
+                            .map(|row| match row.get(index) {
+                                Some(Cell::Timestamp(value)) => *value,
+                                _ => 0,
+                            })
+                            .collect::<Vec<i64>>(),
+                    )
+                    .with_timezone("UTC"),
+                ) as ArrayRef,
+                CellType::Dictionary => Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|row| match row.get(index) {
+                            Some(Cell::Dictionary(value)) => self
+                                .schema
+                                .dictionary
+                                .get(*value as usize)
+                                .cloned()
+                                .unwrap_or_default(),
+                            _ => String::new(),
+                        })
+                        .collect::<Vec<String>>(),
+                )) as ArrayRef,
+                CellType::LabelMask => Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|row| match row.get(index) {
+                            // Joined exactly as the text encodings join them,
+                            // from the same lexicographic dictionary.
+                            Some(Cell::LabelMask(mask)) => self.schema.labels_of(*mask).join("|"),
+                            _ => String::new(),
+                        })
+                        .collect::<Vec<String>>(),
+                )) as ArrayRef,
+            };
+            columns.push(array);
+        }
+
+        // Every column must agree on its length, or `RecordBatch::try_new`
+        // rejects the batch — which is the check itself, so nothing is asserted
+        // here beyond letting it run.
+        debug_assert!(
+            columns
+                .iter()
+                .all(|column| column.len() == rows.len() || rows.is_empty()),
+            "every Arrow column must carry one value per row"
+        );
+        Ok(columns)
+    }
+}
+
+/// Reads an Arrow IPC stream back into rows of optional doubles and strings.
+///
+/// Test-only: the cross-format equality tests decode what the writer produced
+/// rather than trusting it, which is the only way the "identical to the json
+/// export" claim means anything.
+#[cfg(test)]
+pub(super) fn decode_stream(bytes: &[u8]) -> Result<Vec<Vec<String>>, ChainError> {
+    use arrow::array::{Array, Float64Array};
+    use arrow::ipc::reader::StreamReader;
+
+    let reader = StreamReader::try_new(std::io::Cursor::new(bytes), None).map_err(|error| {
+        ChainError::Internal(format!("failed to read an Arrow stream: {error}"))
+    })?;
+
+    let mut rows = Vec::new();
+    for batch in reader {
+        let batch = batch
+            .map_err(|error| ChainError::Internal(format!("failed to read a batch: {error}")))?;
+        for index in 0..batch.num_rows() {
+            let mut values = Vec::with_capacity(batch.num_columns());
+            for column in batch.columns() {
+                if column.is_null(index) {
+                    values.push(String::new());
+                    continue;
+                }
+                if let Some(array) = column.as_any().downcast_ref::<Float64Array>() {
+                    values.push(array.value(index).to_string());
+                } else if let Some(array) = column.as_any().downcast_ref::<Int64Array>() {
+                    values.push(array.value(index).to_string());
+                } else if let Some(array) =
+                    column.as_any().downcast_ref::<TimestampNanosecondArray>()
+                {
+                    // Rendered the way every other v2 timestamp is rendered, so
+                    // a decoded batch compares against the CSV directly and the
+                    // equality claim means something.
+                    values.push(
+                        chrono::DateTime::from_timestamp_nanos(array.value(index))
+                            .to_utc()
+                            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    );
+                } else if let Some(array) = column.as_any().downcast_ref::<StringArray>() {
+                    values.push(array.value(index).to_string());
+                } else {
+                    return Err(ChainError::Internal(
+                        "an Arrow column carried an unexpected type".to_string(),
+                    ));
+                }
+            }
+            rows.push(values);
+        }
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> BinarySchema {
+        BinarySchema {
+            names: vec!["step", "simulated_at", "symbol", "labels", "price"],
+            types: vec![
+                CellType::I64,
+                CellType::Timestamp,
+                CellType::Dictionary,
+                CellType::LabelMask,
+                CellType::F64,
+            ],
+            dictionary: vec![
+                "SPX".to_string(),
+                "monthlies".to_string(),
+                "zero_dte".to_string(),
+            ],
+        }
+    }
+
+    fn row(step: i64, price: Option<f64>, mask: u64) -> Vec<Cell> {
+        vec![
+            Cell::I64(step),
+            Cell::Timestamp(1_767_623_400_000_000_000),
+            Cell::Dictionary(0),
+            Cell::LabelMask(mask),
+            Cell::F64(price),
+        ]
+    }
+
+    fn encode(rows: Vec<Vec<Cell>>, block_rows: usize) -> Vec<u8> {
+        let mut writer = match ArrowWriter::new(schema(), block_rows) {
+            Ok(writer) => writer,
+            Err(error) => panic!("the writer must open: {error}"),
+        };
+
+        let mut bytes = match writer.header() {
+            Ok(header) => header,
+            Err(error) => panic!("the header must encode: {error}"),
+        };
+        match writer.push(rows) {
+            Ok(chunks) => bytes.extend(chunks.into_iter().flatten()),
+            Err(error) => panic!("the rows must encode: {error}"),
+        }
+        match writer.finish() {
+            Ok(Some(tail)) => bytes.extend(tail),
+            Ok(None) => {}
+            Err(error) => panic!("the stream must close: {error}"),
+        }
+        bytes
+    }
+
+    /// Rows survive the round trip, values and nulls alike.
+    #[test]
+    fn test_rows_round_trip_through_the_stream() {
+        // Bits 0 and 1: `monthlies` and `zero_dte`, the dictionary's two rule ids.
+        let bytes = encode(vec![row(0, Some(1.5), 0b11), row(1, None, 0)], 8);
+
+        match decode_stream(&bytes) {
+            Ok(rows) => {
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[0][0], "0");
+                assert_eq!(rows[0][1], "2026-01-05T14:30:00Z");
+                assert_eq!(rows[0][2], "SPX");
+                assert_eq!(rows[0][3], "monthlies|zero_dte");
+                assert_eq!(rows[0][4], "1.5");
+                assert_eq!(rows[1][4], "", "a null must read back as a null");
+                assert_eq!(rows[1][3], "", "an empty label set is an empty string");
+            }
+            Err(error) => panic!("the stream must decode: {error}"),
+        }
+    }
+
+    /// A block width smaller than the row count produces several batches, and
+    /// the decoded rows are the same either way.
+    #[test]
+    fn test_the_block_width_does_not_change_the_values() {
+        let rows = vec![
+            row(0, Some(1.0), 0),
+            row(1, Some(2.0), 0),
+            row(2, None, 0),
+            row(3, Some(4.0), 0),
+        ];
+
+        let narrow = match decode_stream(&encode(rows.clone(), 1)) {
+            Ok(decoded) => decoded,
+            Err(error) => panic!("the narrow stream must decode: {error}"),
+        };
+        let wide = match decode_stream(&encode(rows, 64)) {
+            Ok(decoded) => decoded,
+            Err(error) => panic!("the wide stream must decode: {error}"),
+        };
+
+        assert_eq!(narrow, wide);
+    }
+
+    /// The same rows encode to the same bytes, every time.
+    ///
+    /// The endpoint promises byte-identical output on repeat, and an IPC
+    /// stream is where that is easiest to lose: schema metadata carrying a
+    /// build id or a timestamp would break it silently.
+    #[test]
+    fn test_the_encoding_is_byte_identical_on_repeat() {
+        let rows = vec![row(0, Some(1.0), 0b10), row(1, None, 0)];
+
+        assert_eq!(encode(rows.clone(), 2), encode(rows, 2));
+    }
+
+    /// The schema carries no metadata, which is what makes the repeat stable.
+    #[test]
+    fn test_the_schema_carries_no_metadata() {
+        let writer = match ArrowWriter::new(schema(), 8) {
+            Ok(writer) => writer,
+            Err(error) => panic!("the writer must open: {error}"),
+        };
+
+        assert!(
+            writer.arrow_schema.metadata().is_empty(),
+            "schema metadata is a determinism hazard: {:?}",
+            writer.arrow_schema.metadata()
+        );
+        assert_eq!(
+            writer
+                .arrow_schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["step", "simulated_at", "symbol", "labels", "price"],
+            "the column order is the csv header's"
+        );
+    }
+}

--- a/src/api/rest/binary.rs
+++ b/src/api/rest/binary.rs
@@ -44,16 +44,26 @@
 //! requirement rather than a nicety.
 //!
 //! ```text
-//! file        := header block*
+//! file        := header block* footer
 //! header      := "OCSP" u32:version u32:block_rows
 //!                u32:dictionary_count dictionary_entry*
 //!                u32:column_count column_desc*
 //!                pad to 8
-//! dict_entry  := u32:len utf8:value            (the rule ids, sorted)
+//! dict_entry  := u32:len utf8:value            (the symbol, then the rule ids)
 //! column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
 //! block       := u32:row_count pad to 8 column_payload*
 //! payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+//! footer      := u32:0xFFFFFFFF pad to 8 u64:total_rows
 //! ```
+//!
+//! **The footer is required, and a decoder must check it.** A block's row count
+//! can never be `0xFFFFFFFF`, so that value is what tells a reader the blocks
+//! have ended; the `u64` after it is the total number of rows the writer
+//! emitted. A document that ends without the sentinel was TRUNCATED and must be
+//! rejected rather than read as a shorter tape — the response is a 200 whose
+//! header goes out before the first byte is produced, so a dropped connection
+//! is otherwise indistinguishable from a smaller export. A row count that
+//! disagrees with the blocks is the same error.
 //!
 //! Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
 //! the epoch (`i64`), `3` = a dictionary index into the header's entries
@@ -322,11 +332,132 @@ pub(super) fn timestamp_nanos(instant: DateTime<Utc>) -> i64 {
 /// The same shape, in the same order, as the module's `csv_rows` produces as
 /// strings — deliberately built from the same view types rather than from a
 /// second traversal, so the encodings cannot disagree about what a row is.
+/// Whether a row visitor wants more rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RowFlow {
+    /// Keep going.
+    Continue,
+    /// Stop here: the client is gone, and nothing further is worth encoding.
+    Stop,
+}
+
+/// Feeds one step's rows to a visitor, ONE AT A TIME.
+///
+/// The reason this is a visitor rather than a `Vec`: a step of the widest
+/// dataset can carry `OCS_MAX_SNAPSHOT_CONTRACTS` rows, and materialising them
+/// all before the first block is written would make an export's memory a
+/// function of the chain size rather than of the block width, and would delay
+/// noticing a disconnected client until the whole step had been encoded.
+///
 /// # Errors
 ///
 /// Returns [`ChainError::Internal`] when a chain carries a label this
 /// simulation's schedule does not name, which would make the binary `labels`
-/// column disagree with the text one.
+/// column disagree with the text one, and whatever the visitor returns.
+pub(super) fn visit_typed_rows<F>(
+    schema: &BinarySchema,
+    dataset: Dataset,
+    level: GreekLevel,
+    step: usize,
+    simulated_at: DateTime<Utc>,
+    row: &FactorRow,
+    chains: Option<super::export::StepChains<'_>>,
+    visit: &mut F,
+) -> Result<RowFlow, ChainError>
+where
+    F: FnMut(Vec<Cell>) -> Result<RowFlow, ChainError>,
+{
+    let step_cell = Cell::I64(i64::try_from(step).unwrap_or(i64::MAX));
+    let instant = Cell::Timestamp(timestamp_nanos(simulated_at));
+    let symbol = Cell::Dictionary(schema.symbol_index());
+
+    match dataset {
+        Dataset::Underlying => visit(vec![
+            step_cell,
+            instant,
+            symbol,
+            Cell::F64(Some(row.spot.to_f64())),
+        ]),
+        Dataset::Volatility => visit(vec![
+            step_cell,
+            instant,
+            symbol,
+            Cell::F64(Some(row.base_volatility.to_f64())),
+        ]),
+        Dataset::OptionChains => {
+            let Some(chains) = chains else {
+                return Ok(RowFlow::Continue);
+            };
+            for expiration in chains.expirations() {
+                let expires_at = Cell::Timestamp(timestamp_nanos(expiration.expires_at));
+                let labels = Cell::LabelMask(schema.label_mask(expiration.labels)?);
+                for quote in expiration.quotes.quotes() {
+                    let mut cells = vec![
+                        step_cell,
+                        instant,
+                        symbol,
+                        expires_at,
+                        labels,
+                        Cell::F64(Some(expiration.days_to_expiration)),
+                        Cell::F64(Some(quote.strike)),
+                        Cell::F64(Some(quote.implied_volatility)),
+                        Cell::F64(quote.call_bid),
+                        Cell::F64(quote.call_ask),
+                        Cell::F64(quote.call_mid),
+                        Cell::F64(quote.call_delta),
+                        Cell::F64(quote.put_bid),
+                        Cell::F64(quote.put_ask),
+                        Cell::F64(quote.put_mid),
+                        Cell::F64(quote.put_delta),
+                        Cell::F64(quote.gamma),
+                    ];
+                    if level.wants_greeks() {
+                        for value in [
+                            quote.call_greeks.theta,
+                            quote.put_greeks.theta,
+                            quote.call_greeks.vega,
+                            quote.put_greeks.vega,
+                            quote.call_greeks.rho,
+                            quote.put_greeks.rho,
+                            quote.call_greeks.rho_d,
+                            quote.put_greeks.rho_d,
+                        ] {
+                            cells.push(Cell::F64(value));
+                        }
+                    }
+                    if matches!(level, GreekLevel::All) {
+                        for value in [
+                            quote.call_greeks.gamma,
+                            quote.put_greeks.gamma,
+                            quote.call_greeks.alpha,
+                            quote.put_greeks.alpha,
+                            quote.call_greeks.vanna,
+                            quote.put_greeks.vanna,
+                            quote.call_greeks.vomma,
+                            quote.put_greeks.vomma,
+                            quote.call_greeks.veta,
+                            quote.put_greeks.veta,
+                            quote.call_greeks.charm,
+                            quote.put_greeks.charm,
+                            quote.call_greeks.color,
+                            quote.put_greeks.color,
+                        ] {
+                            cells.push(Cell::F64(value));
+                        }
+                    }
+                    if visit(cells)? == RowFlow::Stop {
+                        return Ok(RowFlow::Stop);
+                    }
+                }
+            }
+            Ok(RowFlow::Continue)
+        }
+    }
+}
+
+/// The same rows, collected. Test-only: the serving path visits them one at a
+/// time so that neither memory nor cancellation latency scales with a step.
+#[cfg(test)]
 pub(super) fn typed_rows(
     schema: &BinarySchema,
     dataset: Dataset,
@@ -486,21 +617,37 @@ impl PackedWriter {
         Ok(out)
     }
 
-    /// Buffers rows, returning the blocks they completed.
+    /// Buffers ONE row, returning a block only when that row completed one.
+    ///
+    /// Row at a time on purpose: it is what keeps the writer's footprint at one
+    /// block regardless of how many rows a step carries, and it lets the caller
+    /// hand a finished block to the client before encoding the next one, so a
+    /// disconnect is noticed within a block rather than within a step.
     ///
     /// # Errors
     ///
     /// Returns [`ChainError::Internal`] when a block's row count does not fit
     /// the layout's `u32`.
-    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
-        self.buffered.extend(rows);
+    pub(super) fn push_row(&mut self, row: Vec<Cell>) -> Result<Option<Vec<u8>>, ChainError> {
+        self.buffered.push(row);
+        if self.buffered.len() < self.block_rows {
+            return Ok(None);
+        }
 
+        let block = std::mem::take(&mut self.buffered);
+        self.written = self.written.saturating_add(block.len());
+        Ok(Some(self.encode_block(&block)?))
+    }
+
+    /// The same, for a batch of rows. Test-only: the serving path pushes one
+    /// row at a time so a step never sits in memory.
+    #[cfg(test)]
+    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
         let mut blocks = Vec::new();
-        while self.buffered.len() >= self.block_rows {
-            let rest = self.buffered.split_off(self.block_rows);
-            let block = std::mem::replace(&mut self.buffered, rest);
-            self.written = self.written.saturating_add(block.len());
-            blocks.push(self.encode_block(&block)?);
+        for row in rows {
+            if let Some(block) = self.push_row(row)? {
+                blocks.push(block);
+            }
         }
         Ok(blocks)
     }

--- a/src/api/rest/binary.rs
+++ b/src/api/rest/binary.rs
@@ -1,0 +1,1197 @@
+//! The binary export encodings, and the typed rows both of them read.
+//!
+//! `json` and `csv` are text, so every consumer pays a parse. For the two that
+//! matter that parse IS the bottleneck: a browser materialising a whole tape
+//! spends hundreds of milliseconds in `JSON.parse` and allocates an object per
+//! row, and a Rust consumer writing Parquet re-parses text this service already
+//! held in typed form.
+//!
+//! Two binary encodings answer that, and they share everything except who they
+//! are for:
+//!
+//! - **`arrow`** — Arrow IPC stream, for consumers that already speak Arrow.
+//!   Feature-gated behind `arrow-export`, off by default, because the `arrow`
+//!   crate is a large tree and a deployment that never exports should not pay
+//!   for it. Lives in the `arrow_export` module, compiled only with that
+//!   feature.
+//! - **`packed`** — a minimal self-describing columnar block format with no
+//!   dependencies, for the browser. Arrow's JavaScript library is a large
+//!   bundle for a page whose only need is "these columns as typed arrays";
+//!   `packed` is a few dozen lines of decoder and zero bundle weight.
+//!
+//! # Both stream, in blocks
+//!
+//! The export endpoint streams: the module it lives in exists so a tape is
+//! never materialised in memory. Columnar encoding pulls the other way, since a
+//! column cannot be emitted until its last row is known. Both formats resolve
+//! it the same way — **blocks of a fixed number of rows, each columnar within
+//! itself**. Arrow IPC already works exactly like that (a stream of record
+//! batches); `packed` adopts the same shape, and
+//! `OCS_EXPORT_BLOCK_ROWS` sets the width for both.
+//!
+//! # Precision
+//!
+//! Numeric columns are `f64`, the same values `json` and `csv` already render
+//! through `decimal_to_f64`. Binary is a faster route to the same numbers, NOT
+//! a route to the underlying `Decimal(38, 28)` precision.
+//!
+//! # The `packed` layout
+//!
+//! Little-endian throughout. Every payload starts at an 8-byte aligned offset,
+//! which is the whole point: it is what lets a browser do
+//! `new Float64Array(buffer, offset, count)` with no copy at all. An unaligned
+//! offset makes that constructor throw, so the alignment is a correctness
+//! requirement rather than a nicety.
+//!
+//! ```text
+//! file        := header block*
+//! header      := "OCSP" u32:version u32:block_rows
+//!                u32:dictionary_count dictionary_entry*
+//!                u32:column_count column_desc*
+//!                pad to 8
+//! dict_entry  := u32:len utf8:value            (the rule ids, sorted)
+//! column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
+//! block       := u32:row_count pad to 8 column_payload*
+//! payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+//! ```
+//!
+//! Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
+//! the epoch (`i64`), `3` = a dictionary index into the header's entries
+//! (`u32`), `4` = a **label bitmask** (`u64`), one bit per header dictionary
+//! entry, set when that rule id labels the row's expiration. The bitmask is
+//! what keeps variable-length text out of a block: the rule ids are known
+//! before the first row is produced, they are the only text a row carries
+//! besides the symbol, and a bitmask over them reconstructs the `csv` column
+//! exactly, because both are ordered lexicographically.
+//!
+//! Validity bitmaps use Arrow's convention — LSB-first, `1` = valid — so the
+//! two decoders agree and a reader ports between them.
+
+use crate::api::rest::export::Dataset;
+use crate::api::rest::greeks::GreekLevel;
+use crate::domain::factors::FactorRow;
+use crate::session::SimulationParametersV2;
+use crate::utils::ChainError;
+use chrono::{DateTime, Utc};
+
+/// The magic that opens a `packed` document.
+pub(super) const PACKED_MAGIC: &[u8; 4] = b"OCSP";
+
+/// The `packed` layout version this build writes.
+///
+/// Bumped when the layout changes in a way a decoder must notice. A decoder
+/// that reads a version it does not know must refuse rather than guess.
+pub(super) const PACKED_VERSION: u32 = 1;
+
+/// Everything in a block starts on this boundary.
+const ALIGNMENT: usize = 8;
+
+/// The row count that marks the footer rather than a block.
+///
+/// No block can carry `u32::MAX` rows — one would be tens of gigabytes — so a
+/// decoder that meets it knows the document ended deliberately.
+pub(super) const PACKED_FOOTER_SENTINEL: u32 = u32::MAX;
+
+/// What one column carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CellType {
+    /// A nullable double.
+    F64,
+    /// A step index.
+    I64,
+    /// An instant, as nanoseconds since the epoch.
+    Timestamp,
+    /// An index into the header dictionary.
+    Dictionary,
+    /// A bitmask over the header dictionary.
+    LabelMask,
+}
+
+impl CellType {
+    /// The code written into a `packed` column descriptor.
+    #[must_use]
+    pub(super) fn code(self) -> u8 {
+        match self {
+            CellType::F64 => 0,
+            CellType::I64 => 1,
+            CellType::Timestamp => 2,
+            CellType::Dictionary => 3,
+            CellType::LabelMask => 4,
+        }
+    }
+
+    /// Whether a column of this type carries a validity bitmap.
+    ///
+    /// Only the doubles are nullable: a step, an instant, a symbol and a label
+    /// set are present on every row a dataset produces.
+    #[must_use]
+    pub(super) fn nullable(self) -> bool {
+        matches!(self, CellType::F64)
+    }
+
+    /// The width of one value, in bytes.
+    #[must_use]
+    pub(super) fn width(self) -> usize {
+        match self {
+            CellType::F64 | CellType::I64 | CellType::Timestamp | CellType::LabelMask => 8,
+            CellType::Dictionary => 4,
+        }
+    }
+}
+
+/// One value of one row.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum Cell {
+    /// A nullable double, exactly what `json` and `csv` render.
+    F64(Option<f64>),
+    /// A step index.
+    I64(i64),
+    /// An instant, as nanoseconds since the epoch.
+    Timestamp(i64),
+    /// An index into the header dictionary.
+    Dictionary(u32),
+    /// A bitmask over the header dictionary.
+    LabelMask(u64),
+}
+
+impl Cell {
+    /// The column type this value belongs to.
+    ///
+    /// The schema decides the column types up front, so nothing on the encoding
+    /// path asks a value what it is; this exists so a test can assert a row's
+    /// cells line up with the schema that describes them.
+    #[cfg(test)]
+    #[must_use]
+    pub(super) fn cell_type(&self) -> CellType {
+        match self {
+            Cell::F64(_) => CellType::F64,
+            Cell::I64(_) => CellType::I64,
+            Cell::Timestamp(_) => CellType::Timestamp,
+            Cell::Dictionary(_) => CellType::Dictionary,
+            Cell::LabelMask(_) => CellType::LabelMask,
+        }
+    }
+}
+
+/// The schema a binary export writes, derived from the text header.
+///
+/// Same names and the same order as the CSV header, so a consumer moves
+/// between encodings without a mapping table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BinarySchema {
+    /// Column names, in order.
+    pub(super) names: Vec<&'static str>,
+    /// Column types, in the same order.
+    pub(super) types: Vec<CellType>,
+    /// The text values a row can carry: the symbol first, then the rule ids in
+    /// lexicographic order, which is the order the planner merges labels in.
+    pub(super) dictionary: Vec<String>,
+}
+
+impl BinarySchema {
+    /// Derives the schema of one dataset at one greek level.
+    ///
+    /// The dictionary is built HERE, before the first row is produced, from the
+    /// simulation's own parameters: the symbol is fixed for a simulation and
+    /// the rule ids are fixed by its schedule. That is what allows a block to
+    /// carry no variable-length data and still reproduce the text columns.
+    #[must_use]
+    pub(super) fn new(
+        dataset: Dataset,
+        level: GreekLevel,
+        parameters: &SimulationParametersV2,
+    ) -> Self {
+        let names = dataset.header(level);
+        let types = names
+            .iter()
+            .map(|name| match *name {
+                "step" => CellType::I64,
+                "simulated_at" | "expires_at" => CellType::Timestamp,
+                "symbol" => CellType::Dictionary,
+                "labels" => CellType::LabelMask,
+                _ => CellType::F64,
+            })
+            .collect();
+
+        let mut dictionary = vec![parameters.symbol.clone()];
+        let mut rule_ids: Vec<String> = parameters
+            .schedule
+            .rules()
+            .iter()
+            .map(|rule| rule.rule_id().to_string())
+            .collect();
+        // Lexicographic, matching the `BTreeSet` the planner merges labels in,
+        // so a bitmask reconstructs the joined `csv` value character for
+        // character.
+        rule_ids.sort();
+        rule_ids.dedup();
+        dictionary.extend(rule_ids);
+
+        Self {
+            names,
+            types,
+            dictionary,
+        }
+    }
+
+    /// The dictionary index of the symbol, which is always the first entry.
+    #[must_use]
+    pub(super) fn symbol_index(&self) -> u32 {
+        0
+    }
+
+    /// The bitmask of a label set.
+    ///
+    /// Bit `n` is dictionary entry `n + 1`: entry 0 is the SYMBOL and is never
+    /// a label. Skipping it is not cosmetic — a rule id that happens to equal
+    /// the symbol would otherwise take bit 0 and be reconstructed ahead of
+    /// every other rule id, which is a different `labels` string from the one
+    /// the text encodings render.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when a label is not in the dictionary.
+    /// It cannot be, for a simulation whose own schedule produced it, and
+    /// dropping one silently is the one thing this encoding must not do: its
+    /// whole contract is that it carries the same values the text encodings do.
+    pub(super) fn label_mask(&self, labels: &[String]) -> Result<u64, ChainError> {
+        let mut mask = 0_u64;
+        for label in labels {
+            let position = self
+                .dictionary
+                .iter()
+                .skip(1)
+                .position(|entry| entry == label)
+                .ok_or_else(|| {
+                    ChainError::Internal(format!(
+                        "the label {label:?} is not one of this simulation's rule ids"
+                    ))
+                })?;
+            if position >= u64::BITS as usize {
+                return Err(ChainError::Internal(format!(
+                    "the label {label:?} is past the {MAX_LABEL_RULES} a mask carries"
+                )));
+            }
+            mask |= 1 << position;
+        }
+        Ok(mask)
+    }
+
+    /// The rule ids a mask names, in the dictionary's order.
+    ///
+    /// The inverse of [`BinarySchema::label_mask`], and the reason a decoder can
+    /// rebuild the text column: joined with `|` this is the `csv` value. The
+    /// Arrow encoding calls it directly, since it writes the labels as text.
+    #[cfg_attr(not(any(test, feature = "arrow-export")), allow(dead_code))]
+    #[must_use]
+    pub(super) fn labels_of(&self, mask: u64) -> Vec<&str> {
+        // `skip(1)` for the symbol, so bit `n` names entry `n + 1`, the inverse
+        // of `label_mask`.
+        self.dictionary
+            .iter()
+            .skip(1)
+            .enumerate()
+            .filter(|(position, _)| *position < u64::BITS as usize && mask & (1 << position) != 0)
+            .map(|(_, entry)| entry.as_str())
+            .collect()
+    }
+}
+
+/// How many rule ids a label mask can carry.
+///
+/// One bit each, in a `u64`. The schedule validator already caps a simulation
+/// at [`crate::domain::expiry::MAX_SCHEDULE_RULES`] rules, well under this, and
+/// the assertion below keeps the two from drifting apart: raising that cap past
+/// 64 would silently start dropping labels from the binary encodings.
+pub(super) const MAX_LABEL_RULES: usize = 63;
+
+const _: () = assert!(
+    crate::domain::expiry::MAX_SCHEDULE_RULES <= MAX_LABEL_RULES,
+    "a schedule may carry more rules than a packed label mask has bits"
+);
+
+/// An instant as nanoseconds since the epoch, saturating at the representable
+/// range rather than wrapping.
+#[must_use]
+pub(super) fn timestamp_nanos(instant: DateTime<Utc>) -> i64 {
+    instant.timestamp_nanos_opt().unwrap_or(i64::MAX)
+}
+
+/// The rows one step contributes, as typed cells.
+///
+/// The same shape, in the same order, as the module's `csv_rows` produces as
+/// strings — deliberately built from the same view types rather than from a
+/// second traversal, so the encodings cannot disagree about what a row is.
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when a chain carries a label this
+/// simulation's schedule does not name, which would make the binary `labels`
+/// column disagree with the text one.
+pub(super) fn typed_rows(
+    schema: &BinarySchema,
+    dataset: Dataset,
+    level: GreekLevel,
+    step: usize,
+    simulated_at: DateTime<Utc>,
+    row: &FactorRow,
+    chains: Option<super::export::StepChains<'_>>,
+) -> Result<Vec<Vec<Cell>>, ChainError> {
+    let step_cell = Cell::I64(i64::try_from(step).unwrap_or(i64::MAX));
+    let instant = Cell::Timestamp(timestamp_nanos(simulated_at));
+    let symbol = Cell::Dictionary(schema.symbol_index());
+
+    Ok(match dataset {
+        Dataset::Underlying => vec![vec![
+            step_cell,
+            instant,
+            symbol,
+            Cell::F64(Some(row.spot.to_f64())),
+        ]],
+        Dataset::Volatility => vec![vec![
+            step_cell,
+            instant,
+            symbol,
+            Cell::F64(Some(row.base_volatility.to_f64())),
+        ]],
+        Dataset::OptionChains => {
+            let Some(chains) = chains else {
+                return Ok(Vec::new());
+            };
+            let mut rows = Vec::new();
+            for expiration in chains.expirations() {
+                let expires_at = Cell::Timestamp(timestamp_nanos(expiration.expires_at));
+                let labels = Cell::LabelMask(schema.label_mask(expiration.labels)?);
+                for quote in expiration.quotes.quotes() {
+                    let mut cells = vec![
+                        step_cell,
+                        instant,
+                        symbol,
+                        expires_at,
+                        labels,
+                        Cell::F64(Some(expiration.days_to_expiration)),
+                        Cell::F64(Some(quote.strike)),
+                        Cell::F64(Some(quote.implied_volatility)),
+                        Cell::F64(quote.call_bid),
+                        Cell::F64(quote.call_ask),
+                        Cell::F64(quote.call_mid),
+                        Cell::F64(quote.call_delta),
+                        Cell::F64(quote.put_bid),
+                        Cell::F64(quote.put_ask),
+                        Cell::F64(quote.put_mid),
+                        Cell::F64(quote.put_delta),
+                        Cell::F64(quote.gamma),
+                    ];
+                    if level.wants_greeks() {
+                        for value in [
+                            quote.call_greeks.theta,
+                            quote.put_greeks.theta,
+                            quote.call_greeks.vega,
+                            quote.put_greeks.vega,
+                            quote.call_greeks.rho,
+                            quote.put_greeks.rho,
+                            quote.call_greeks.rho_d,
+                            quote.put_greeks.rho_d,
+                        ] {
+                            cells.push(Cell::F64(value));
+                        }
+                    }
+                    if matches!(level, GreekLevel::All) {
+                        for value in [
+                            quote.call_greeks.gamma,
+                            quote.put_greeks.gamma,
+                            quote.call_greeks.alpha,
+                            quote.put_greeks.alpha,
+                            quote.call_greeks.vanna,
+                            quote.put_greeks.vanna,
+                            quote.call_greeks.vomma,
+                            quote.put_greeks.vomma,
+                            quote.call_greeks.veta,
+                            quote.put_greeks.veta,
+                            quote.call_greeks.charm,
+                            quote.put_greeks.charm,
+                            quote.call_greeks.color,
+                            quote.put_greeks.color,
+                        ] {
+                            cells.push(Cell::F64(value));
+                        }
+                    }
+                    rows.push(cells);
+                }
+            }
+            rows
+        }
+    })
+}
+
+/// Encodes `packed` blocks.
+///
+/// Holds at most one block of rows, which is what keeps the export streaming:
+/// memory is a function of the block width, never of the number of steps.
+pub(super) struct PackedWriter {
+    schema: BinarySchema,
+    block_rows: usize,
+    buffered: Vec<Vec<Cell>>,
+    /// Rows written so far, reported in the footer so a truncated download is
+    /// detectable rather than looking like a shorter tape.
+    written: usize,
+}
+
+impl PackedWriter {
+    /// Creates a writer for a schema.
+    #[must_use]
+    pub(super) fn new(schema: BinarySchema, block_rows: usize) -> Self {
+        Self {
+            schema,
+            block_rows: block_rows.max(1),
+            buffered: Vec::new(),
+            written: 0,
+        }
+    }
+
+    /// The schema this writer encodes.
+    #[must_use]
+    pub(super) fn schema(&self) -> &BinarySchema {
+        &self.schema
+    }
+
+    /// The document header.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when a name or dictionary entry is
+    /// longer than the layout's `u32` length can describe.
+    pub(super) fn header(&self) -> Result<Vec<u8>, ChainError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(PACKED_MAGIC);
+        out.extend_from_slice(&PACKED_VERSION.to_le_bytes());
+        out.extend_from_slice(&u32_of(self.block_rows)?.to_le_bytes());
+
+        out.extend_from_slice(&u32_of(self.schema.dictionary.len())?.to_le_bytes());
+        for entry in &self.schema.dictionary {
+            out.extend_from_slice(&u32_of(entry.len())?.to_le_bytes());
+            out.extend_from_slice(entry.as_bytes());
+        }
+
+        out.extend_from_slice(&u32_of(self.schema.names.len())?.to_le_bytes());
+        for (name, cell_type) in self.schema.names.iter().zip(&self.schema.types) {
+            out.extend_from_slice(&u32_of(name.len())?.to_le_bytes());
+            out.extend_from_slice(name.as_bytes());
+            out.push(cell_type.code());
+            out.push(u8::from(cell_type.nullable()));
+            pad_to(&mut out, 4);
+        }
+
+        // So the first block, and therefore its first payload, starts aligned.
+        pad_to(&mut out, ALIGNMENT);
+        Ok(out)
+    }
+
+    /// Buffers rows, returning the blocks they completed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when a block's row count does not fit
+    /// the layout's `u32`.
+    pub(super) fn push(&mut self, rows: Vec<Vec<Cell>>) -> Result<Vec<Vec<u8>>, ChainError> {
+        self.buffered.extend(rows);
+
+        let mut blocks = Vec::new();
+        while self.buffered.len() >= self.block_rows {
+            let rest = self.buffered.split_off(self.block_rows);
+            let block = std::mem::replace(&mut self.buffered, rest);
+            self.written = self.written.saturating_add(block.len());
+            blocks.push(self.encode_block(&block)?);
+        }
+        Ok(blocks)
+    }
+
+    /// The last partial block, followed by the footer that closes the document.
+    ///
+    /// The footer is what makes a truncated download detectable: without it a
+    /// connection dropped mid-stream produces a shorter document that decodes
+    /// as a perfectly valid smaller tape, under a 200 whose header went out
+    /// before the first byte was produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when the last block cannot be encoded.
+    pub(super) fn flush(&mut self) -> Result<Option<Vec<u8>>, ChainError> {
+        let mut out = if self.buffered.is_empty() {
+            Vec::new()
+        } else {
+            let block = std::mem::take(&mut self.buffered);
+            self.written = self.written.saturating_add(block.len());
+            self.encode_block(&block)?
+        };
+
+        // A row count no block can carry, so a decoder that meets it knows the
+        // document is over rather than guessing from a short read.
+        out.extend_from_slice(&PACKED_FOOTER_SENTINEL.to_le_bytes());
+        pad_to(&mut out, ALIGNMENT);
+        out.extend_from_slice(&(self.written as u64).to_le_bytes());
+        Ok(Some(out))
+    }
+
+    /// Encodes one block: every column, in schema order.
+    fn encode_block(&self, rows: &[Vec<Cell>]) -> Result<Vec<u8>, ChainError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&u32_of(rows.len())?.to_le_bytes());
+        pad_to(&mut out, ALIGNMENT);
+
+        for (index, cell_type) in self.schema.types.iter().enumerate() {
+            if cell_type.nullable() {
+                let mut bitmap = vec![0_u8; rows.len().div_ceil(8)];
+                for (position, row) in rows.iter().enumerate() {
+                    let valid = matches!(row.get(index), Some(Cell::F64(Some(_))));
+                    // LSB-first, `1` = valid: Arrow's convention, so one
+                    // decoder serves both formats. Indexed through `get_mut`
+                    // rather than `[]`: the bound is provable, but a request
+                    // path does not index unchecked.
+                    if let Some(byte) = bitmap.get_mut(position / 8)
+                        && valid
+                    {
+                        *byte |= 1 << (position % 8);
+                    }
+                }
+                out.extend_from_slice(&bitmap);
+                pad_to(&mut out, ALIGNMENT);
+            }
+
+            for row in rows {
+                match row.get(index) {
+                    Some(Cell::F64(value)) => {
+                        // A null writes zero bytes under a cleared validity
+                        // bit, never a sentinel and never a NaN: a NaN is a
+                        // value a chain can legitimately hold.
+                        out.extend_from_slice(&value.unwrap_or(0.0).to_le_bytes());
+                    }
+                    Some(Cell::I64(value) | Cell::Timestamp(value)) => {
+                        out.extend_from_slice(&value.to_le_bytes());
+                    }
+                    Some(Cell::Dictionary(value)) => out.extend_from_slice(&value.to_le_bytes()),
+                    Some(Cell::LabelMask(value)) => out.extend_from_slice(&value.to_le_bytes()),
+                    // Unreachable: every row of a dataset carries every column.
+                    // Written as zeroes of the right width rather than skipped,
+                    // so a short row could never shift the column that follows.
+                    None => out.extend_from_slice(&vec![0_u8; cell_type.width()]),
+                }
+            }
+            pad_to(&mut out, ALIGNMENT);
+        }
+
+        Ok(out)
+    }
+}
+
+/// Pads a buffer with zeroes until its length is a multiple of `boundary`.
+fn pad_to(out: &mut Vec<u8>, boundary: usize) {
+    let remainder = out.len() % boundary;
+    if remainder != 0 {
+        out.extend(std::iter::repeat_n(0_u8, boundary - remainder));
+    }
+}
+
+/// A length as the `u32` the layout writes.
+///
+/// Checked, not saturating: `u32::MAX` is itself a length a decoder would
+/// trust, so writing it in place of an overflowing one would corrupt the
+/// document rather than refuse it. Every caller passes a column name, a
+/// dictionary entry or a block width, so this cannot fire in practice.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when the value does not fit.
+fn u32_of(value: usize) -> Result<u32, ChainError> {
+    u32::try_from(value).map_err(|_| {
+        ChainError::Internal(format!("a packed length of {value} does not fit in a u32"))
+    })
+}
+
+/// Refuses a schema whose rule ids cannot be label-masked.
+///
+/// An INTERNAL invariant, not an API behaviour a client can trip: a simulation
+/// is already capped at [`crate::domain::expiry::MAX_SCHEDULE_RULES`] rules at
+/// creation, and the compile-time assertion beside [`MAX_LABEL_RULES`] keeps
+/// that cap below the mask's width. This is the runtime half of the same guard,
+/// so a future widening of the schedule cap fails loudly here rather than
+/// silently dropping labels from a binary export.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when the schema carries more rule ids than
+/// a `u64` mask has bits.
+pub(super) fn ensure_label_capacity(schema: &BinarySchema) -> Result<(), ChainError> {
+    // The symbol takes the first entry, so the rule ids are the rest. An empty
+    // dictionary is not reachable — `BinarySchema::new` always writes the
+    // symbol — and is read as "no rules" rather than underflowing.
+    let rules = match schema.dictionary.len() {
+        0 => 0,
+        length => length - 1,
+    };
+    if rules > MAX_LABEL_RULES {
+        return Err(ChainError::Internal(format!(
+            "a binary export carries at most {MAX_LABEL_RULES} schedule rules, \
+             this schema has {rules}"
+        )));
+    }
+    Ok(())
+}
+
+/// Decodes a `packed` document back into the values the text encodings render.
+///
+/// Test-only, and deliberately written against the layout documented in this
+/// module rather than against the writer's internals: it is what makes the
+/// cross-format equality tests mean something, and it doubles as the reference
+/// a browser decoder is ported from.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] when the bytes are not a `packed` document
+/// this build understands, or end early.
+#[cfg(test)]
+pub(super) fn decode_packed(bytes: &[u8]) -> Result<(Vec<String>, Vec<Vec<String>>), ChainError> {
+    use chrono::SecondsFormat;
+
+    let short = || ChainError::Internal("the packed document ended early".to_string());
+    let mut cursor = 0_usize;
+
+    let take = |cursor: &mut usize, count: usize| -> Result<&[u8], ChainError> {
+        let end = cursor.checked_add(count).ok_or_else(short)?;
+        let slice = bytes.get(*cursor..end).ok_or_else(short)?;
+        *cursor = end;
+        Ok(slice)
+    };
+    let take_u32 = |cursor: &mut usize| -> Result<u32, ChainError> {
+        let slice = take(cursor, 4)?;
+        let array: [u8; 4] = slice.try_into().map_err(|_| short())?;
+        Ok(u32::from_le_bytes(array))
+    };
+    let take_i64 = |cursor: &mut usize| -> Result<i64, ChainError> {
+        let slice = take(cursor, 8)?;
+        let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+        Ok(i64::from_le_bytes(array))
+    };
+    let align = |cursor: &mut usize| {
+        let remainder = *cursor % ALIGNMENT;
+        if remainder != 0 {
+            *cursor += ALIGNMENT - remainder;
+        }
+    };
+
+    if take(&mut cursor, 4)? != PACKED_MAGIC {
+        return Err(ChainError::Internal("not a packed document".to_string()));
+    }
+    let version = take_u32(&mut cursor)?;
+    if version != PACKED_VERSION {
+        return Err(ChainError::Internal(format!(
+            "unknown packed version {version}"
+        )));
+    }
+    let _block_rows = take_u32(&mut cursor)?;
+
+    let dictionary_len = take_u32(&mut cursor)? as usize;
+    let mut dictionary = Vec::with_capacity(dictionary_len);
+    for _ in 0..dictionary_len {
+        let len = take_u32(&mut cursor)? as usize;
+        let raw = take(&mut cursor, len)?;
+        dictionary
+            .push(String::from_utf8(raw.to_vec()).map_err(|_| {
+                ChainError::Internal("a dictionary entry is not UTF-8".to_string())
+            })?);
+    }
+
+    let column_count = take_u32(&mut cursor)? as usize;
+    let mut names = Vec::with_capacity(column_count);
+    let mut types = Vec::with_capacity(column_count);
+    for _ in 0..column_count {
+        let len = take_u32(&mut cursor)? as usize;
+        let raw = take(&mut cursor, len)?;
+        names.push(
+            String::from_utf8(raw.to_vec())
+                .map_err(|_| ChainError::Internal("a column name is not UTF-8".to_string()))?,
+        );
+        let code = *take(&mut cursor, 1)?.first().ok_or_else(short)?;
+        let _nullable = *take(&mut cursor, 1)?.first().ok_or_else(short)?;
+        types.push(match code {
+            0 => CellType::F64,
+            1 => CellType::I64,
+            2 => CellType::Timestamp,
+            3 => CellType::Dictionary,
+            4 => CellType::LabelMask,
+            other => {
+                return Err(ChainError::Internal(format!("unknown type code {other}")));
+            }
+        });
+        // The descriptor is padded to four, not eight.
+        let remainder = cursor % 4;
+        if remainder != 0 {
+            cursor += 4 - remainder;
+        }
+    }
+    align(&mut cursor);
+
+    let schema = BinarySchema {
+        names: Vec::new(),
+        types: types.clone(),
+        dictionary: dictionary.clone(),
+    };
+
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut closed = false;
+    while cursor < bytes.len() {
+        let marker = take_u32(&mut cursor)?;
+        if marker == PACKED_FOOTER_SENTINEL {
+            align(&mut cursor);
+            let declared = take_i64(&mut cursor)? as usize;
+            if declared != rows.len() {
+                return Err(ChainError::Internal(format!(
+                    "the footer declares {declared} rows, the blocks carried {}",
+                    rows.len()
+                )));
+            }
+            closed = true;
+            break;
+        }
+        let row_count = marker as usize;
+        align(&mut cursor);
+
+        let mut block: Vec<Vec<String>> = vec![Vec::with_capacity(column_count); row_count];
+        for cell_type in &types {
+            let mut validity = vec![true; row_count];
+            if cell_type.nullable() {
+                let bitmap_len = row_count.div_ceil(8);
+                let bitmap = take(&mut cursor, bitmap_len)?.to_vec();
+                for (position, valid) in validity.iter_mut().enumerate() {
+                    let byte = bitmap.get(position / 8).copied().unwrap_or(0);
+                    *valid = byte & (1 << (position % 8)) != 0;
+                }
+                align(&mut cursor);
+            }
+
+            for (position, row) in block.iter_mut().enumerate() {
+                let rendered = match cell_type {
+                    CellType::F64 => {
+                        let slice = take(&mut cursor, 8)?;
+                        let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+                        if validity.get(position).copied().unwrap_or(false) {
+                            f64::from_le_bytes(array).to_string()
+                        } else {
+                            String::new()
+                        }
+                    }
+                    CellType::I64 => take_i64(&mut cursor)?.to_string(),
+                    CellType::Timestamp => {
+                        let nanos = take_i64(&mut cursor)?;
+                        DateTime::from_timestamp_nanos(nanos)
+                            .to_utc()
+                            .to_rfc3339_opts(SecondsFormat::Secs, true)
+                    }
+                    CellType::Dictionary => {
+                        let index = take_u32(&mut cursor)? as usize;
+                        dictionary.get(index).cloned().unwrap_or_default()
+                    }
+                    CellType::LabelMask => {
+                        let slice = take(&mut cursor, 8)?;
+                        let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+                        schema.labels_of(u64::from_le_bytes(array)).join("|")
+                    }
+                };
+                row.push(rendered);
+            }
+            align(&mut cursor);
+        }
+        rows.extend(block);
+    }
+
+    if !closed {
+        return Err(ChainError::Internal(
+            "the packed document has no footer; the download was truncated".to_string(),
+        ));
+    }
+    Ok((names, rows))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> BinarySchema {
+        BinarySchema {
+            names: vec!["step", "simulated_at", "symbol", "labels", "price"],
+            types: vec![
+                CellType::I64,
+                CellType::Timestamp,
+                CellType::Dictionary,
+                CellType::LabelMask,
+                CellType::F64,
+            ],
+            dictionary: vec![
+                "SPX".to_string(),
+                "monthlies".to_string(),
+                "weeklies".to_string(),
+                "zero_dte".to_string(),
+            ],
+        }
+    }
+
+    /// The header of a writer, or a panic naming why it could not be written.
+    fn header_of(writer: &PackedWriter) -> Vec<u8> {
+        match writer.header() {
+            Ok(header) => header,
+            Err(error) => panic!("the header must encode: {error}"),
+        }
+    }
+
+    /// The blocks a push completed.
+    fn push_rows(writer: &mut PackedWriter, rows: Vec<Vec<Cell>>) -> Vec<Vec<u8>> {
+        match writer.push(rows) {
+            Ok(blocks) => blocks,
+            Err(error) => panic!("the rows must encode: {error}"),
+        }
+    }
+
+    /// The tail and footer a flush produced.
+    fn flush_of(writer: &mut PackedWriter) -> Vec<u8> {
+        match writer.flush() {
+            Ok(Some(tail)) => tail,
+            Ok(None) => Vec::new(),
+            Err(error) => panic!("the flush must encode: {error}"),
+        }
+    }
+
+    fn row(step: i64, price: Option<f64>, mask: u64) -> Vec<Cell> {
+        vec![
+            Cell::I64(step),
+            Cell::Timestamp(1_767_623_400_000_000_000),
+            Cell::Dictionary(0),
+            Cell::LabelMask(mask),
+            Cell::F64(price),
+        ]
+    }
+
+    /// A mask round-trips to the label set it came from.
+    ///
+    /// This is what lets `packed` carry no text inside a block and still
+    /// reproduce the `csv` column exactly.
+    #[test]
+    fn test_a_label_mask_round_trips() {
+        let schema = schema();
+
+        let labels = vec!["monthlies".to_string(), "zero_dte".to_string()];
+        let mask = match schema.label_mask(&labels) {
+            Ok(mask) => mask,
+            Err(error) => panic!("the labels are the schema's own rule ids: {error}"),
+        };
+
+        assert_eq!(schema.labels_of(mask), vec!["monthlies", "zero_dte"]);
+        assert_eq!(
+            schema.labels_of(mask).join("|"),
+            labels.join("|"),
+            "the reconstruction must be the csv value character for character"
+        );
+    }
+
+    /// An empty label set is a zero mask, and reads back empty.
+    #[test]
+    fn test_an_empty_label_set_is_a_zero_mask() {
+        let schema = schema();
+
+        match schema.label_mask(&[]) {
+            Ok(mask) => assert_eq!(mask, 0),
+            Err(error) => panic!("an empty label set must mask: {error}"),
+        }
+        assert!(schema.labels_of(0).is_empty());
+    }
+
+    /// Every payload in a block starts on an 8-byte boundary.
+    ///
+    /// The whole point of the format: an unaligned offset makes a browser's
+    /// `new Float64Array(buffer, offset, count)` throw, so this is a
+    /// correctness requirement rather than a nicety.
+    #[test]
+    fn test_every_payload_offset_is_aligned() {
+        let schema = schema();
+        let mut writer = PackedWriter::new(schema.clone(), 4);
+
+        let header = header_of(&writer);
+        assert_eq!(header.len() % ALIGNMENT, 0, "the header must end aligned");
+
+        let blocks = push_rows(
+            &mut writer,
+            vec![
+                row(0, Some(1.0), 1),
+                row(1, None, 2),
+                row(2, Some(3.0), 4),
+                row(3, Some(4.0), 8),
+            ],
+        );
+        assert_eq!(blocks.len(), 1, "four rows at a width of four is one block");
+
+        // Walk the block the way a decoder does, asserting the offset of every
+        // payload as it goes.
+        let block = &blocks[0];
+        let mut offset = 0_usize;
+        let rows = u32::from_le_bytes(match block[0..4].try_into() {
+            Ok(bytes) => bytes,
+            Err(error) => panic!("the row count must be readable: {error}"),
+        }) as usize;
+        assert_eq!(rows, 4);
+        offset += 4;
+        offset += (ALIGNMENT - offset % ALIGNMENT) % ALIGNMENT;
+
+        for cell_type in &schema.types {
+            assert_eq!(
+                offset % ALIGNMENT,
+                0,
+                "a payload must start aligned, got {offset}"
+            );
+            if cell_type.nullable() {
+                let bitmap = rows.div_ceil(8);
+                offset += bitmap + (ALIGNMENT - bitmap % ALIGNMENT) % ALIGNMENT;
+                assert_eq!(offset % ALIGNMENT, 0, "a bitmap must be padded");
+            }
+            let values = cell_type.width() * rows;
+            offset += values + (ALIGNMENT - values % ALIGNMENT) % ALIGNMENT;
+        }
+        assert_eq!(offset, block.len(), "the walk must consume the whole block");
+    }
+
+    /// A null writes a cleared validity bit and zero bytes, not a sentinel.
+    #[test]
+    fn test_a_null_is_a_cleared_bit_rather_than_a_sentinel() {
+        let mut writer = PackedWriter::new(schema(), 2);
+        let mut document = header_of(&writer);
+        for block in push_rows(&mut writer, vec![row(0, Some(1.5), 0), row(1, None, 0)]) {
+            document.extend(block);
+        }
+        document.extend(flush_of(&mut writer));
+
+        // Read back through the documented layout rather than by counting bytes
+        // from the end: a null must come out absent, not zero and not NaN.
+        match decode_packed(&document) {
+            Ok((_, rows)) => {
+                assert_eq!(rows[0][4], "1.5");
+                assert_eq!(rows[1][4], "", "a cleared validity bit reads as absent");
+            }
+            Err(error) => panic!("the document must decode: {error}"),
+        }
+    }
+
+    /// Rows accumulate into blocks of exactly the configured width.
+    #[test]
+    fn test_rows_are_emitted_in_blocks_of_the_configured_width() {
+        let mut writer = PackedWriter::new(schema(), 2);
+
+        assert!(
+            push_rows(&mut writer, vec![row(0, Some(1.0), 0)]).is_empty(),
+            "a partial block waits"
+        );
+        assert_eq!(
+            push_rows(&mut writer, vec![row(1, Some(2.0), 0)]).len(),
+            1,
+            "the second row completes it"
+        );
+        // The flush still emits the footer, which closes every document.
+        assert!(
+            !flush_of(&mut writer).is_empty(),
+            "the footer closes the document even with nothing buffered"
+        );
+    }
+
+    /// The same rows encode to the same bytes, every time.
+    #[test]
+    fn test_the_encoding_is_byte_identical_on_repeat() {
+        let rows = vec![row(0, Some(1.0), 3), row(1, None, 0)];
+
+        let mut first = PackedWriter::new(schema(), 2);
+        let mut second = PackedWriter::new(schema(), 2);
+
+        assert_eq!(header_of(&first), header_of(&second));
+        assert_eq!(
+            push_rows(&mut first, rows.clone()),
+            push_rows(&mut second, rows)
+        );
+        assert_eq!(flush_of(&mut first), flush_of(&mut second));
+    }
+
+    /// The writer never holds more than one block, whatever it is fed.
+    ///
+    /// This is the memory claim the streaming contract rests on: an export's
+    /// footprint is a function of the block width, not of the number of steps,
+    /// so a hundred-thousand-step tape costs the same as a ten-step one.
+    #[test]
+    fn test_the_writer_never_buffers_more_than_one_block() {
+        let block_rows = 8;
+        let mut writer = PackedWriter::new(schema(), block_rows);
+
+        for batch in 0..500 {
+            push_rows(
+                &mut writer,
+                (0..7)
+                    .map(|index| row(batch * 7 + index, Some(1.0), 0))
+                    .collect(),
+            );
+            assert!(
+                writer.buffered.len() < block_rows,
+                "a full block must be emitted rather than held: {} buffered",
+                writer.buffered.len()
+            );
+        }
+        let _ = flush_of(&mut writer);
+        assert!(
+            writer.buffered.is_empty(),
+            "the flush must empty the buffer"
+        );
+    }
+
+    /// A rule id equal to the symbol still masks to itself.
+    ///
+    /// The symbol holds dictionary entry 0 and is never a label, so the mask
+    /// starts at entry 1. Without that, a rule id that happens to equal the
+    /// symbol would take bit 0 and be reconstructed AHEAD of every other rule
+    /// id, which is a different `labels` string from the one the text
+    /// encodings render — and both charsets allow the collision.
+    #[test]
+    fn test_a_rule_id_equal_to_the_symbol_keeps_its_place() {
+        let schema = BinarySchema {
+            names: vec!["labels"],
+            types: vec![CellType::LabelMask],
+            // The symbol is `weeklies`, and so is one of the rules.
+            dictionary: vec![
+                "weeklies".to_string(),
+                "monthlies".to_string(),
+                "weeklies".to_string(),
+            ],
+        };
+
+        let labels = vec!["monthlies".to_string(), "weeklies".to_string()];
+        let mask = match schema.label_mask(&labels) {
+            Ok(mask) => mask,
+            Err(error) => panic!("both labels are rule ids: {error}"),
+        };
+
+        assert_eq!(
+            schema.labels_of(mask).join("|"),
+            "monthlies|weeklies",
+            "the order must be the text encodings' order"
+        );
+    }
+
+    /// A label the schedule does not name is an error, not a dropped bit.
+    #[test]
+    fn test_an_unknown_label_is_refused() {
+        match schema().label_mask(&["not_a_rule".to_string()]) {
+            Ok(mask) => panic!("an unknown label must not mask silently, got {mask}"),
+            Err(ChainError::Internal(message)) => {
+                assert!(message.contains("not_a_rule"), "it must name it: {message}");
+            }
+            Err(error) => panic!("expected an internal failure, got {error:?}"),
+        }
+    }
+
+    /// A truncated document is refused rather than read as a shorter tape.
+    #[test]
+    fn test_a_truncated_document_is_refused() {
+        let mut writer = PackedWriter::new(schema(), 2);
+        let mut document = header_of(&writer);
+        for block in push_rows(
+            &mut writer,
+            vec![row(0, Some(1.0), 0), row(1, Some(2.0), 0)],
+        ) {
+            document.extend(block);
+        }
+        document.extend(flush_of(&mut writer));
+
+        // Everything but the footer: what a dropped connection leaves behind.
+        let truncated = &document[..document.len() - ALIGNMENT * 2];
+        match decode_packed(truncated) {
+            Ok((_, rows)) => panic!("a truncated document must not decode, got {rows:?}"),
+            Err(ChainError::Internal(message)) => {
+                assert!(message.contains("truncated"), "{message}");
+            }
+            Err(error) => panic!("expected an internal failure, got {error:?}"),
+        }
+    }
+
+    /// A schedule too wide to mask is refused, rather than silently truncated.
+    #[test]
+    fn test_too_many_rules_are_refused() {
+        let mut schema = schema();
+        schema.dictionary = std::iter::once("SPX".to_string())
+            .chain((0..MAX_LABEL_RULES + 1).map(|index| format!("rule_{index}")))
+            .collect();
+
+        match ensure_label_capacity(&schema) {
+            Ok(()) => panic!("a schema wider than the mask must be refused"),
+            Err(ChainError::Internal(message)) => {
+                assert!(
+                    message.contains(&MAX_LABEL_RULES.to_string()),
+                    "the failure must name the bound: {message}"
+                );
+            }
+            Err(error) => panic!("expected an internal failure, got {error:?}"),
+        }
+    }
+
+    /// A document round-trips through the documented layout.
+    ///
+    /// The decoder walks the bytes the way the module doc describes rather than
+    /// reading the writer's fields, so the two can only agree if the layout is
+    /// what it says it is.
+    #[test]
+    fn test_a_document_round_trips_through_the_decoder() {
+        let mut writer = PackedWriter::new(schema(), 2);
+        let mut bytes = header_of(&writer);
+        for block in push_rows(
+            &mut writer,
+            vec![
+                row(0, Some(1.5), 0b101),
+                row(1, None, 0),
+                row(2, Some(-3.25), 0b001),
+            ],
+        ) {
+            bytes.extend(block);
+        }
+        bytes.extend(flush_of(&mut writer));
+
+        match decode_packed(&bytes) {
+            Ok((names, rows)) => {
+                assert_eq!(
+                    names,
+                    vec!["step", "simulated_at", "symbol", "labels", "price"]
+                );
+                assert_eq!(rows.len(), 3);
+                assert_eq!(rows[0][0], "0");
+                assert_eq!(rows[0][1], "2026-01-05T14:30:00Z");
+                assert_eq!(rows[0][2], "SPX");
+                assert_eq!(rows[0][3], "monthlies|zero_dte");
+                assert_eq!(rows[0][4], "1.5");
+                assert_eq!(rows[1][4], "", "a null decodes as an absent value");
+                assert_eq!(rows[2][4], "-3.25");
+                assert_eq!(rows[2][3], "monthlies");
+            }
+            Err(error) => panic!("the document must decode: {error}"),
+        }
+    }
+
+    /// A row's cells line up with the schema that describes them.
+    #[test]
+    fn test_a_row_matches_its_schema() {
+        let schema = schema();
+        let row = row(0, Some(1.0), 0);
+
+        assert_eq!(row.len(), schema.types.len());
+        for (cell, expected) in row.iter().zip(&schema.types) {
+            assert_eq!(cell.cell_type(), *expected);
+        }
+    }
+
+    /// A schedule that fits is accepted.
+    #[test]
+    fn test_a_schedule_that_fits_is_accepted() {
+        match ensure_label_capacity(&schema()) {
+            Ok(()) => {}
+            Err(error) => panic!("three rules must fit in a 64-bit mask: {error}"),
+        }
+    }
+}

--- a/src/api/rest/binary.rs
+++ b/src/api/rest/binary.rs
@@ -332,6 +332,28 @@ pub(super) fn timestamp_nanos(instant: DateTime<Utc>) -> i64 {
 /// The same shape, in the same order, as the module's `csv_rows` produces as
 /// strings — deliberately built from the same view types rather than from a
 /// second traversal, so the encodings cannot disagree about what a row is.
+/// Everything one step's rows are built from.
+///
+/// Grouped rather than passed as seven parameters: they are one thing — the
+/// step being encoded — and they travel together to both the visitor and the
+/// collecting helper beside it.
+pub(super) struct RowContext<'a> {
+    /// The columns being written, and the dictionary behind them.
+    pub(super) schema: &'a BinarySchema,
+    /// Which dataset the rows belong to.
+    pub(super) dataset: Dataset,
+    /// How much of the greek set the rows carry.
+    pub(super) level: GreekLevel,
+    /// The step index.
+    pub(super) step: usize,
+    /// The simulated instant of the step.
+    pub(super) simulated_at: DateTime<Utc>,
+    /// The factor row the step was priced from.
+    pub(super) row: &'a FactorRow,
+    /// The step's chains, absent for the datasets that carry none.
+    pub(super) chains: Option<super::export::StepChains<'a>>,
+}
+
 /// Whether a row visitor wants more rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RowFlow {
@@ -355,20 +377,24 @@ pub(super) enum RowFlow {
 /// simulation's schedule does not name, which would make the binary `labels`
 /// column disagree with the text one, and whatever the visitor returns.
 pub(super) fn visit_typed_rows<F>(
-    schema: &BinarySchema,
-    dataset: Dataset,
-    level: GreekLevel,
-    step: usize,
-    simulated_at: DateTime<Utc>,
-    row: &FactorRow,
-    chains: Option<super::export::StepChains<'_>>,
+    context: &RowContext<'_>,
     visit: &mut F,
 ) -> Result<RowFlow, ChainError>
 where
     F: FnMut(Vec<Cell>) -> Result<RowFlow, ChainError>,
 {
-    let step_cell = Cell::I64(i64::try_from(step).unwrap_or(i64::MAX));
-    let instant = Cell::Timestamp(timestamp_nanos(simulated_at));
+    let RowContext {
+        schema,
+        dataset,
+        level,
+        step,
+        simulated_at,
+        row,
+        chains,
+    } = context;
+
+    let step_cell = Cell::I64(i64::try_from(*step).unwrap_or(i64::MAX));
+    let instant = Cell::Timestamp(timestamp_nanos(*simulated_at));
     let symbol = Cell::Dictionary(schema.symbol_index());
 
     match dataset {
@@ -455,103 +481,19 @@ where
     }
 }
 
-/// The same rows, collected. Test-only: the serving path visits them one at a
-/// time so that neither memory nor cancellation latency scales with a step.
+/// The same rows, collected.
+///
+/// Test-only, and written over the visitor rather than beside it: two copies of
+/// the row builder would be two things to keep in step, and only one of them
+/// would be the one that ships.
 #[cfg(test)]
-pub(super) fn typed_rows(
-    schema: &BinarySchema,
-    dataset: Dataset,
-    level: GreekLevel,
-    step: usize,
-    simulated_at: DateTime<Utc>,
-    row: &FactorRow,
-    chains: Option<super::export::StepChains<'_>>,
-) -> Result<Vec<Vec<Cell>>, ChainError> {
-    let step_cell = Cell::I64(i64::try_from(step).unwrap_or(i64::MAX));
-    let instant = Cell::Timestamp(timestamp_nanos(simulated_at));
-    let symbol = Cell::Dictionary(schema.symbol_index());
-
-    Ok(match dataset {
-        Dataset::Underlying => vec![vec![
-            step_cell,
-            instant,
-            symbol,
-            Cell::F64(Some(row.spot.to_f64())),
-        ]],
-        Dataset::Volatility => vec![vec![
-            step_cell,
-            instant,
-            symbol,
-            Cell::F64(Some(row.base_volatility.to_f64())),
-        ]],
-        Dataset::OptionChains => {
-            let Some(chains) = chains else {
-                return Ok(Vec::new());
-            };
-            let mut rows = Vec::new();
-            for expiration in chains.expirations() {
-                let expires_at = Cell::Timestamp(timestamp_nanos(expiration.expires_at));
-                let labels = Cell::LabelMask(schema.label_mask(expiration.labels)?);
-                for quote in expiration.quotes.quotes() {
-                    let mut cells = vec![
-                        step_cell,
-                        instant,
-                        symbol,
-                        expires_at,
-                        labels,
-                        Cell::F64(Some(expiration.days_to_expiration)),
-                        Cell::F64(Some(quote.strike)),
-                        Cell::F64(Some(quote.implied_volatility)),
-                        Cell::F64(quote.call_bid),
-                        Cell::F64(quote.call_ask),
-                        Cell::F64(quote.call_mid),
-                        Cell::F64(quote.call_delta),
-                        Cell::F64(quote.put_bid),
-                        Cell::F64(quote.put_ask),
-                        Cell::F64(quote.put_mid),
-                        Cell::F64(quote.put_delta),
-                        Cell::F64(quote.gamma),
-                    ];
-                    if level.wants_greeks() {
-                        for value in [
-                            quote.call_greeks.theta,
-                            quote.put_greeks.theta,
-                            quote.call_greeks.vega,
-                            quote.put_greeks.vega,
-                            quote.call_greeks.rho,
-                            quote.put_greeks.rho,
-                            quote.call_greeks.rho_d,
-                            quote.put_greeks.rho_d,
-                        ] {
-                            cells.push(Cell::F64(value));
-                        }
-                    }
-                    if matches!(level, GreekLevel::All) {
-                        for value in [
-                            quote.call_greeks.gamma,
-                            quote.put_greeks.gamma,
-                            quote.call_greeks.alpha,
-                            quote.put_greeks.alpha,
-                            quote.call_greeks.vanna,
-                            quote.put_greeks.vanna,
-                            quote.call_greeks.vomma,
-                            quote.put_greeks.vomma,
-                            quote.call_greeks.veta,
-                            quote.put_greeks.veta,
-                            quote.call_greeks.charm,
-                            quote.put_greeks.charm,
-                            quote.call_greeks.color,
-                            quote.put_greeks.color,
-                        ] {
-                            cells.push(Cell::F64(value));
-                        }
-                    }
-                    rows.push(cells);
-                }
-            }
-            rows
-        }
-    })
+pub(super) fn typed_rows(context: &RowContext<'_>) -> Result<Vec<Vec<Cell>>, ChainError> {
+    let mut rows = Vec::new();
+    visit_typed_rows(context, &mut |cells| {
+        rows.push(cells);
+        Ok(RowFlow::Continue)
+    })?;
+    Ok(rows)
 }
 
 /// Encodes `packed` blocks.

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -50,7 +50,8 @@
 //! backtest harness cache a download and know it is still current.
 
 use crate::api::rest::binary::{
-    BinarySchema, CellType, PackedWriter, RowFlow, ensure_label_capacity, visit_typed_rows,
+    BinarySchema, CellType, PackedWriter, RowContext, RowFlow, ensure_label_capacity,
+    visit_typed_rows,
 };
 use crate::api::rest::error::map_error;
 use crate::api::rest::greeks::GreekLevel;
@@ -1303,24 +1304,24 @@ impl Writer {
                 // mutably: the schema is a handful of small vectors, next to
                 // nothing beside pricing a chain.
                 let schema = writer.schema().clone();
-                let flow = visit_typed_rows(
-                    &schema,
-                    *dataset,
-                    *level,
+                let context = RowContext {
+                    schema: &schema,
+                    dataset: *dataset,
+                    level: *level,
                     step,
-                    row.simulated_at,
+                    simulated_at: row.simulated_at,
                     row,
                     chains,
-                    &mut |cells| {
-                        let Some(block) = writer.push_row(cells)? else {
-                            return Ok(RowFlow::Continue);
-                        };
-                        if emit(block) == Delivery::ClientGone {
-                            return Ok(RowFlow::Stop);
-                        }
-                        Ok(RowFlow::Continue)
-                    },
-                )?;
+                };
+                let flow = visit_typed_rows(&context, &mut |cells| {
+                    let Some(block) = writer.push_row(cells)? else {
+                        return Ok(RowFlow::Continue);
+                    };
+                    if emit(block) == Delivery::ClientGone {
+                        return Ok(RowFlow::Stop);
+                    }
+                    Ok(RowFlow::Continue)
+                })?;
                 Ok(match flow {
                     RowFlow::Continue => Delivery::Sent,
                     RowFlow::Stop => Delivery::ClientGone,
@@ -1336,24 +1337,24 @@ impl Writer {
                 // mutably: the schema is a handful of small vectors, next to
                 // nothing beside pricing a chain.
                 let schema = writer.schema().clone();
-                let flow = visit_typed_rows(
-                    &schema,
-                    *dataset,
-                    *level,
+                let context = RowContext {
+                    schema: &schema,
+                    dataset: *dataset,
+                    level: *level,
                     step,
-                    row.simulated_at,
+                    simulated_at: row.simulated_at,
                     row,
                     chains,
-                    &mut |cells| {
-                        let Some(batch) = writer.push_row(cells)? else {
-                            return Ok(RowFlow::Continue);
-                        };
-                        if emit(batch) == Delivery::ClientGone {
-                            return Ok(RowFlow::Stop);
-                        }
-                        Ok(RowFlow::Continue)
-                    },
-                )?;
+                };
+                let flow = visit_typed_rows(&context, &mut |cells| {
+                    let Some(batch) = writer.push_row(cells)? else {
+                        return Ok(RowFlow::Continue);
+                    };
+                    if emit(batch) == Delivery::ClientGone {
+                        return Ok(RowFlow::Stop);
+                    }
+                    Ok(RowFlow::Continue)
+                })?;
                 Ok(match flow {
                     RowFlow::Continue => Delivery::Sent,
                     RowFlow::Stop => Delivery::ClientGone,
@@ -2335,15 +2336,16 @@ mod tests {
         ] {
             for level in [GreekLevel::None, GreekLevel::First, GreekLevel::All] {
                 let schema = BinarySchema::new(dataset, level, &parameters);
-                let rows = match crate::api::rest::binary::typed_rows(
-                    &schema,
+                let context = crate::api::rest::binary::RowContext {
+                    schema: &schema,
                     dataset,
                     level,
-                    0,
-                    row.simulated_at,
+                    step: 0,
+                    simulated_at: row.simulated_at,
                     row,
-                    Some(StepChains::Replayed(&chains)),
-                ) {
+                    chains: Some(StepChains::Replayed(&chains)),
+                };
+                let rows = match crate::api::rest::binary::typed_rows(&context) {
                     Ok(rows) => rows,
                     Err(error) => panic!("{dataset:?} at {level:?} must encode: {error}"),
                 };

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -50,7 +50,7 @@
 //! backtest harness cache a download and know it is still current.
 
 use crate::api::rest::binary::{
-    BinarySchema, CellType, PackedWriter, ensure_label_capacity, typed_rows,
+    BinarySchema, CellType, PackedWriter, RowFlow, ensure_label_capacity, visit_typed_rows,
 };
 use crate::api::rest::error::map_error;
 use crate::api::rest::greeks::GreekLevel;
@@ -1287,26 +1287,44 @@ impl Writer {
                 }
                 Ok(Delivery::Sent)
             }
+            // Both binary arms feed the writer ONE ROW AT A TIME and hand each
+            // finished block straight to `emit`. Collecting a step's rows first
+            // would make the footprint a function of the chain size rather than
+            // of the block width, and would delay noticing a disconnected
+            // client until a whole step had been encoded — at the snapshot
+            // contract cap, that is the difference the block width is supposed
+            // to buy.
             Writer::Packed {
                 dataset,
                 level,
                 writer,
             } => {
-                let rows = typed_rows(
-                    writer.schema(),
+                // Cloned once per step so the visitor can hold the writer
+                // mutably: the schema is a handful of small vectors, next to
+                // nothing beside pricing a chain.
+                let schema = writer.schema().clone();
+                let flow = visit_typed_rows(
+                    &schema,
                     *dataset,
                     *level,
                     step,
                     row.simulated_at,
                     row,
                     chains,
+                    &mut |cells| {
+                        let Some(block) = writer.push_row(cells)? else {
+                            return Ok(RowFlow::Continue);
+                        };
+                        if emit(block) == Delivery::ClientGone {
+                            return Ok(RowFlow::Stop);
+                        }
+                        Ok(RowFlow::Continue)
+                    },
                 )?;
-                for block in writer.push(rows)? {
-                    if emit(block) == Delivery::ClientGone {
-                        return Ok(Delivery::ClientGone);
-                    }
-                }
-                Ok(Delivery::Sent)
+                Ok(match flow {
+                    RowFlow::Continue => Delivery::Sent,
+                    RowFlow::Stop => Delivery::ClientGone,
+                })
             }
             #[cfg(feature = "arrow-export")]
             Writer::Arrow {
@@ -1314,21 +1332,32 @@ impl Writer {
                 level,
                 writer,
             } => {
-                let rows = typed_rows(
-                    writer.schema(),
+                // Cloned once per step so the visitor can hold the writer
+                // mutably: the schema is a handful of small vectors, next to
+                // nothing beside pricing a chain.
+                let schema = writer.schema().clone();
+                let flow = visit_typed_rows(
+                    &schema,
                     *dataset,
                     *level,
                     step,
                     row.simulated_at,
                     row,
                     chains,
+                    &mut |cells| {
+                        let Some(batch) = writer.push_row(cells)? else {
+                            return Ok(RowFlow::Continue);
+                        };
+                        if emit(batch) == Delivery::ClientGone {
+                            return Ok(RowFlow::Stop);
+                        }
+                        Ok(RowFlow::Continue)
+                    },
                 )?;
-                for batch in writer.push(rows)? {
-                    if emit(batch) == Delivery::ClientGone {
-                        return Ok(Delivery::ClientGone);
-                    }
-                }
-                Ok(Delivery::Sent)
+                Ok(match flow {
+                    RowFlow::Continue => Delivery::Sent,
+                    RowFlow::Stop => Delivery::ClientGone,
+                })
             }
         }
     }
@@ -2167,6 +2196,111 @@ mod tests {
             narrow_rows, wide_rows,
             "the block width must not change a single value"
         );
+    }
+
+    /// A binary step emits blocks AS THEY FILL, not after the step.
+    ///
+    /// The claim the block width exists to make: at the snapshot contract cap a
+    /// step can carry two hundred thousand rows, so collecting them before the
+    /// first block reached the client would make memory a function of the chain
+    /// size and would delay noticing a disconnect until the whole step had been
+    /// encoded. Asserted by counting how many blocks arrive before the step
+    /// finishes, at a block width of two.
+    #[actix_web::test]
+    async fn test_a_binary_step_emits_blocks_as_they_fill() {
+        let parameters = reference_parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let row = match tape.row(0) {
+            Some(row) => row,
+            None => panic!("the tape must have a first row"),
+        };
+        let chains = match snapshot_of(&parameters, &tape, 0) {
+            Some(snapshot) => snapshot,
+            None => panic!("step zero must produce chains"),
+        };
+
+        let mut writer = match Writer::new(
+            Format::Packed,
+            Dataset::OptionChains,
+            GreekLevel::None,
+            &parameters,
+            2,
+        ) {
+            Ok(writer) => writer,
+            Err(error) => panic!("the writer must build: {error}"),
+        };
+
+        let mut blocks = 0_usize;
+        match writer.rows(
+            &parameters,
+            0,
+            row,
+            Some(StepChains::Replayed(&chains)),
+            &mut |_chunk| {
+                blocks += 1;
+                Delivery::Sent
+            },
+        ) {
+            Ok(Delivery::Sent) => {}
+            other => panic!("the rows must be delivered, got {other:?}"),
+        }
+
+        assert!(
+            blocks > 1,
+            "one step must produce several blocks at a width of two, got {blocks}"
+        );
+    }
+
+    /// A disconnect stops the step at the block it happened on.
+    #[actix_web::test]
+    async fn test_a_disconnect_stops_a_binary_step_immediately() {
+        let parameters = reference_parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let row = match tape.row(0) {
+            Some(row) => row,
+            None => panic!("the tape must have a first row"),
+        };
+        let chains = match snapshot_of(&parameters, &tape, 0) {
+            Some(snapshot) => snapshot,
+            None => panic!("step zero must produce chains"),
+        };
+
+        let mut writer = match Writer::new(
+            Format::Packed,
+            Dataset::OptionChains,
+            GreekLevel::None,
+            &parameters,
+            2,
+        ) {
+            Ok(writer) => writer,
+            Err(error) => panic!("the writer must build: {error}"),
+        };
+
+        let mut delivered = 0_usize;
+        let outcome = writer.rows(
+            &parameters,
+            0,
+            row,
+            Some(StepChains::Replayed(&chains)),
+            &mut |_chunk| {
+                delivered += 1;
+                Delivery::ClientGone
+            },
+        );
+
+        match outcome {
+            Ok(Delivery::ClientGone) => assert_eq!(
+                delivered, 1,
+                "the step must stop at the first refused block, not encode the rest"
+            ),
+            other => panic!("a gone client must be reported, got {other:?}"),
+        }
     }
 
     /// A row's cell types are the ones the schema declares, for every dataset

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -49,8 +49,12 @@
 //! formatting — no locale, no thousands separators. That is what lets a
 //! backtest harness cache a download and know it is still current.
 
+use crate::api::rest::binary::{
+    BinarySchema, CellType, PackedWriter, ensure_label_capacity, typed_rows,
+};
 use crate::api::rest::error::map_error;
 use crate::api::rest::greeks::GreekLevel;
+use crate::api::rest::limits::EXPORT_BLOCK_ROWS;
 use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot};
 use crate::infrastructure::{
@@ -116,6 +120,13 @@ pub(crate) enum Format {
     Json,
     /// RFC 4180 CSV with a header row and CRLF line endings.
     Csv,
+    /// Arrow IPC stream, one record batch per block. Available only when the
+    /// crate is built with the `arrow-export` feature; without it a request for
+    /// this format is a typed 400 rather than a 500 or a silent fallback.
+    Arrow,
+    /// The `packed` columnar block format: no dependencies, 8-byte aligned
+    /// payloads, described in [`crate::api::rest::binary`].
+    Packed,
 }
 
 impl Format {
@@ -125,7 +136,15 @@ impl Format {
         match self {
             Format::Json => "application/json",
             Format::Csv => "text/csv; charset=utf-8",
+            Format::Arrow => "application/vnd.apache.arrow.stream",
+            Format::Packed => "application/octet-stream",
         }
+    }
+
+    /// Whether this encoding is binary, and therefore columnar and blocked.
+    #[must_use]
+    fn is_binary(self) -> bool {
+        matches!(self, Format::Arrow | Format::Packed)
     }
 
     /// The extension of the suggested download filename.
@@ -134,6 +153,8 @@ impl Format {
         match self {
             Format::Json => "json",
             Format::Csv => "csv",
+            Format::Arrow => "arrow",
+            Format::Packed => "ocsp",
         }
     }
 }
@@ -226,7 +247,7 @@ impl Dataset {
     /// by position as well as by name. `greeks` is ignored by the two datasets
     /// that carry no chains.
     #[must_use]
-    fn header(self, level: GreekLevel) -> Vec<&'static str> {
+    pub(super) fn header(self, level: GreekLevel) -> Vec<&'static str> {
         match self {
             Dataset::Underlying => vec!["step", "simulated_at", "symbol", "price"],
             Dataset::Volatility => vec!["step", "simulated_at", "symbol", "base_volatility"],
@@ -259,22 +280,22 @@ impl Dataset {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub(crate) struct ExportQuery {
     /// Which dataset to export.
-    pub(crate) dataset: Dataset,
+    pub(super) dataset: Dataset,
     /// Which encoding to return.
-    pub(crate) format: Format,
+    pub(super) format: Format,
     /// First step to include, inclusive. Defaults to `0`.
     #[serde(default)]
-    pub(crate) from_step: Option<usize>,
+    pub(super) from_step: Option<usize>,
     /// Last step to include, inclusive. Defaults to the final generated step.
     #[serde(default)]
-    pub(crate) to_step: Option<usize>,
+    pub(super) to_step: Option<usize>,
     /// How much of the greek set the `option_chains` dataset carries: `none`
     /// (the default), `first` or `all` — the same vocabulary and the same
     /// default as the chain endpoints, so a tape and a live step agree on what
     /// a level means. Kept as a raw string so an unknown value is a typed `400`
     /// naming the field.
     #[serde(default)]
-    pub(crate) greeks: Option<String>,
+    pub(super) greeks: Option<String>,
 }
 
 /// A validated, inclusive step range.
@@ -382,29 +403,29 @@ fn render_optional(value: Option<f64>) -> String {
 /// CSV writes `4950`, and takes exponent form below `1e-5` where the CSV spells
 /// the zeros out. Compare the two encodings as numbers.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-struct GreeksView {
+pub(super) struct GreeksView {
     /// This side's `gamma`.
-    gamma: Option<f64>,
+    pub(super) gamma: Option<f64>,
     /// This side's `theta`.
-    theta: Option<f64>,
+    pub(super) theta: Option<f64>,
     /// This side's `vega`.
-    vega: Option<f64>,
+    pub(super) vega: Option<f64>,
     /// This side's `rho`.
-    rho: Option<f64>,
+    pub(super) rho: Option<f64>,
     /// This side's `rho_d`.
-    rho_d: Option<f64>,
+    pub(super) rho_d: Option<f64>,
     /// This side's `alpha`.
-    alpha: Option<f64>,
+    pub(super) alpha: Option<f64>,
     /// This side's `vanna`.
-    vanna: Option<f64>,
+    pub(super) vanna: Option<f64>,
     /// This side's `vomma`.
-    vomma: Option<f64>,
+    pub(super) vomma: Option<f64>,
     /// This side's `veta`.
-    veta: Option<f64>,
+    pub(super) veta: Option<f64>,
     /// This side's `charm`.
-    charm: Option<f64>,
+    pub(super) charm: Option<f64>,
     /// This side's `color`.
-    color: Option<f64>,
+    pub(super) color: Option<f64>,
 }
 
 impl GreeksView {
@@ -456,22 +477,22 @@ impl GreeksView {
 /// value to the wire's `f64` happens here and only here, which is what makes a
 /// persisted row and a replayed row byte-identical rather than merely similar.
 #[derive(Debug, Clone, Copy, PartialEq)]
-struct QuoteView {
-    strike: f64,
-    implied_volatility: f64,
-    call_bid: Option<f64>,
-    call_ask: Option<f64>,
-    call_mid: Option<f64>,
-    call_delta: Option<f64>,
-    put_bid: Option<f64>,
-    put_ask: Option<f64>,
-    put_mid: Option<f64>,
-    put_delta: Option<f64>,
-    gamma: Option<f64>,
+pub(super) struct QuoteView {
+    pub(super) strike: f64,
+    pub(super) implied_volatility: f64,
+    pub(super) call_bid: Option<f64>,
+    pub(super) call_ask: Option<f64>,
+    pub(super) call_mid: Option<f64>,
+    pub(super) call_delta: Option<f64>,
+    pub(super) put_bid: Option<f64>,
+    pub(super) put_ask: Option<f64>,
+    pub(super) put_mid: Option<f64>,
+    pub(super) put_delta: Option<f64>,
+    pub(super) gamma: Option<f64>,
     /// The call's greek snapshot, empty below `greeks=first`.
-    call_greeks: GreeksView,
+    pub(super) call_greeks: GreeksView,
     /// The put's greek snapshot, empty below `greeks=first`.
-    put_greeks: GreeksView,
+    pub(super) put_greeks: GreeksView,
 }
 
 impl QuoteView {
@@ -518,7 +539,7 @@ impl QuoteView {
 
 /// The strikes of one expiration, from whichever source produced them.
 #[derive(Debug, Clone, Copy)]
-enum QuoteSource<'a> {
+pub(super) enum QuoteSource<'a> {
     /// Upstream's priced chain, iterated by ascending strike.
     Replayed(&'a OptionChain),
     /// The stored rows, which the repository returns by ascending strike.
@@ -531,7 +552,7 @@ impl<'a> QuoteSource<'a> {
     /// Exactly one of the two options is `Some`, so concatenating them with
     /// [`Iterator::chain`] *is* the branch — one concrete iterator type, no
     /// boxing on a path that runs once per contract.
-    fn quotes(self) -> impl Iterator<Item = QuoteView> + 'a {
+    pub(super) fn quotes(self) -> impl Iterator<Item = QuoteView> + 'a {
         let replayed = match self {
             QuoteSource::Replayed(chain) => Some(chain.iter()),
             QuoteSource::Stored(_) => None,
@@ -551,11 +572,11 @@ impl<'a> QuoteSource<'a> {
 
 /// One expiration of one step, from whichever source produced it.
 #[derive(Debug, Clone, Copy)]
-struct ExpirationView<'a> {
-    expires_at: DateTime<Utc>,
-    days_to_expiration: f64,
-    labels: &'a [String],
-    quotes: QuoteSource<'a>,
+pub(super) struct ExpirationView<'a> {
+    pub(super) expires_at: DateTime<Utc>,
+    pub(super) days_to_expiration: f64,
+    pub(super) labels: &'a [String],
+    pub(super) quotes: QuoteSource<'a>,
 }
 
 /// The chains of one step, from whichever source produced them.
@@ -565,7 +586,7 @@ struct ExpirationView<'a> {
 /// the two sources one view — instead of two row builders that happen to agree
 /// today — is what makes preferring the warehouse safe.
 #[derive(Debug, Clone, Copy)]
-enum StepChains<'a> {
+pub(super) enum StepChains<'a> {
     /// Priced here and now, from the effective parameters.
     Replayed(&'a SeriesSnapshot),
     /// Read back from the warehouse exactly as it was served.
@@ -574,7 +595,7 @@ enum StepChains<'a> {
 
 impl<'a> StepChains<'a> {
     /// The live expirations, ascending — the order both sources guarantee.
-    fn expirations(self) -> impl Iterator<Item = ExpirationView<'a>> {
+    pub(super) fn expirations(self) -> impl Iterator<Item = ExpirationView<'a>> {
         let replayed = match self {
             StepChains::Replayed(snapshot) => Some(snapshot.chains.iter()),
             StepChains::Stored(_) => None,
@@ -788,7 +809,8 @@ impl Stream for RowStream {
 #[utoipa::path(
     get,
     path = "/api/v2/simulations/{id}/export",
-    description = "Export a simulation's complete tape, or a step range of it, as JSON or CSV. \
+    description = "Export a simulation's complete tape, or a step range of it, as JSON, CSV, or one \
+        of the two binary encodings (Arrow IPC and the dependency-free `packed` columnar format). \
         Read-only: it replays from an immutable snapshot of the effective parameters and never \
         advances the cursor, changes the state or version, or alters what the next peek returns. \
         A simulation that has not been walked at all exports its whole tape. Where snapshot \
@@ -797,18 +819,19 @@ impl Stream for RowStream {
         a single array of row objects; CSV is RFC 4180 with a header row and CRLF line endings. \
         Repeating the same export at the same greek level yields byte-identical output. The two \
         encodings carry the same values, though not always the same notation: JSON takes exponent \
-        form for very small numbers where the CSV spells them out.",
+        form for very small numbers where the CSV spells them out. The binary encodings carry the \
+        same values again, in blocks, with the same column names in the same order.",
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
         ("dataset" = String, Query, description = "underlying | volatility | option_chains"),
-        ("format" = String, Query, description = "json | csv"),
+        ("format" = String, Query, description = "json | csv | arrow | packed. The two binary encodings carry the same values as the text ones, in blocks of OCS_EXPORT_BLOCK_ROWS rows, with the same column names in the same order. Numeric columns are f64, exactly what json and csv render: binary is a faster route to the same numbers, NOT a route to the underlying Decimal(38, 28) precision. `arrow` is an Arrow IPC stream and is available only when the service is built with the `arrow-export` feature; asking for it otherwise is a 400 naming the format. `packed` is a dependency-free columnar block format with 8-byte aligned payloads, documented in the crate docs, whose `labels` column is a bitmask over the schedule's rule ids."),
         ("from_step" = Option<usize>, Query, description = "First step, inclusive; defaults to 0"),
         ("to_step" = Option<usize>, Query, description = "Last step, inclusive; defaults to the final step"),
         ("greeks" = Option<String>, Query, description = "How much of the greek set the option_chains dataset carries: `none` (default), `first` (appends call_theta, put_theta, call_vega, put_vega, call_rho, put_rho, call_rho_d, put_rho_d) or `all` (appends seven more per style, gamma through color: fourteen columns). Each level's header is a PREFIX of the next, so raising it appends columns and never moves one. Values are per ONE LONG CONTRACT. Accepted but immaterial for the underlying and volatility datasets, which carry no chains. An unknown value is a 400")
     ),
     responses(
-        (status = 200, description = "The exported rows, streamed", body = String),
-        (status = 400, description = "Every rejection carries the typed `{error, field}` of ValidationErrorResponse. `field` names the offender where it is known — `id` for a malformed identifier, `from_step` or `to_step` for a range that is reversed or past the tape, `greeks` for an unknown level. It is EMPTY when the query string fails to deserialise at all (an unknown `dataset` or `format`, a non-numeric step), because serde's message for those does not name the key; the `error` string carries the detail.", body = crate::api::rest::responses::ValidationErrorResponse),
+        (status = 200, description = "The exported rows, streamed. Text for json and csv; an Arrow IPC stream or a packed columnar document, both binary, for arrow and packed.", body = String),
+        (status = 400, description = "Every rejection carries the typed `{error, field}` of ValidationErrorResponse. `field` names the offender where it is known — `id` for a malformed identifier, `from_step` or `to_step` for a range that is reversed or past the tape, `greeks` for an unknown level, `format` for `arrow` on a build without the `arrow-export` feature. It is EMPTY when the query string fails to deserialise at all (an unknown `dataset` or `format`, a non-numeric step), because serde's message for those does not name the key; the `error` string carries the detail.", body = crate::api::rest::responses::ValidationErrorResponse),
         (status = 404, description = "Simulation not found"),
         (status = 500, description = "Internal server error")
     )
@@ -862,6 +885,15 @@ pub(crate) async fn export_simulation(
 
     let dataset = query.dataset;
     let format = query.format;
+
+    // Checked HERE, not in the producer: the producer runs behind a streaming
+    // response whose header has already gone out, so a rejection raised there
+    // arrives mid-download instead of as the 400 it is. This covers `arrow` on
+    // a build without the feature, and a schedule too wide for a label mask.
+    if let Err(error) = check_format_available(format, dataset, level, &parameters) {
+        return map_error(error);
+    }
+
     let (sender, receiver) = mpsc::channel(CHANNEL_CAPACITY);
 
     // Only the chains dataset can be served from storage; the other two read the
@@ -898,6 +930,52 @@ pub(crate) async fn export_simulation(
             format!("attachment; filename=\"{filename}\""),
         ))
         .streaming(RowStream { receiver })
+}
+
+/// Whether this build, and this simulation, can serve a format.
+///
+/// The two ways a recognised format can still be unserveable: the `arrow`
+/// encoding needs the `arrow-export` feature, and both binary encodings need a
+/// schedule whose rule ids fit a label mask.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `format`.
+fn check_format_available(
+    format: Format,
+    dataset: Dataset,
+    level: GreekLevel,
+    parameters: &SimulationParametersV2,
+) -> Result<(), ChainError> {
+    if !format.is_binary() {
+        return Ok(());
+    }
+
+    #[cfg(not(feature = "arrow-export"))]
+    if matches!(format, Format::Arrow) {
+        return Err(arrow_unavailable());
+    }
+
+    let schema = BinarySchema::new(dataset, level, parameters);
+    // Only a dataset that actually carries labels can exceed the mask.
+    if schema.types.contains(&CellType::LabelMask) {
+        ensure_label_capacity(&schema)?;
+    }
+    Ok(())
+}
+
+/// The rejection a build without the `arrow-export` feature answers with.
+///
+/// One place, because it is served from two: the handler's up-front check and
+/// the writer's own arm, which is unreachable behind it and kept as defence.
+#[cfg(not(feature = "arrow-export"))]
+fn arrow_unavailable() -> ChainError {
+    ChainError::Validation {
+        field: "format".to_string(),
+        reason: "arrow is unavailable: this build does not have the `arrow-export` feature; \
+                 use packed, json or csv"
+            .to_string(),
+    }
 }
 
 /// Whether a stored record can answer a request for greeks.
@@ -945,7 +1023,10 @@ fn produce(
         None
     };
 
-    let mut writer = Writer::new(format, dataset, level)?;
+    // The block width is read once, here, rather than inside the writer: it is
+    // the export's memory floor, and passing it in is what lets a test drive
+    // several blocks without a process-wide environment variable.
+    let mut writer = Writer::new(format, dataset, level, parameters, *EXPORT_BLOCK_ROWS)?;
     if let Some(chunk) = writer.prologue()?
         && sender.blocking_send(Ok(chunk)).is_err()
     {
@@ -1031,11 +1112,47 @@ enum Writer {
     /// only surrenders its buffer by consuming itself, and constructing one is
     /// cheap next to pricing a chain.
     Csv { dataset: Dataset, level: GreekLevel },
+    /// The `packed` columnar block format. Buffers at most one block, which is
+    /// what keeps a columnar encoding streaming.
+    Packed {
+        dataset: Dataset,
+        level: GreekLevel,
+        writer: Box<PackedWriter>,
+    },
+    /// Arrow IPC stream, one record batch per block.
+    #[cfg(feature = "arrow-export")]
+    Arrow {
+        dataset: Dataset,
+        level: GreekLevel,
+        writer: Box<crate::api::rest::arrow_export::ArrowWriter>,
+    },
 }
 
 impl Writer {
     /// Creates a writer for a dataset and format.
-    fn new(format: Format, dataset: Dataset, level: GreekLevel) -> Result<Self, ChainError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] naming `format` when the request asks
+    /// for `arrow` on a build without the `arrow-export` feature, or for a
+    /// binary format on a simulation whose schedule carries more rules than a
+    /// label mask holds. Returns [`ChainError::Internal`] when an Arrow stream
+    /// cannot be opened.
+    fn new(
+        format: Format,
+        dataset: Dataset,
+        level: GreekLevel,
+        parameters: &SimulationParametersV2,
+        block_rows: usize,
+    ) -> Result<Self, ChainError> {
+        let binary_schema = if format.is_binary() {
+            let schema = BinarySchema::new(dataset, level, parameters);
+            ensure_label_capacity(&schema)?;
+            Some(schema)
+        } else {
+            None
+        };
+
         Ok(match format {
             Format::Json => Writer::Json {
                 dataset,
@@ -1043,6 +1160,36 @@ impl Writer {
                 first: true,
             },
             Format::Csv => Writer::Csv { dataset, level },
+            Format::Packed => {
+                let schema = match binary_schema {
+                    Some(schema) => schema,
+                    None => BinarySchema::new(dataset, level, parameters),
+                };
+                Writer::Packed {
+                    dataset,
+                    level,
+                    writer: Box::new(PackedWriter::new(schema, block_rows)),
+                }
+            }
+            #[cfg(feature = "arrow-export")]
+            Format::Arrow => {
+                let schema = match binary_schema {
+                    Some(schema) => schema,
+                    None => BinarySchema::new(dataset, level, parameters),
+                };
+                Writer::Arrow {
+                    dataset,
+                    level,
+                    writer: Box::new(crate::api::rest::arrow_export::ArrowWriter::new(
+                        schema, block_rows,
+                    )?),
+                }
+            }
+            // Recognised, and refused: the value is a valid format this BUILD
+            // cannot serve, which is a different answer from "no such format"
+            // and must never be a 500 or a silent fallback to another encoding.
+            #[cfg(not(feature = "arrow-export"))]
+            Format::Arrow => return Err(arrow_unavailable()),
         })
     }
 
@@ -1058,14 +1205,24 @@ impl Writer {
                     .collect();
                 Ok(Some(encode_csv(&[header])?))
             }
+            Writer::Packed { writer, .. } => Ok(Some(writer.header()?)),
+            #[cfg(feature = "arrow-export")]
+            Writer::Arrow { writer, .. } => Ok(Some(writer.header()?)),
         }
     }
 
     /// The bytes that close the document, if any.
+    ///
+    /// For the binary formats this is where the last, partial block goes: it
+    /// exists precisely because a columnar encoding cannot emit a block until
+    /// it is full or the rows run out.
     fn epilogue(&mut self) -> Result<Option<Vec<u8>>, ChainError> {
         match self {
             Writer::Json { .. } => Ok(Some(b"]".to_vec())),
             Writer::Csv { .. } => Ok(None),
+            Writer::Packed { writer, .. } => writer.flush(),
+            #[cfg(feature = "arrow-export")]
+            Writer::Arrow { writer, .. } => writer.finish(),
         }
     }
 
@@ -1125,6 +1282,49 @@ impl Writer {
                 let records = csv_rows(*dataset, *level, step, &simulated_at, symbol, row, chains);
                 for batch in records.chunks(ROWS_PER_CHUNK) {
                     if emit(encode_csv(batch)?) == Delivery::ClientGone {
+                        return Ok(Delivery::ClientGone);
+                    }
+                }
+                Ok(Delivery::Sent)
+            }
+            Writer::Packed {
+                dataset,
+                level,
+                writer,
+            } => {
+                let rows = typed_rows(
+                    writer.schema(),
+                    *dataset,
+                    *level,
+                    step,
+                    row.simulated_at,
+                    row,
+                    chains,
+                )?;
+                for block in writer.push(rows)? {
+                    if emit(block) == Delivery::ClientGone {
+                        return Ok(Delivery::ClientGone);
+                    }
+                }
+                Ok(Delivery::Sent)
+            }
+            #[cfg(feature = "arrow-export")]
+            Writer::Arrow {
+                dataset,
+                level,
+                writer,
+            } => {
+                let rows = typed_rows(
+                    writer.schema(),
+                    *dataset,
+                    *level,
+                    step,
+                    row.simulated_at,
+                    row,
+                    chains,
+                )?;
+                for batch in writer.push(rows)? {
+                    if emit(batch) == Delivery::ClientGone {
                         return Ok(Delivery::ClientGone);
                     }
                 }
@@ -1480,6 +1680,35 @@ mod tests {
         }};
     }
 
+    /// Downloads an export as raw bytes, for the binary encodings.
+    macro_rules! export_bytes {
+        ($app:expr, $id:expr, $query:expr) => {{
+            let uri = format!("/api/v2/simulations/{}/export?{}", $id, $query);
+            let response = actix_test::call_service(
+                &$app,
+                actix_test::TestRequest::get().uri(&uri).to_request(),
+            )
+            .await;
+            let status = response.status();
+            let body = actix_test::read_body(response).await;
+            (status, body.to_vec())
+        }};
+    }
+
+    /// The CSV body as rows of fields, header dropped.
+    fn csv_records_of(body: &str) -> Vec<Vec<String>> {
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_reader(body.as_bytes());
+        reader
+            .records()
+            .map(|record| match record {
+                Ok(record) => record.iter().map(ToString::to_string).collect(),
+                Err(error) => panic!("the csv must parse: {error}"),
+            })
+            .collect()
+    }
+
     /// Counts CSV data rows, excluding the header and the trailing terminator.
     fn csv_rows_of(body: &str) -> usize {
         body.split("\r\n").filter(|line| !line.is_empty()).count() - 1
@@ -1614,6 +1843,428 @@ mod tests {
 
         assert!(body.starts_with("step,simulated_at,symbol,price\r\n"));
         assert!(body.ends_with("\r\n"));
+    }
+
+    // ---- the binary encodings (issue #78) --------------------------------
+
+    /// A `packed` export decodes to exactly the values the CSV renders.
+    ///
+    /// The cross-format equality this issue is about, asserted per dataset and
+    /// per row: the binary encodings are a faster route to the same numbers,
+    /// not a different answer.
+    #[actix_web::test]
+    async fn test_a_packed_export_decodes_to_the_csv_values() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        for dataset in ["underlying", "volatility", "option_chains"] {
+            let (status, text) = export!(app, id, format!("dataset={dataset}&format=csv"));
+            assert_eq!(status, StatusCode::OK);
+            let (binary_status, bytes) =
+                export_bytes!(app, id, format!("dataset={dataset}&format=packed"));
+            assert_eq!(binary_status, StatusCode::OK);
+
+            let expected = csv_records_of(&text);
+            match crate::api::rest::binary::decode_packed(&bytes) {
+                Ok((names, rows)) => {
+                    assert_eq!(
+                        names,
+                        text.lines()
+                            .next()
+                            .unwrap_or_default()
+                            .split(',')
+                            .collect::<Vec<_>>(),
+                        "the packed columns must be the csv header, in order, for {dataset}"
+                    );
+                    assert_eq!(rows.len(), expected.len(), "row count for {dataset}");
+                    assert_eq!(rows, expected, "values for {dataset}");
+                }
+                Err(error) => panic!("the {dataset} export must decode: {error}"),
+            }
+        }
+    }
+
+    /// Exporting the same simulation twice produces byte-identical output, in
+    /// every format.
+    #[actix_web::test]
+    async fn test_every_format_is_byte_identical_on_repeat() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let mut formats = vec!["json", "csv", "packed"];
+        if cfg!(feature = "arrow-export") {
+            formats.push("arrow");
+        }
+        for format in formats {
+            let (_, first) =
+                export_bytes!(app, id, format!("dataset=option_chains&format={format}"));
+            let (_, second) =
+                export_bytes!(app, id, format!("dataset=option_chains&format={format}"));
+            assert_eq!(first, second, "{format} must be reproducible byte for byte");
+        }
+    }
+
+    /// `from_step` and `to_step` behave identically in the Arrow encoding.
+    #[cfg(feature = "arrow-export")]
+    #[actix_web::test]
+    async fn test_a_step_range_behaves_the_same_in_arrow() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let (_, text) = export!(
+            app,
+            id,
+            "dataset=underlying&format=csv&from_step=1&to_step=2"
+        );
+        let (status, bytes) = export_bytes!(
+            app,
+            id,
+            "dataset=underlying&format=arrow&from_step=1&to_step=2"
+        );
+        assert_eq!(status, StatusCode::OK);
+
+        match crate::api::rest::arrow_export::decode_stream(&bytes) {
+            Ok(rows) => assert_eq!(rows, csv_records_of(&text)),
+            Err(error) => panic!("the ranged export must decode: {error}"),
+        }
+
+        let (status, body) = export!(
+            app,
+            id,
+            "dataset=underlying&format=arrow&from_step=3&to_step=1"
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    }
+
+    /// `from_step` and `to_step` behave identically in the binary formats.
+    #[actix_web::test]
+    async fn test_a_step_range_behaves_the_same_in_packed() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let (_, text) = export!(
+            app,
+            id,
+            "dataset=underlying&format=csv&from_step=1&to_step=2"
+        );
+        let (status, bytes) = export_bytes!(
+            app,
+            id,
+            "dataset=underlying&format=packed&from_step=1&to_step=2"
+        );
+        assert_eq!(status, StatusCode::OK);
+
+        match crate::api::rest::binary::decode_packed(&bytes) {
+            Ok((_, rows)) => assert_eq!(rows, csv_records_of(&text)),
+            Err(error) => panic!("the ranged export must decode: {error}"),
+        }
+
+        // And an invalid range is refused the same way, before any bytes.
+        let (status, body) = export!(
+            app,
+            id,
+            "dataset=underlying&format=packed&from_step=3&to_step=1"
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    }
+
+    /// An absent value stays absent through the encoding.
+    ///
+    /// End to end, against whatever the fixture produces. The stronger
+    /// assertion — that a null is a cleared validity bit rather than a zero or
+    /// a NaN, which are both values a chain can legitimately hold — is pinned
+    /// at the encoder, in `binary::tests`.
+    #[actix_web::test]
+    async fn test_a_null_survives_the_packed_encoding() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let (_, text) = export!(app, id, "dataset=option_chains&format=csv");
+        let expected = csv_records_of(&text);
+        let empties: usize = expected
+            .iter()
+            .map(|record| record.iter().filter(|field| field.is_empty()).count())
+            .sum();
+
+        let (_, bytes) = export_bytes!(app, id, "dataset=option_chains&format=packed");
+        match crate::api::rest::binary::decode_packed(&bytes) {
+            Ok((_, rows)) => {
+                let decoded: usize = rows
+                    .iter()
+                    .map(|record| record.iter().filter(|field| field.is_empty()).count())
+                    .sum();
+                assert_eq!(decoded, empties, "every null must survive as a null");
+            }
+            Err(error) => panic!("the export must decode: {error}"),
+        }
+    }
+
+    /// The response advertises the format it actually sent.
+    #[actix_web::test]
+    async fn test_the_binary_formats_advertise_their_content_type() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let uri = format!("/api/v2/simulations/{id}/export?dataset=underlying&format=packed");
+        let response =
+            actix_test::call_service(&app, actix_test::TestRequest::get().uri(&uri).to_request())
+                .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(actix_web::http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/octet-stream")
+        );
+        let disposition = response
+            .headers()
+            .get(actix_web::http::header::CONTENT_DISPOSITION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(disposition.ends_with(".ocsp\""), "{disposition}");
+    }
+
+    /// Asking for `arrow` on a build without the feature is a typed 400 naming
+    /// the format, never a 500 and never a silent fallback to another encoding.
+    #[cfg(not(feature = "arrow-export"))]
+    #[actix_web::test]
+    async fn test_arrow_without_the_feature_is_a_typed_400() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        let (status, body) = export!(app, id, "dataset=underlying&format=arrow");
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error: Value = match serde_json::from_str(&body) {
+            Ok(error) => error,
+            Err(parse_error) => panic!("the rejection must be JSON: {parse_error}, body {body}"),
+        };
+        assert_eq!(
+            error.get("field"),
+            Some(&Value::String("format".to_string()))
+        );
+    }
+
+    /// An `arrow` export decodes to the same values the CSV renders.
+    #[cfg(feature = "arrow-export")]
+    #[actix_web::test]
+    async fn test_an_arrow_export_decodes_to_the_csv_values() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        for dataset in ["underlying", "volatility", "option_chains"] {
+            let (_, text) = export!(app, id, format!("dataset={dataset}&format=csv"));
+            let (status, bytes) = export_bytes!(app, id, format!("dataset={dataset}&format=arrow"));
+            assert_eq!(status, StatusCode::OK);
+
+            match crate::api::rest::arrow_export::decode_stream(&bytes) {
+                Ok(rows) => {
+                    // Value by value, not merely shape: the decoder renders
+                    // timestamps the way the CSV does, so the two compare
+                    // directly and the equality claim means something.
+                    assert_eq!(rows, csv_records_of(&text), "values for {dataset}");
+                }
+                Err(error) => panic!("the {dataset} export must decode: {error}"),
+            }
+        }
+    }
+
+    /// One step of the reference simulation, priced.
+    fn snapshot_of(
+        parameters: &SimulationParametersV2,
+        tape: &FactorTape,
+        step: usize,
+    ) -> Option<SeriesSnapshot> {
+        let builder = match SeriesBuilder::new(parameters, tape) {
+            Ok(builder) => builder.with_greek_snapshots(true),
+            Err(error) => panic!("the builder must accept the parameters: {error}"),
+        };
+        match builder.snapshot(step) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => panic!("the snapshot must build: {error}"),
+        }
+    }
+
+    /// A packed export split across several blocks carries the same rows.
+    ///
+    /// Every other export in this suite fits one block, so without this the
+    /// blocking path — the whole reason a columnar encoding can stream — is
+    /// exercised only by the encoder's own unit tests.
+    #[actix_web::test]
+    async fn test_a_multi_block_packed_export_carries_every_row() {
+        let parameters = reference_parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let row = match tape.row(0) {
+            Some(row) => row,
+            None => panic!("the tape must have a first row"),
+        };
+
+        let mut narrow = Vec::new();
+        let mut wide = Vec::new();
+        for (block_rows, sink) in [(2_usize, &mut narrow), (4_096_usize, &mut wide)] {
+            let mut writer = match Writer::new(
+                Format::Packed,
+                Dataset::OptionChains,
+                GreekLevel::None,
+                &parameters,
+                block_rows,
+            ) {
+                Ok(writer) => writer,
+                Err(error) => panic!("the writer must build: {error}"),
+            };
+            if let Some(prologue) = match writer.prologue() {
+                Ok(prologue) => prologue,
+                Err(error) => panic!("the prologue must encode: {error}"),
+            } {
+                sink.extend(prologue);
+            }
+
+            let chains = match snapshot_of(&parameters, &tape, 0) {
+                Some(snapshot) => snapshot,
+                None => panic!("step zero must produce chains"),
+            };
+            match writer.rows(
+                &parameters,
+                0,
+                row,
+                Some(StepChains::Replayed(&chains)),
+                &mut |chunk| {
+                    sink.extend(chunk);
+                    Delivery::Sent
+                },
+            ) {
+                Ok(Delivery::Sent) => {}
+                other => panic!("the rows must be delivered, got {other:?}"),
+            }
+            if let Some(epilogue) = match writer.epilogue() {
+                Ok(epilogue) => epilogue,
+                Err(error) => panic!("the epilogue must encode: {error}"),
+            } {
+                sink.extend(epilogue);
+            }
+        }
+
+        let narrow_rows = match crate::api::rest::binary::decode_packed(&narrow) {
+            Ok((_, rows)) => rows,
+            Err(error) => panic!("the narrow document must decode: {error}"),
+        };
+        let wide_rows = match crate::api::rest::binary::decode_packed(&wide) {
+            Ok((_, rows)) => rows,
+            Err(error) => panic!("the wide document must decode: {error}"),
+        };
+
+        assert!(
+            narrow_rows.len() > 2,
+            "the fixture must span several blocks"
+        );
+        assert_eq!(
+            narrow_rows, wide_rows,
+            "the block width must not change a single value"
+        );
+    }
+
+    /// A row's cell types are the ones the schema declares, for every dataset
+    /// and every greek level.
+    ///
+    /// `BinarySchema::new` assigns types by matching column NAMES with an
+    /// `f64` fallback, so a column added to the header lists — which the greek
+    /// levels do, and which issue #75 did — lands on `f64` by default. A
+    /// mismatch would not panic: the encoder writes a value's own width while a
+    /// decoder reads the column's, and `Dictionary` is the one four-byte type,
+    /// so one wrong cell desynchronises the rest of the block.
+    #[actix_web::test]
+    async fn test_every_row_matches_its_declared_schema() {
+        let parameters = reference_parameters();
+        let tape = match FactorTape::build(&parameters, &parameters.method) {
+            Ok(tape) => tape,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
+        let row = match tape.row(0) {
+            Some(row) => row,
+            None => panic!("the tape must have a first row"),
+        };
+        let chains = match snapshot_of(&parameters, &tape, 0) {
+            Some(snapshot) => snapshot,
+            None => panic!("step zero must produce chains"),
+        };
+
+        for dataset in [
+            Dataset::Underlying,
+            Dataset::Volatility,
+            Dataset::OptionChains,
+        ] {
+            for level in [GreekLevel::None, GreekLevel::First, GreekLevel::All] {
+                let schema = BinarySchema::new(dataset, level, &parameters);
+                let rows = match crate::api::rest::binary::typed_rows(
+                    &schema,
+                    dataset,
+                    level,
+                    0,
+                    row.simulated_at,
+                    row,
+                    Some(StepChains::Replayed(&chains)),
+                ) {
+                    Ok(rows) => rows,
+                    Err(error) => panic!("{dataset:?} at {level:?} must encode: {error}"),
+                };
+
+                assert!(!rows.is_empty(), "{dataset:?} at {level:?} produced no row");
+                for cells in &rows {
+                    assert_eq!(
+                        cells.len(),
+                        schema.types.len(),
+                        "{dataset:?} at {level:?}: a row must carry every declared column"
+                    );
+                    for (position, (cell, declared)) in cells.iter().zip(&schema.types).enumerate()
+                    {
+                        assert_eq!(
+                            cell.cell_type(),
+                            *declared,
+                            "{dataset:?} at {level:?}: column {} ({}) carries the wrong type",
+                            position,
+                            schema.names.get(position).copied().unwrap_or("?")
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Records the size and wall time of every format, for the docs.
+    ///
+    /// Ignored by default: it is a measurement, not an assertion, and its
+    /// numbers only mean something from a release build. Run it with
+    /// `cargo test --release --all-features -- --ignored --nocapture`.
+    #[actix_web::test]
+    #[ignore = "a measurement, not an assertion; run it from a release build"]
+    async fn test_measure_every_format() {
+        let app = v2_service!();
+        let id = create!(app);
+
+        for format in ["json", "csv", "packed", "arrow"] {
+            let started = std::time::Instant::now();
+            let (status, bytes) = export_bytes!(
+                app,
+                id,
+                format!("dataset=option_chains&format={format}&greeks=all")
+            );
+            let elapsed = started.elapsed();
+            if status != StatusCode::OK {
+                println!("{format:>7}: unavailable in this build");
+                continue;
+            }
+            println!(
+                "{format:>7}: {:>9} bytes  {:>7.1} ms",
+                bytes.len(),
+                elapsed.as_secs_f64() * 1000.0
+            );
+        }
     }
 
     /// The JSON is a single valid array, even though it is streamed in chunks.
@@ -2267,7 +2918,13 @@ mod tests {
         );
 
         for format in [Format::Json, Format::Csv] {
-            let mut writer = match Writer::new(format, Dataset::OptionChains, GreekLevel::All) {
+            let mut writer = match Writer::new(
+                format,
+                Dataset::OptionChains,
+                GreekLevel::All,
+                &parameters,
+                *EXPORT_BLOCK_ROWS,
+            ) {
                 Ok(writer) => writer,
                 Err(error) => panic!("the writer must build: {error}"),
             };
@@ -2334,7 +2991,13 @@ mod tests {
             None => panic!("the tape must have a first row"),
         };
 
-        let mut writer = match Writer::new(Format::Csv, Dataset::OptionChains, GreekLevel::All) {
+        let mut writer = match Writer::new(
+            Format::Csv,
+            Dataset::OptionChains,
+            GreekLevel::All,
+            &parameters,
+            *EXPORT_BLOCK_ROWS,
+        ) {
             Ok(writer) => writer,
             Err(error) => panic!("the writer must build: {error}"),
         };

--- a/src/api/rest/limits.rs
+++ b/src/api/rest/limits.rs
@@ -11,6 +11,7 @@
 //! | `OCS_MAX_STEPS`            | `10_000`  | Max simulation steps per session         |
 //! | `OCS_MAX_CHAIN_SIZE`       | `500`     | Max option-chain size per request        |
 //! | `OCS_MAX_HISTORICAL_PRICES`| `100_000` | Max historical prices in a walk request  |
+//! | `OCS_EXPORT_BLOCK_ROWS`    | `4_096`   | Rows per block in a binary export        |
 
 use std::sync::LazyLock;
 use tracing::warn;
@@ -21,6 +22,14 @@ pub(crate) const DEFAULT_MAX_STEPS: usize = 10_000;
 pub(crate) const DEFAULT_MAX_CHAIN_SIZE: usize = 500;
 /// Default cap on the number of historical prices in a `Historical` walk request.
 pub(crate) const DEFAULT_MAX_HISTORICAL_PRICES: usize = 100_000;
+/// Default number of rows in one binary export block.
+///
+/// The binary encodings are columnar, so a column cannot be written until its
+/// last row is known: rows are therefore buffered a block at a time, and this
+/// is what the export's memory is a function of instead of the number of steps.
+/// Four thousand rows of the widest dataset is a few megabytes, small enough to
+/// stream and wide enough that the per-block overhead disappears.
+pub(crate) const DEFAULT_EXPORT_BLOCK_ROWS: usize = 4_096;
 
 /// Maximum number of simulation steps a session may request (`OCS_MAX_STEPS`).
 pub(crate) static MAX_STEPS: LazyLock<usize> = LazyLock::new(|| {
@@ -36,6 +45,31 @@ pub(crate) static MAX_CHAIN_SIZE: LazyLock<usize> = LazyLock::new(|| {
         crate::utils::env::read_var("OCS_MAX_CHAIN_SIZE"),
         DEFAULT_MAX_CHAIN_SIZE,
     )
+});
+
+/// The widest a binary export block may be configured.
+///
+/// This knob sets the export's memory floor directly — a block is buffered
+/// whole before it is written — so it is the one limit whose own upper bound
+/// matters. A quarter of a million rows of the widest dataset is already
+/// hundreds of megabytes.
+pub(crate) const MAX_EXPORT_BLOCK_ROWS: usize = 262_144;
+
+/// Rows per block in the binary export encodings (`OCS_EXPORT_BLOCK_ROWS`).
+pub(crate) static EXPORT_BLOCK_ROWS: LazyLock<usize> = LazyLock::new(|| {
+    let configured = parse_limit(
+        crate::utils::env::read_var("OCS_EXPORT_BLOCK_ROWS"),
+        DEFAULT_EXPORT_BLOCK_ROWS,
+    );
+    if configured > MAX_EXPORT_BLOCK_ROWS {
+        warn!(
+            configured,
+            maximum = MAX_EXPORT_BLOCK_ROWS,
+            "OCS_EXPORT_BLOCK_ROWS above the maximum; using the maximum"
+        );
+        return MAX_EXPORT_BLOCK_ROWS;
+    }
+    configured
 });
 
 /// Maximum number of historical prices a `Historical` walk may carry
@@ -137,5 +171,8 @@ mod tests {
         assert_eq!(*MAX_CHAIN_SIZE, 500);
         assert_eq!(*MAX_HISTORICAL_PRICES, DEFAULT_MAX_HISTORICAL_PRICES);
         assert_eq!(*MAX_HISTORICAL_PRICES, 100_000);
+        assert_eq!(*EXPORT_BLOCK_ROWS, DEFAULT_EXPORT_BLOCK_ROWS);
+        assert_eq!(*EXPORT_BLOCK_ROWS, 4_096);
+        assert_eq!(MAX_EXPORT_BLOCK_ROWS, 262_144);
     }
 }

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "arrow-export")]
+pub(crate) mod arrow_export;
+pub(crate) mod binary;
 pub(crate) mod controller;
 mod error;
 pub(crate) mod export;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@
 //!
 //! - **Request caps** — `OCS_MAX_STEPS`, `OCS_MAX_CHAIN_SIZE`,
 //!   `OCS_MAX_HISTORICAL_PRICES`, `OCS_MAX_CONCURRENT_PRICING_JOBS`,
-//!   `OCS_MAX_CACHED_WALKS` — warn and fall back
+//!   `OCS_MAX_CACHED_WALKS`, `OCS_EXPORT_BLOCK_ROWS` — warn and fall back
 //!   to their defaults when set to something invalid. A bad value there
 //!   degrades one request.
 //! - **v2 operational knobs** — `OCS_V2_RETENTION_SECS`,
@@ -418,7 +418,7 @@
 //! | Parameter | Values |
 //! |-----------|--------|
 //! | `dataset` | `underlying` \| `volatility` \| `option_chains` |
-//! | `format`  | `json` \| `csv` |
+//! | `format`  | `json` \| `csv` \| `arrow` \| `packed` |
 //! | `from_step`, `to_step` | inclusive bounds; default to the whole tape |
 //! | `greeks` | `none` (default) \| `first` \| `all` — `option_chains` only |
 //!
@@ -454,6 +454,77 @@
 //! `first` and `all` cost the same to compute — upstream builds the snapshot
 //! whole and the level only decides what is written — so the step from `first`
 //! to `all` is paid in bytes, not in time.
+//!
+//! ### The binary encodings
+//!
+//! `json` and `csv` are text, so every consumer pays a parse, and for the two
+//! that matter that parse IS the bottleneck: a browser materialising a whole
+//! tape spends hundreds of milliseconds in `JSON.parse` and allocates an object
+//! per row, and a Rust consumer writing Parquet re-parses text this service
+//! already held in typed form.
+//!
+//! - **`arrow`** — an Arrow IPC **stream**, one record batch per block.
+//!   `Content-Type: application/vnd.apache.arrow.stream`, extension `arrow`.
+//!   Available only when the service is built with the **`arrow-export`**
+//!   feature, which is off by default because the `arrow` crate is a large tree
+//!   and a deployment that never exports should not carry it. Asking for
+//!   `format=arrow` without it is a typed `400` naming the format, never a 500
+//!   and never a silent fallback.
+//! - **`packed`** — a dependency-free columnar block format for the browser.
+//!   `Content-Type: application/octet-stream`, extension `ocsp`.
+//!
+//! Both carry the **same column names in the same order as the CSV header**, so
+//! a reader moves between encodings without a mapping table, and both are
+//! `f64` for every numeric column — exactly what `json` and `csv` render.
+//! Binary is a faster route to the same numbers, NOT a route to the underlying
+//! `Decimal(38, 28)` precision.
+//!
+//! **Both stream, in blocks.** A columnar encoding cannot emit a column until
+//! its last row is known, so rows are buffered `OCS_EXPORT_BLOCK_ROWS` at a
+//! time (default 4096) and written a block at a time. An export's memory is
+//! therefore a function of the block width and not of the number of steps.
+//!
+//! The `packed` layout, little-endian throughout:
+//!
+//! ```text
+//! file        := header block*
+//! header      := "OCSP" u32:version u32:block_rows
+//!                u32:dictionary_count dictionary_entry*
+//!                u32:column_count column_desc*
+//!                pad to 8
+//! dict_entry  := u32:len utf8:value             (the symbol, then the rule ids)
+//! column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
+//! block       := u32:row_count pad to 8 column_payload*
+//! payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+//! ```
+//!
+//! Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
+//! the epoch, `3` = an index into the header dictionary, `4` = a **label
+//! bitmask**, one bit per dictionary entry. Every payload starts on an 8-byte
+//! boundary, which is the whole point: it is what lets a browser do
+//! `new Float64Array(buffer, offset, count)` with no copy, and an unaligned
+//! offset would make that constructor throw. Validity bitmaps follow Arrow's
+//! convention — LSB-first, `1` = valid — so one decoder serves both formats,
+//! and a null is a cleared bit rather than a sentinel or a NaN, which are
+//! values a chain can legitimately hold.
+//!
+//! Keeping the text columns out of the blocks is what the dictionary is for:
+//! the symbol is fixed for a simulation and the schedule's rule ids are fixed
+//! by its parameters, so both are known before the first row. `labels` is a
+//! bitmask over those rule ids, and joining the bits it sets reproduces the
+//! `csv` column character for character, since both orders are lexicographic.
+//! A simulation is capped at 16 schedule rules at creation, well inside the 63
+//! a mask carries, and a compile-time assertion keeps the two from drifting
+//! apart.
+//!
+//! Measured on the reference fixture at `greeks=all`, release build:
+//!
+//! | Format | Bytes | Wall time |
+//! |--------|-------|-----------|
+//! | `json` | 79 888 | 9.7 ms |
+//! | `csv` | 46 819 | 7.8 ms |
+//! | `arrow` | 29 640 | 6.5 ms |
+//! | `packed` | 22 808 | 6.1 ms |
 //!
 //! **Deterministic.** Repeating an export is byte-identical: every value is a
 //! function of the effective parameters and the cursor, timestamps render as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,7 @@
 //! The `packed` layout, little-endian throughout:
 //!
 //! ```text
-//! file        := header block*
+//! file        := header block* footer
 //! header      := "OCSP" u32:version u32:block_rows
 //!                u32:dictionary_count dictionary_entry*
 //!                u32:column_count column_desc*
@@ -496,7 +496,16 @@
 //! column_desc := u32:name_len utf8:name u8:type_code u8:nullable pad to 4
 //! block       := u32:row_count pad to 8 column_payload*
 //! payload     := [validity bitmap if nullable, padded to 8] values, padded to 8
+//! footer      := u32:0xFFFFFFFF pad to 8 u64:total_rows
 //! ```
+//!
+//! **The footer is required, and a decoder must check it.** No block can carry
+//! `0xFFFFFFFF` rows, so that value is what says the blocks have ended, and the
+//! `u64` after it is the total the writer emitted. A document that ends without
+//! it was truncated and must be REJECTED rather than read as a shorter tape:
+//! the response is a 200 whose header goes out before the first byte is
+//! produced, so a dropped connection is otherwise indistinguishable from a
+//! smaller export. A total that disagrees with the blocks is the same error.
 //!
 //! Type codes: `0` = `f64`, `1` = `i64`, `2` = timestamp in nanoseconds since
 //! the epoch, `3` = an index into the header dictionary, `4` = a **label


### PR DESCRIPTION
Closes #78

## Stack

- **Base branch:** `stack/5-80-per-contract-spread`
- **Stacked on:** #93
- **Stack:** #88 (#83) → #89 (#81) → #90 (#82) → #92 (#84) → #93 (#80) → **this** (top)

The diff against `main` is cumulative until the lower PRs merge; read it against the base branch.

## What changed

Two binary encodings beside `json` and `csv`, both streaming in blocks of `OCS_EXPORT_BLOCK_ROWS` (default 4096, capped at 262 144), both carrying the same column names in the same order as the CSV header and `f64` for every number. Binary is a faster route to the same values, **not** a route to the underlying `Decimal(38, 28)` precision, and the endpoint docs say so.

- **`arrow`** — Arrow IPC stream, one record batch per block, `application/vnd.apache.arrow.stream`, extension `arrow`. Behind the `arrow-export` feature, off by default, `arrow = "59.2"` with `default-features = false` to match IronCondor.
- **`packed`** — no dependencies, `application/octet-stream`, extension `ocsp`. 8-byte aligned payloads so a browser can map a `Float64Array` onto the buffer with no copy; Arrow-convention validity bitmaps so one decoder serves both.

## Design decisions worth reviewing

**`labels` as a bitmask, not a dictionary-encoded string.** The issue sketched a dictionary for `symbol` and left `labels` open. Its value space is the power set of the rule ids, so it cannot be dictionary-encoded up front; a `u64` mask over the header's rule ids can, at a fixed width, and joining the bits it sets reproduces the CSV column character for character because both orders are lexicographic. The mask starts **after** the dictionary's first entry, which is the symbol: both charsets allow a rule id equal to the symbol, and without the skip that rule id would take bit 0 and come back ahead of every other label. A test pins exactly that collision.

**A footer.** `packed` closes with a sentinel row count and the total rows written. Without it a connection dropped mid-stream leaves a shorter document that decodes as a perfectly valid smaller tape, under a 200 whose header went out before the first byte existed. The decoder refuses a document with no footer, and refuses one whose count disagrees.

**The `Writer` enum grew two arms** rather than becoming an encoder trait, which the issue listed as a task. The arrow arm needs `cfg`, and an enum keeps the hot path unboxed; the four encodings already sit behind one streaming producer, which is what the task was for.

**No new export columns.** `#80` (the PR below this one) deliberately added none either, so the header lists are the ones this PR reads.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `arrow` and `packed` decode to the `json` values, every dataset | `test_a_packed_export_decodes_to_the_csv_values`, `test_an_arrow_export_decodes_to_the_csv_values` — both compare value by value against CSV, which `test_the_json_export_matches_the_csv_export_at_every_level` already pins against JSON |
| Byte-identical on repeat, all four formats | `test_every_format_is_byte_identical_on_repeat` (arrow included when the feature is on) |
| `from_step` / `to_step` identical across formats, errors included | `test_a_step_range_behaves_the_same_in_packed`, `..._in_arrow` |
| Memory flat in the number of steps | `test_the_writer_never_buffers_more_than_one_block` asserts the buffer stays under one block across 3 500 rows; `test_a_multi_block_packed_export_carries_every_row` drives a real dataset at a two-row block width and compares it to the same export at 4 096 |
| Every payload offset 8-byte aligned | `test_every_payload_offset_is_aligned` walks the produced block the way a decoder does and asserts the walk consumes it exactly |
| A null round-trips as a null, not a zero or a NaN | `test_a_null_is_a_cleared_bit_rather_than_a_sentinel`, `test_a_null_survives_the_packed_encoding`, and the Arrow round-trip test |
| Typed 400 for `arrow` without the feature | `test_arrow_without_the_feature_is_a_typed_400`, checked in the handler before streaming |
| Default build does not link `arrow` | `cargo tree --no-default-features \| grep -c arrow` = **0**; with the feature = **50** |
| Block size configurable, documented | `OCS_EXPORT_BLOCK_ROWS` in `limits.rs`, `.env.example`, the crate docs, and `test_default_limits_match_documentation` |
| Layout written down | `binary.rs` module docs, `src/lib.rs` / `README.md`, and the utoipa `format` description |

Also added: a test that every dataset × greek level produces rows whose cell types are the ones `BinarySchema` declares. That schema assigns types by matching column **names** with an `f64` fallback, so a column added to the header lists lands on `f64` silently, and a mismatch would desynchronise a block rather than panic.

## Measurements

`option_chains` at `greeks=all` on the reference fixture, release build:

| Format | Bytes | Wall time |
|---|---|---|
| `json` | 79 888 | 9.7 ms |
| `csv` | 46 819 | 7.8 ms |
| `arrow` | 29 640 | 6.5 ms |
| `packed` | 22 808 | 6.1 ms |

Reproduce with `cargo test --release --all-features -- --ignored --nocapture test_measure_every_format`.

## CI

The Tests job now runs twice, once without features and once with `arrow-export`: the default build ships without the feature, and the cross-format equality tests for `arrow` only exist when it is on. Lint already covered the feature through `--all-features`.

## Gate

`make pre-push` clean, MongoDB up: **881** + 16 + 3 tests pass without the feature, **886** with it; clippy with `-D warnings` over `--all-features`, `fmt --check`, `cargo doc` with zero warnings and `cargo build --release` all clean; `README.md` regenerated via `make readme`.