### PR TITLE
Percent-encode Redis credentials in RedisConfig::url (#87)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,10 @@ REDIS_DB=0
 # `REDIS_PASSWORD=` is the same as not writing it — which is what you want
 # against a password-less Redis, and used to be an AUTH attempt with an empty
 # password instead.
+#
+# Write the raw credential: punctuation is percent-encoded into the connection
+# URL for you, so a password containing `/`, `#`, `?`, `@`, `:` or a space is
+# sent as written. Pre-encoding one by hand would send the escapes themselves.
 #REDIS_USER=
 #REDIS_PASSWORD=
 

--- a/src/infrastructure/config/mod.rs
+++ b/src/infrastructure/config/mod.rs
@@ -32,10 +32,13 @@ pub(crate) use crate::utils::env::{read_secret, read_var};
 /// next whitespace (or end of string); if it contains an `@`, everything
 /// between `://` and its LAST `@` is treated as credentials and replaced with
 /// `***`. Bounding by the last `@` is deliberately CONSERVATIVE: a raw
-/// credential may contain `/`, `:`, or `@` (RedisConfig::url and env-provided
-/// URIs embed them verbatim), so the scan prefers over-redacting a legitimate
-/// path `@` (`scheme://host/some@path` → `scheme://***@path`) to ever leaking
-/// a password fragment. Credentials containing whitespace cannot be recovered
+/// credential may contain `/`, `:`, or `@`, which an operator-supplied URI such
+/// as `MONGODB_URI` embeds verbatim, so the scan prefers over-redacting a
+/// legitimate path `@` (`scheme://host/some@path` → `scheme://***@path`) to
+/// ever leaking a password fragment. `RedisConfig::url` percent-encodes its own
+/// userinfo (issue #87), so for the URL this service builds the last `@` IS the
+/// separator and the conservative rule is load-bearing only for the URIs it was
+/// handed. Credentials containing whitespace cannot be recovered
 /// from mid-text scanning; whole-string values should use [`redact_uri`].
 pub(crate) fn redact_userinfo(s: &str) -> String {
     let mut result = String::with_capacity(s.len());

--- a/src/infrastructure/config/redis.rs
+++ b/src/infrastructure/config/redis.rs
@@ -49,22 +49,55 @@ fn parse_timeout_secs(var: &str, default: u64) -> u64 {
     }
 }
 
+/// Percent-encodes one credential for the URL's userinfo section.
+///
+/// Everything outside RFC 3986's `unreserved` set is encoded, which is wider
+/// than the minimum the grammar demands: `sub-delims` and `:` are legal in
+/// userinfo unencoded, but encoding them costs nothing and removes every
+/// question about where the section ends. `%` is escaped along with the rest,
+/// so a password that legitimately contains `%40` becomes `%2540` and cannot
+/// decode back to `@`.
+///
+/// A credential of letters, digits, `-`, `.`, `_` or `~` passes through
+/// untouched, so a URL that works today is byte-identical after this.
+#[must_use]
+fn encode_userinfo(raw: &str) -> String {
+    let mut encoded = String::with_capacity(raw.len());
+    for byte in raw.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            // Uppercase hex, as RFC 3986 recommends for what a producer emits.
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
 impl RedisConfig {
     pub(crate) fn url(&self) -> String {
         // Start building the URL
         let mut url = String::from("redis://");
 
         // Add credentials if either username or password is present
+        //
+        // PERCENT-ENCODED, both of them. Interpolated verbatim, a credential
+        // carrying a URL delimiter builds a URL that is WRONG rather than one
+        // that fails: a `/` moves what the driver reads as the database index,
+        // a `#` truncates the rest, and a `@` moves where the credentials are
+        // taken to end. The resolved fields stay unencoded, so a caller reading
+        // `RedisConfig.password` still sees what the operator set.
         if self.username.is_some() || self.password.is_some() {
             // Add username if present, otherwise an empty string
             if let Some(username) = &self.username {
-                url.push_str(username);
+                url.push_str(&encode_userinfo(username));
             }
 
             // Add password with colon prefix if present
             if let Some(password) = &self.password {
                 url.push(':');
-                url.push_str(password);
+                url.push_str(&encode_userinfo(password));
             }
 
             // Add the @ separator after credentials
@@ -239,10 +272,9 @@ mod tests {
             "a real password must reach the config untouched"
         );
 
-        // That it also reaches the URL is asserted with a plain password on
-        // purpose. `url()` does no percent-encoding, so asserting the
-        // punctuated one round-trips through the URL would freeze that gap as
-        // intended behaviour rather than leave it a known one.
+        // And that it reaches the URL, now percent-encoded: the punctuated
+        // password round-trips through a real parse in
+        // `test_a_punctuated_credential_round_trips_through_the_url`.
         set_var("REDIS_PASSWORD", "s3cret");
         let config = RedisConfig::default();
         assert!(
@@ -493,6 +525,151 @@ mod tests {
         );
     }
 
+    /// The credentials a URL parses back to, or `None` when the driver
+    /// refuses it.
+    ///
+    /// A real parse by the driver that will consume this URL, so the assertion
+    /// is about what Redis receives rather than about the string this module
+    /// produced. Both halves: the username is encoded too, and a driver that
+    /// stopped decoding usernames would leave a password-only assertion green.
+    fn credentials_of(url: &str) -> Option<(Option<String>, Option<String>)> {
+        let client = redis::Client::open(url).ok()?;
+        let settings = client.get_connection_info().redis_settings();
+        Some((
+            settings.username().map(ToString::to_string),
+            settings.password().map(ToString::to_string),
+        ))
+    }
+
+    /// A credential full of delimiters parses back to exactly itself.
+    ///
+    /// Every one of these characters means something in a URL: `/` moves the
+    /// database index, `#` truncates the rest, `?` opens a query, `@` moves
+    /// where the credentials end, `:` splits user from password, a space is not
+    /// allowed at all, and `%` is what an encoder must escape first or a
+    /// literal `%40` decodes to `@`.
+    #[test]
+    fn test_a_punctuated_credential_round_trips_through_the_url() {
+        for password in [
+            "s3cr:t@pass",
+            "p/secret",
+            "with#hash",
+            "with?query",
+            "with space",
+            "100%pure",
+            "everything: /#?@% and more",
+        ] {
+            // The same punctuation in BOTH slots: the username goes through
+            // the same encoder and the same decode on the driver's side.
+            let config = RedisConfig {
+                host: "localhost".to_string(),
+                port: 6379,
+                username: Some(password.to_string()),
+                password: Some(password.to_string()),
+                database: 0,
+                timeout: 30,
+                connect_timeout: 5,
+            };
+
+            assert_eq!(
+                credentials_of(&config.url()),
+                Some((Some(password.to_string()), Some(password.to_string()))),
+                "{password:?} did not survive the URL: {}",
+                config.url()
+            );
+        }
+    }
+
+    /// A `/` in a credential does not move the database index.
+    ///
+    /// The failure that motivated the issue: unencoded, `p/secret` ends the
+    /// authority early and the driver reads a database that nobody configured.
+    #[test]
+    fn test_a_slash_in_a_credential_leaves_the_database_alone() {
+        let config = RedisConfig {
+            host: "localhost".to_string(),
+            port: 6379,
+            username: None,
+            password: Some("p/7/secret".to_string()),
+            database: 3,
+            timeout: 30,
+            connect_timeout: 5,
+        };
+
+        let client = match redis::Client::open(config.url()) {
+            Ok(client) => client,
+            Err(error) => panic!("the URL must parse: {error}, url {}", config.url()),
+        };
+        let info = client.get_connection_info();
+
+        assert_eq!(
+            info.redis_settings().db(),
+            3,
+            "the configured database must survive"
+        );
+        assert_eq!(info.redis_settings().password(), Some("p/7/secret"));
+    }
+
+    /// An unreserved credential produces the URL it produced before.
+    ///
+    /// The encoding must be invisible to everything already working: letters,
+    /// digits, `-`, `.`, `_` and `~` pass through untouched.
+    #[test]
+    fn test_an_unreserved_credential_is_untouched() {
+        let config = RedisConfig {
+            host: "redis.internal".to_string(),
+            port: 6380,
+            username: Some("admin".to_string()),
+            password: Some("s3cret-pass.word_v2~1".to_string()),
+            database: 2,
+            timeout: 30,
+            connect_timeout: 5,
+        };
+
+        assert_eq!(
+            config.url(),
+            "redis://admin:s3cret-pass.word_v2~1@redis.internal:6380/2"
+        );
+    }
+
+    /// The encoder escapes what it must, and nothing else.
+    #[test]
+    fn test_the_encoder_escapes_only_the_reserved() {
+        assert_eq!(encode_userinfo("aZ09-._~"), "aZ09-._~");
+        assert_eq!(encode_userinfo("a/b"), "a%2Fb");
+        assert_eq!(encode_userinfo("a@b"), "a%40b");
+        assert_eq!(encode_userinfo("a:b"), "a%3Ab");
+        assert_eq!(encode_userinfo("a b"), "a%20b");
+        // `%` first: otherwise a literal %40 in a password would decode to @.
+        assert_eq!(encode_userinfo("%40"), "%2540");
+        // Multi-byte characters are encoded per UTF-8 byte.
+        assert_eq!(encode_userinfo("ñ"), "%C3%B1");
+    }
+
+    /// A punctuated credential still cannot leak through the redaction.
+    ///
+    /// Encoding removes every `@` from the credential, so the last `@` in the
+    /// URL is the real separator and `redact_userinfo` cannot be walked past it.
+    #[test]
+    fn test_the_redaction_covers_the_encoded_form() {
+        let config = RedisConfig {
+            host: "localhost".to_string(),
+            port: 6379,
+            username: Some("adm@in".to_string()),
+            password: Some("p@ss/word".to_string()),
+            database: 0,
+            timeout: 30,
+            connect_timeout: 5,
+        };
+
+        let redacted = crate::infrastructure::config::redact_userinfo(&config.url());
+
+        assert_eq!(
+            redacted, "redis://***@localhost:6379",
+            "nothing of either credential may survive"
+        );
+    }
+
     #[test]
     fn test_display_and_debug_redact_delimiter_passwords() {
         // Display/Debug are built from fields, so passwords containing URL
@@ -512,8 +689,13 @@ mod tests {
             assert!(!display.contains(pw), "Display leaked {pw:?}: {display}");
             assert!(!debug.contains(pw), "Debug leaked {pw:?}: {debug}");
             assert!(display.contains("***@"));
-            // The connection URL still carries the real credential.
-            assert!(config.url().contains(pw));
+            // The URL still carries the credential, percent-encoded, which is
+            // what makes the last `@` the real separator for the redaction.
+            assert_eq!(
+                credentials_of(&config.url()),
+                Some((Some("user".to_string()), Some(pw.to_string()))),
+                "the URL must parse back to the credential"
+            );
         }
     }
 
@@ -541,7 +723,8 @@ mod tests {
         assert!(debug.contains("***"));
 
         // The connection URL must still carry the real credentials so the
-        // connection path keeps working.
+        // connection path keeps working. Alphanumerics and `-` are unreserved,
+        // so these two appear verbatim.
         assert!(config.url().contains("s3ntinel-pw"));
         assert!(config.url().contains("admin"));
     }


### PR DESCRIPTION
Closes #87

## Stack

- **Base branch:** `main`
- **Stack:** this and the PR for #91 are **independent**. They touch disjoint files — this one is `infrastructure/config/redis.rs`, the other is the v2 chain path — so they are two parallel PRs off `main` rather than a stack. Merge them in any order.

## What changed

`url()` interpolated the username and password verbatim, so a credential carrying a URL delimiter built a URL that was **wrong** rather than one that failed: a `/` moved what the driver reads as the database index, a `#` truncated the rest, an `@` moved where the credentials were taken to end.

Both credentials are percent-encoded now. Everything outside RFC 3986's `unreserved` set is escaped — wider than the grammar demands, since `sub-delims` and `:` are legal there unencoded — because redis decodes both halves (`url_to_tcp_connection_info`) and over-encoding removes every question about where the section ends. `%` is escaped with the rest, so a literal `%40` in a password becomes `%2540` and cannot decode back to `@`. The resolved config fields stay unencoded.

## No new dependency

`percent-encoding` is in the lock file transitively but is not a workspace dependency, and adding one needs approval. It would also buy nothing here: its `NON_ALPHANUMERIC` set escapes `-._~` too, so the call site would need `NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~')` to keep an alphanumeric URL byte-identical — comparable in size to the twelve-line loop, plus a version surface. If you would rather have the crate, it is a two-line change.

## Acceptance criteria

| Criterion | Where |
|---|---|
| A password with `/`, `#`, `?`, `@`, `:` and a space parses back to the same credential | `test_a_punctuated_credential_round_trips_through_the_url` — seven cases, driven through `redis::Client::open` and asserted on **both** the username and the password |
| The database index is unaffected by a `/` in a credential | `test_a_slash_in_a_credential_leaves_the_database_alone` asserts `db() == 3` and the password |
| An alphanumeric credential produces a byte-identical URL | `test_an_unreserved_credential_is_untouched` compares the whole URL string, and covers all of `-._~` |
| clippy, fmt, tests clean | gate below |

## The redaction, and the third task

Encoding **tightens** the redaction rather than needing it extended: with no `@` left inside a credential, the last `@` in a URL this service builds is provably the separator. `test_the_redaction_covers_the_encoded_form` pins that a username and password both full of delimiters redact to exactly `redis://***@localhost:6379`, and `redact_userinfo`'s doc now says its conservative bound is load-bearing only for URIs an operator supplies whole, such as `MONGODB_URI`. The `Display` half needed nothing: it never puts credentials in the string.

## Also

`.env.example` now says to write the raw credential, since pre-encoding one by hand would send the escapes themselves.

Found while reviewing the diff, **not** fixed here because it is outside this issue: the **host** is still interpolated verbatim, so `REDIS_HOST="evil@host"` parses to address `host` with password `pw@evil`. Same bug class, other axis. I can file it as a follow-up issue if you want it tracked.

## Gate

`make pre-push` clean, MongoDB up: 893 + 16 + 3 tests pass, 25 ignored; clippy with `-D warnings`, `fmt --check`, `cargo doc` and `cargo build --release` all clean.