### PR TITLE
Offer a pinned strike ladder so a position keeps its contracts (#91)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 
 [workspace.dependencies]
 optionchain_simulator = { path = "." }
-optionstratlib = "0.20"
+optionstratlib = "0.21"
 positive = "0.6"
 tracing = "0.1"
 rust_decimal = { version = "1.42", features = ["maths", "serde"] }

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     # default tag in the same PR that bumps the crate version.
     image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.0}
     deploy:
-      replicas: 1
+      replicas: 2
       restart_policy:
         condition: any
         delay: 5s

--- a/README.md
+++ b/README.md
@@ -299,8 +299,46 @@ rather than being marked up to a penny it is not worth.
   request that took the documented default — the quotes are unchanged.
 
 Persisted snapshots are therefore a new tape: `CURRENT_SNAPSHOT_GENERATION`
-is `3`, so rows written by an older binary stay addressable under generation
-`2` and are never mixed with these.
+is `4`, so rows written by an older binary stay addressable under the
+generation they were filed under and are never mixed with these. It moved
+again with optionstratlib 0.21.1, which quotes an option worth nothing at
+zero instead of pricing it as absent (OptionStratLib#487): upstream had
+stopped extending a ladder at a strike whose worthless side carried no
+price, so a chain near expiry held fewer strikes than `chain_size` asked
+for — 23 instead of 41 at a spot of 5100 with a 25-point interval at 0.3125
+days. That changes the strike set of those steps for rolling ladders as
+much as for pinned ones.
+
+#### The strike ladder can be pinned
+
+The ladder is rebuilt around the current underlying at every step, so the
+quoted strikes follow the spot and a contract quoted at step 0 can be gone
+by step 2: a move of 0.27 percent over two steps was enough to drop a
+strike. `chain_size` fixes how MANY strikes are quoted, never WHICH.
+
+For a client browsing a chain that is right. For one holding a position it
+is not: a leg opened at 4850 cannot be marked, closed or settled at a step
+where 4850 does not exist, and a defined-risk structure loses its furthest
+wings first, which are the legs that cap its risk.
+
+`strike_ladder` on the v2 create request chooses:
+
+| Value | Meaning |
+|-------|---------|
+| `rolling` | The default, and what the service always did. The ladder follows the spot, so the quoted strikes stay near the money and a contract can leave the chain. |
+| `pinned` | The ladder is fixed at creation from `initial_price`, `chain_size` and `strike_interval`. Every step quotes that same set, so a contract quoted once is quoted for the simulation's whole life. |
+
+A pinned simulation must supply `strike_interval`: without one the interval
+is derived per expiration and there is no fixed grid to pin, so the request
+is a `400` naming the field. The effective value is echoed in the simulation
+response and survives a store round trip, and a document written before the
+field reads as `rolling`.
+
+**A pinned ladder does not follow a large move.** If the spot leaves the
+pinned range the chain is all calls or all puts, which is correct and
+informative: a simulation that silently invented new strikes would not be
+the closed world the setting exists to provide. Widen the ladder at
+creation, with `chain_size`, rather than at step time.
 
 `/api/v1/chain` is untouched, model and all: it is frozen, and its chains
 come from a different upstream path.

--- a/README.md
+++ b/README.md
@@ -335,10 +335,13 @@ response and survives a store round trip, and a document written before the
 field reads as `rolling`.
 
 **A pinned ladder does not follow a large move.** If the spot leaves the
-pinned range the chain is all calls or all puts, which is correct and
-informative: a simulation that silently invented new strikes would not be
-the closed world the setting exists to provide. Widen the ladder at
-creation, with `chain_size`, rather than at step time.
+pinned range every quoted strike ends up on one side of the money — each
+contract still carries both a call and a put, but they are all deep in or
+deep out. That is correct and informative: a simulation that silently
+invented new strikes would not be the closed world the setting exists to
+provide. Widen the ladder at creation, with `chain_size`, rather than at
+step time. A spot that drifts further than the service will widen for is a
+`400` naming `strike_ladder` rather than a silently shorter chain.
 
 `/api/v1/chain` is untouched, model and all: it is frozen, and its chains
 come from a different upstream path.

--- a/doc/adr/0001-v2-rolling-simulation-contract.md
+++ b/doc/adr/0001-v2-rolling-simulation-contract.md
@@ -474,9 +474,9 @@ Invariants a reviewer can check:
 > **time frame**, **timezone**, **calendar version**, **IANA tzdb version**,
 > **normalised schedules**, and market and chain parameters (`symbol`, `steps`,
 > `initial_price`, `volatility`, `risk_free_rate`, `dividend_yield`, `method`,
-> `chain_size`, `strike_interval`, `skew_slope`, `smile_curve`, and the spread
-> model: `spread`, `spread_proportional`, `spread_moneyness_widening`,
-> `spread_tenor_widening`, `spread_tick`).
+> `chain_size`, `strike_interval`, `skew_slope`, `smile_curve`,
+> `strike_ladder`, and the spread model: `spread`, `spread_proportional`,
+> `spread_moneyness_widening`, `spread_tenor_widening`, `spread_tick`).
 
 That list is exhaustive and is meant to be checkable. All of it is resolved once
 at creation, persisted, and echoed in the creation and session responses — so a
@@ -1043,6 +1043,7 @@ last-Friday monthlies, all expiring at 17:00 America/New_York.
   "spread_moneyness_widening": 0.5,
   "spread_tenor_widening": 0.1,
   "spread_tick": 0.01,
+  "strike_ladder": "rolling",
   "seed": 42
 }
 ```
@@ -1085,7 +1086,8 @@ last-Friday monthlies, all expiring at 17:00 America/New_York.
     "spread_proportional": 0.01,
     "spread_moneyness_widening": 0.5,
     "spread_tenor_widening": 0.1,
-    "spread_tick": 0.01
+    "spread_tick": 0.01,
+    "strike_ladder": "rolling"
   }
 }
 ```

--- a/doc/requests/create_simulation_v2.json
+++ b/doc/requests/create_simulation_v2.json
@@ -46,5 +46,6 @@
   "spread_moneyness_widening": 0.5,
   "spread_tenor_widening": 0.1,
   "spread_tick": 0.01,
+  "strike_ladder": "rolling",
   "seed": 42
 }

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -117,7 +117,17 @@ fn parse_id(raw: &str) -> Result<Uuid, ChainError> {
     description = "Create a deterministic rolling multi-expiration simulation. Resolves the \
         effective seed, simulated start and step interval once, and returns them with the \
         normalised schedules — together they are everything needed to replay the run. The \
-        configuration is immutable: changing any of it means creating a new simulation.",
+        configuration is immutable: changing any of it means creating a new simulation. \
+        `strike_ladder` decides which strikes the simulation quotes and is the one choice \
+        worth making deliberately: `rolling`, the default, rebuilds the ladder around the \
+        underlying at every step, so the quoted strikes stay near the money and a contract \
+        can leave the chain as the spot moves; `pinned` fixes the ladder at creation from \
+        `initial_price`, `chain_size` and `strike_interval`, so a contract quoted once is \
+        quoted for the simulation's whole life, which is what a client holding a position \
+        across steps needs. A pinned simulation must supply `strike_interval`, because \
+        without one the interval is derived per expiration and there is no fixed grid to \
+        pin, and a pinned ladder does not follow a large move: if the spot leaves its range \
+        the chain becomes all calls or all puts rather than inventing new strikes.",
     request_body = CreateSimulationRequest,
     responses(
         (status = 201, description = "Simulation created", body = SimulationResponse),
@@ -960,6 +970,119 @@ mod tests {
                 "the echo must carry {field}: {parameters}"
             );
         }
+    }
+
+    /// The strike ladder is accepted over HTTP and echoed back.
+    ///
+    /// `CreateSimulationRequest` denies unknown fields, so this is what proves
+    /// `strike_ladder` is part of the wire contract rather than only of the
+    /// stored shape, and the echo is what lets a client replay the run.
+    #[actix_web::test]
+    async fn test_the_strike_ladder_is_accepted_and_echoed() {
+        let app = v2_service!();
+
+        let mut request_body = reference_body();
+        match request_body.as_object_mut() {
+            Some(map) => {
+                map.insert("strike_ladder".to_string(), json!("pinned"));
+                // A pinned ladder needs an explicit grid, and one narrow enough
+                // that upstream can build every strike of it.
+                map.insert("strike_interval".to_string(), json!(25.0));
+                map.insert("chain_size".to_string(), json!(3));
+            }
+            None => panic!("the reference body must be an object"),
+        }
+
+        let request = actix_test::TestRequest::post()
+            .uri("/api/v2/simulations")
+            .set_json(request_body)
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(
+            body.get("parameters").and_then(|p| p.get("strike_ladder")),
+            Some(&json!("pinned")),
+            "the echo must carry the ladder: {body}"
+        );
+    }
+
+    /// A request that says nothing gets the ladder the service always had.
+    #[actix_web::test]
+    async fn test_the_strike_ladder_defaults_to_rolling() {
+        let app = v2_service!();
+        let body = create!(app);
+
+        assert_eq!(
+            body.get("parameters").and_then(|p| p.get("strike_ladder")),
+            Some(&json!("rolling")),
+            "an untouched request must read as rolling: {body}"
+        );
+    }
+
+    /// A pinned ladder without a grid is a typed 400 naming the field.
+    #[actix_web::test]
+    async fn test_a_pinned_ladder_without_an_interval_is_a_typed_400() {
+        let app = v2_service!();
+
+        let mut request_body = reference_body();
+        match request_body.as_object_mut() {
+            Some(map) => {
+                map.insert("strike_ladder".to_string(), json!("pinned"));
+                map.remove("strike_interval");
+            }
+            None => panic!("the reference body must be an object"),
+        }
+
+        let request = actix_test::TestRequest::post()
+            .uri("/api/v2/simulations")
+            .set_json(request_body)
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(
+            body.get("field"),
+            Some(&json!("strike_interval")),
+            "the rejection must name the field: {body}"
+        );
+    }
+
+    /// A pinned ladder wider than the spot is refused at creation.
+    ///
+    /// Upstream stops building a chain once the offset passes the anchor, so
+    /// those strikes would never exist; refusing here beats failing on the
+    /// first step of a simulation the client already holds.
+    #[actix_web::test]
+    async fn test_a_pinned_ladder_wider_than_the_spot_is_refused() {
+        let app = v2_service!();
+
+        let mut request_body = reference_body();
+        match request_body.as_object_mut() {
+            Some(map) => {
+                map.insert("strike_ladder".to_string(), json!("pinned"));
+                map.insert("initial_price".to_string(), json!(100.0));
+                map.insert("strike_interval".to_string(), json!(5.0));
+                map.insert("chain_size".to_string(), json!(25));
+            }
+            None => panic!("the reference body must be an object"),
+        }
+
+        let request = actix_test::TestRequest::post()
+            .uri("/api/v2/simulations")
+            .set_json(request_body)
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body: Value = actix_test::read_body_json(response).await;
+        assert_eq!(
+            body.get("field"),
+            Some(&json!("chain_size")),
+            "the rejection must name what to lower: {body}"
+        );
     }
 
     /// A spread coefficient outside its range is a typed 400 naming the field.

--- a/src/api/rest/handlers_v2.rs
+++ b/src/api/rest/handlers_v2.rs
@@ -127,7 +127,9 @@ fn parse_id(raw: &str) -> Result<Uuid, ChainError> {
         across steps needs. A pinned simulation must supply `strike_interval`, because \
         without one the interval is derived per expiration and there is no fixed grid to \
         pin, and a pinned ladder does not follow a large move: if the spot leaves its range \
-        the chain becomes all calls or all puts rather than inventing new strikes.",
+        every quoted strike ends up on one side of the money rather than the simulation \
+        inventing new ones, and a spot that drifts further than the service will widen for \
+        is a 400 naming strike_ladder.",
     request_body = CreateSimulationRequest,
     responses(
         (status = 201, description = "Simulation created", body = SimulationResponse),

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -10,6 +10,7 @@
 //! (`crate::session::model_v2`).
 
 use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+use crate::domain::ladder::StrikeLadder;
 use crate::session::ExpiryRule;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,20 @@ pub struct CreateSimulationRequest {
     /// Curvature of the volatility smile.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smile_curve: Option<f64>,
+    /// Which strikes the simulation quotes, `rolling` or `pinned`.
+    ///
+    /// `rolling` — the default, and what the service has always done —
+    /// rebuilds the ladder around the current underlying at every step, so the
+    /// quoted strikes stay near the money and a contract can leave the chain.
+    /// `pinned` fixes the ladder at creation from `initial_price`,
+    /// `chain_size` and `strike_interval`, so a contract quoted once is quoted
+    /// for the simulation's whole life, which is what a client holding a
+    /// position across steps needs. A pinned simulation must supply
+    /// `strike_interval`: without it the interval is derived per expiration and
+    /// there is no fixed grid to pin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub strike_ladder: Option<StrikeLadder>,
     /// The constant term of the spread model, applied to every contract. On
     /// its own — which is how every request that predates the model reads — it
     /// IS the whole model, exactly as before: one absolute bid-ask spread. A

--- a/src/api/rest/requests_v2.rs
+++ b/src/api/rest/requests_v2.rs
@@ -10,8 +10,8 @@
 //! (`crate::session::model_v2`).
 
 use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
-use crate::domain::ladder::StrikeLadder;
 use crate::session::ExpiryRule;
+use crate::session::StrikeLadder;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -106,7 +106,6 @@ pub struct CreateSimulationRequest {
     /// `strike_interval`: without it the interval is derived per expiration and
     /// there is no fixed grid to pin.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
     pub strike_ladder: Option<StrikeLadder>,
     /// The constant term of the spread model, applied to every contract. On
     /// its own — which is how every request that predates the model reads — it

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -18,9 +18,8 @@
 //! changes between two otherwise-identical replays.
 
 use crate::api::rest::greeks::{GreekLevel, GreeksResponse, greeks_for};
-use crate::domain::ladder::StrikeLadder;
 use crate::domain::series::SeriesSnapshot;
-use crate::session::{ExpiryRule, ExpiryRuleKind, SessionV2};
+use crate::session::{ExpiryRule, ExpiryRuleKind, SessionV2, StrikeLadder};
 use chrono::{DateTime, SecondsFormat, Utc};
 use optionstratlib::chains::OptionData;
 use rust_decimal::Decimal;
@@ -136,7 +135,6 @@ pub struct SimulationParametersResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smile_curve: Option<f64>,
     /// Which strikes the simulation quotes: `rolling` or `pinned`.
-    #[schema(value_type = String)]
     pub strike_ladder: StrikeLadder,
     /// The constant term of the spread model.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -18,6 +18,7 @@
 //! changes between two otherwise-identical replays.
 
 use crate::api::rest::greeks::{GreekLevel, GreeksResponse, greeks_for};
+use crate::domain::ladder::StrikeLadder;
 use crate::domain::series::SeriesSnapshot;
 use crate::session::{ExpiryRule, ExpiryRuleKind, SessionV2};
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -134,6 +135,9 @@ pub struct SimulationParametersResponse {
     /// Curvature of the volatility smile.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smile_curve: Option<f64>,
+    /// Which strikes the simulation quotes: `rolling` or `pinned`.
+    #[schema(value_type = String)]
+    pub strike_ladder: StrikeLadder,
     /// The constant term of the spread model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spread: Option<f64>,
@@ -349,6 +353,7 @@ impl From<&SessionV2> for SimulationParametersResponse {
             strike_interval: parameters.strike_interval.map(|value| value.to_f64()),
             skew_slope: parameters.skew_slope.and_then(|value| value.to_f64()),
             smile_curve: parameters.smile_curve.and_then(|value| value.to_f64()),
+            strike_ladder: parameters.strike_ladder,
             spread: parameters.spread.map(|value| value.to_f64()),
             spread_proportional: parameters
                 .spread_proportional

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -30,6 +30,7 @@ use utoipa::OpenApi;
             crate::api::rest::requests_v2::CreateSimulationRequest,
             crate::api::rest::responses_v2::SimulationResponse,
             crate::api::rest::responses_v2::SimulationParametersResponse,
+            crate::session::StrikeLadder,
             crate::api::rest::responses_v2::ScheduleRuleResponse,
             crate::api::rest::responses_v2::SnapshotResponse,
             crate::api::rest::responses_v2::ExpiryChainResponse,

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -69,7 +69,9 @@
 //! two agree algebraically but not in the last `Decimal` digits. The tolerance
 //! is pinned by a test. ADR 0001 §8 records the contract.
 
+use crate::api::rest::limits::MAX_CHAIN_SIZE;
 use crate::domain::Walker;
+use crate::domain::ladder::PinnedLadder;
 use crate::domain::simulator::{DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE};
 use crate::domain::spread::SpreadModel;
 use crate::session::{SimulationMethod, SimulationParametersV2};
@@ -949,7 +951,21 @@ pub(crate) fn build_chain(
     expiration: ExpirationDate,
     greek_snapshots: bool,
 ) -> Result<OptionChain, ChainError> {
-    let chain_size = parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE);
+    // A pinned simulation quotes the ladder it fixed at creation, so the chain
+    // is built wide enough to REACH those strikes from wherever the spot is now
+    // and filtered down to them afterwards. Upstream anchors every ladder on
+    // the same interval grid, so the pinned strikes are always among the ones
+    // it builds. See `crate::domain::ladder`.
+    let pinned = if parameters.strike_ladder.is_pinned() {
+        Some(PinnedLadder::resolve(parameters)?)
+    } else {
+        None
+    };
+
+    let chain_size = match &pinned {
+        Some(ladder) => ladder.width_from(spot, *MAX_CHAIN_SIZE)?,
+        None => parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE),
+    };
     let skew_slope = parameters.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);
     let smile_curve = parameters.smile_curve.unwrap_or(DEFAULT_SMILE_CURVE);
     // The spread model, not one scalar. Read once per chain: every coefficient
@@ -1014,6 +1030,13 @@ pub(crate) fn build_chain(
     let mut chain = OptionChain::build_chain(&build_params)
         .map_err(|e| ChainError::Internal(format!("Failed to build the option chain: {e}")))?;
 
+    // Down to the pinned strikes, before the spread model runs: the widened
+    // strikes exist only to reach the pinned ones and nothing should pay to
+    // quote them.
+    if let Some(ladder) = &pinned {
+        ladder.keep_pinned(&mut chain);
+    }
+
     spread_model.apply(&mut chain, days_to_expiration);
 
     Ok(chain)
@@ -1047,6 +1070,7 @@ mod tests {
     use super::*;
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::domain::ladder::StrikeLadder;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use chrono::{TimeZone, Weekday};
     use optionstratlib::error::SimulationError;
@@ -1083,6 +1107,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,
@@ -1425,6 +1450,97 @@ mod tests {
             chain.iter().count() > 0,
             "the lowest volatility above the floor must still quote a strike"
         );
+    }
+
+    // ---- the strike ladder (issue #91) ------------------------------------
+
+    /// A pinned ladder quotes the same strikes however far the spot moves.
+    ///
+    /// The criterion the issue is about: a position opened at step 0 must still
+    /// have its contracts at step 499. Driven at spots that move well past the
+    /// pinned range in both directions, since that is precisely when a rolling
+    /// ladder drops the strikes a defined-risk structure needs.
+    #[test]
+    fn test_a_pinned_ladder_quotes_one_strike_set_at_every_spot() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(6);
+        request.strike_interval = Some(25.0);
+        request.strike_ladder = Some(StrikeLadder::Pinned);
+        let parameters = parameters(request);
+
+        let expected = strike_set(&parameters, 5000.0);
+        assert_eq!(expected.len(), 13, "a half-width of six is 13 strikes");
+
+        for spot in [5000.0, 5004.95, 5013.54, 4800.0, 5400.0, 4000.0, 6500.0] {
+            assert_eq!(
+                strike_set(&parameters, spot),
+                expected,
+                "the pinned ladder moved at a spot of {spot}"
+            );
+        }
+    }
+
+    /// A rolling ladder does move, which is what the pinned one exists to fix.
+    ///
+    /// Without this the test above could pass on a ladder that never moves for
+    /// any configuration, and would be proving nothing.
+    #[test]
+    fn test_a_rolling_ladder_follows_the_spot() {
+        let mut request = request(4, brownian(0.2), 0.2);
+        request.chain_size = Some(6);
+        request.strike_interval = Some(25.0);
+        let parameters = parameters(request);
+
+        let at_the_start = strike_set(&parameters, 5000.0);
+        let after_a_move = strike_set(&parameters, 5013.54);
+
+        assert_ne!(
+            at_the_start, after_a_move,
+            "a rolling ladder must follow the spot, which is the reported bug"
+        );
+        assert_eq!(at_the_start.len(), after_a_move.len(), "the width is fixed");
+    }
+
+    /// A pinned chain carries the same prices a rolling one gives those strikes.
+    ///
+    /// Pinning decides WHICH contracts are quoted, never what they are worth:
+    /// the chain is built by upstream at the same spot either way, and the
+    /// pinned one is that chain with the other strikes removed.
+    #[test]
+    fn test_pinning_does_not_change_a_quote() {
+        let mut rolling = request(4, brownian(0.2), 0.2);
+        rolling.chain_size = Some(6);
+        rolling.strike_interval = Some(25.0);
+        let mut pinned = rolling.clone();
+        pinned.strike_ladder = Some(StrikeLadder::Pinned);
+
+        // At the starting spot the two ladders agree on the strike set, so
+        // every contract can be compared one to one.
+        let rolling = built_chain(&parameters(rolling));
+        let pinned = built_chain(&parameters(pinned));
+
+        assert_eq!(
+            rolling.options, pinned.options,
+            "pinning must not touch a price"
+        );
+    }
+
+    /// The strikes a chain quotes at one spot.
+    fn strike_set(parameters: &SimulationParametersV2, spot: f64) -> Vec<String> {
+        let chain = match build_chain(
+            parameters,
+            pos_or_panic!(spot),
+            pos_or_panic!(0.2),
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            false,
+        ) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the chain must build at {spot}: {error}"),
+        };
+        chain
+            .iter()
+            .map(|contract| contract.strike_price.to_string())
+            .collect()
     }
 
     // ---- the per-contract spread model (issue #80) ------------------------

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -70,7 +70,7 @@
 //! is pinned by a test. ADR 0001 §8 records the contract.
 
 use crate::domain::Walker;
-use crate::domain::ladder::{MAX_PINNED_WIDTH, PinnedLadder};
+use crate::domain::ladder::{PinnedLadder, max_pinned_width};
 use crate::domain::simulator::{DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE};
 use crate::domain::spread::SpreadModel;
 use crate::session::{SimulationMethod, SimulationParametersV2};
@@ -962,7 +962,11 @@ pub(crate) fn build_chain(
     };
 
     let chain_size = match &pinned {
-        Some(ladder) => ladder.width_from(spot, MAX_PINNED_WIDTH)?,
+        // The ceiling is this simulation's own snapshot budget, not a constant:
+        // a configuration validated for a handful of contracts per snapshot
+        // must not price a thousand strikes per expiration because its spot
+        // drifted.
+        Some(ladder) => ladder.width_from(spot, max_pinned_width(parameters)?)?,
         None => parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE),
     };
     let skew_slope = parameters.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -69,9 +69,8 @@
 //! two agree algebraically but not in the last `Decimal` digits. The tolerance
 //! is pinned by a test. ADR 0001 §8 records the contract.
 
-use crate::api::rest::limits::MAX_CHAIN_SIZE;
 use crate::domain::Walker;
-use crate::domain::ladder::PinnedLadder;
+use crate::domain::ladder::{MAX_PINNED_WIDTH, PinnedLadder};
 use crate::domain::simulator::{DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE};
 use crate::domain::spread::SpreadModel;
 use crate::session::{SimulationMethod, SimulationParametersV2};
@@ -963,7 +962,7 @@ pub(crate) fn build_chain(
     };
 
     let chain_size = match &pinned {
-        Some(ladder) => ladder.width_from(spot, *MAX_CHAIN_SIZE)?,
+        Some(ladder) => ladder.width_from(spot, MAX_PINNED_WIDTH)?,
         None => parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE),
     };
     let skew_slope = parameters.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);
@@ -1034,7 +1033,7 @@ pub(crate) fn build_chain(
     // strikes exist only to reach the pinned ones and nothing should pay to
     // quote them.
     if let Some(ladder) = &pinned {
-        ladder.keep_pinned(&mut chain);
+        ladder.keep_pinned(&mut chain)?;
     }
 
     spread_model.apply(&mut chain, days_to_expiration);

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -1013,12 +1013,15 @@ pub(crate) fn build_chain(
         parameters.strike_interval,
         skew_slope,
         smile_curve,
-        // ZERO, and the widening happens below instead. Upstream's
-        // `apply_spread` sets bid, ask AND mid to `None` when `mid <= spread`
-        // (OptionStratLib#439, fixed upstream but not in the published 0.20
-        // this builds against), so handing it the real spread would erase the
-        // cheap wings before anything here could quote them. With no spread it
-        // leaves each mid alone, which is what the model needs to work from.
+        // ZERO, and the widening happens below instead. The spread model here
+        // is per contract, so a single scalar handed to upstream would be the
+        // wrong number for every strike but one; asking for no spread leaves
+        // each mid untouched, which is what the model works from.
+        //
+        // It also used to be load-bearing against OptionStratLib#439, where
+        // `apply_spread` withdrew a quote whose mid fell below the spread.
+        // That is fixed as of 0.21.1, which this pins, so the zero is now
+        // about owning the widening rather than about avoiding an erasure.
         Positive::ZERO,
         2,
         price_params,

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -1,0 +1,469 @@
+//! Which strikes a simulation quotes, and for how long.
+//!
+//! Upstream rebuilds the strike ladder around the CURRENT underlying at every
+//! step, so the set of quoted contracts follows the spot. `chain_size` fixes how
+//! many strikes are quoted; it does not fix which. Measured on a live v2
+//! simulation, a spot move of 0.27 percent over two steps was enough for the
+//! 4850 strike to leave the chain.
+//!
+//! For a client browsing a chain that is the right behaviour. For a client
+//! HOLDING a position it is not: a leg opened at 4850 cannot be marked, closed
+//! or settled at a step where 4850 does not exist, and over the 500 steps of the
+//! reference scenario that is the normal case rather than an edge one. A
+//! defined-risk structure loses its furthest wings first, which are exactly the
+//! legs that cap its risk.
+//!
+//! [`StrikeLadder::Pinned`] answers that by fixing the contract universe at
+//! creation: the ladder is computed once from `initial_price`, `chain_size` and
+//! `strike_interval`, and every step quotes that same set. A simulation becomes
+//! a closed world for its whole life, which is what makes a position in it well
+//! defined. [`StrikeLadder::Rolling`] is the default and is exactly what the
+//! service did before.
+//!
+//! # How a pinned ladder is served
+//!
+//! Upstream anchors every chain at `rounder(underlying, strike_interval)`, which
+//! snaps to a MULTIPLE of the interval, so every ladder it builds — at any spot
+//! — lies on the same grid. A pinned strike is therefore always reachable from
+//! the current at-the-money strike by a whole number of intervals.
+//!
+//! Serving a pinned ladder is then: ask upstream for a chain wide enough to
+//! reach the furthest pinned strike from where the spot is now, and keep the
+//! pinned strikes out of it. The chain is priced by upstream exactly as it
+//! always was, at the current spot, and nothing here builds a contract by hand.
+//!
+//! The cost is the strikes that get priced and dropped, which grows as the spot
+//! drifts away from where it started. That is the price of the closed world, and
+//! it is paid only by a simulation that asked for one.
+//!
+//! **A pinned ladder does not follow a large move.** If the spot leaves the
+//! pinned range the chain becomes all calls or all puts, which is correct and
+//! informative: a real chain does get listed further out, but a simulation that
+//! silently invented new strikes would not be the closed world this exists to
+//! provide. Widen the ladder at creation, with `chain_size`, rather than at step
+//! time.
+
+use crate::session::SimulationParametersV2;
+use crate::utils::ChainError;
+use positive::Positive;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use utoipa::ToSchema;
+
+/// Which strikes a simulation quotes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StrikeLadder {
+    /// The ladder is rebuilt around the current underlying at every step, so
+    /// the quoted strikes stay near the money and a contract can leave the
+    /// chain. The default, and what the service has always done.
+    #[default]
+    Rolling,
+    /// The ladder is fixed at creation and every step quotes the same strikes,
+    /// so a contract quoted once is quoted for the simulation's whole life.
+    Pinned,
+}
+
+impl StrikeLadder {
+    /// Whether this ladder fixes the contract universe.
+    #[must_use]
+    pub fn is_pinned(self) -> bool {
+        matches!(self, StrikeLadder::Pinned)
+    }
+}
+
+/// The strikes a pinned simulation quotes, resolved once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PinnedLadder {
+    /// The strikes, ascending. A `BTreeSet` because that is how a chain stores
+    /// its contracts and because membership is what the filter asks.
+    strikes: BTreeSet<Positive>,
+    /// The grid the strikes sit on.
+    interval: Positive,
+}
+
+impl PinnedLadder {
+    /// Resolves the ladder a simulation pinned at creation.
+    ///
+    /// A pure function of parameters that are already stored — the initial
+    /// price, the chain size and the strike interval — so a replay reproduces
+    /// it without anything extra being persisted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the parameters carry no
+    /// `strike_interval`. A pinned ladder needs a fixed grid, and with the
+    /// interval absent upstream derives a different one per expiration, so
+    /// there would be no single ladder to pin. The request path refuses the
+    /// combination, so this is the stored-document half of the same guard.
+    pub(crate) fn resolve(parameters: &SimulationParametersV2) -> Result<Self, ChainError> {
+        let Some(interval) = parameters.strike_interval else {
+            return Err(ChainError::Validation {
+                field: "strike_interval".to_string(),
+                reason: "a pinned strike ladder needs an explicit strike_interval: without one \
+                         the interval is derived per expiration and there is no fixed grid to pin"
+                    .to_string(),
+            });
+        };
+
+        let chain_size = parameters
+            .chain_size
+            .unwrap_or(crate::domain::simulator::DEFAULT_CHAIN_SIZE);
+        let centre = at_the_money(parameters.initial_price, interval);
+
+        let mut strikes = BTreeSet::new();
+        strikes.insert(centre);
+        for step in 1..=chain_size {
+            let offset = interval * Decimal::from(step as u64);
+            if let Ok(upper) = Positive::new_decimal(centre.to_dec() + offset.to_dec()) {
+                strikes.insert(upper);
+            }
+            // A strike at or below zero is not a contract; upstream stops
+            // extending downwards at the same point.
+            let lower = centre.to_dec() - offset.to_dec();
+            if lower > Decimal::ZERO
+                && let Ok(lower) = Positive::new_decimal(lower)
+            {
+                strikes.insert(lower);
+            }
+        }
+
+        Ok(Self { strikes, interval })
+    }
+
+    /// The strikes, ascending.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn strikes(&self) -> &BTreeSet<Positive> {
+        &self.strikes
+    }
+
+    /// How wide a chain built at `spot` must be to contain every pinned strike.
+    ///
+    /// Measured in strikes per side, which is what `chain_size` means to
+    /// upstream: the distance in intervals from the spot's at-the-money strike
+    /// to whichever pinned strike is furthest from it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when that distance exceeds `maximum`.
+    /// Reaching it takes a spot that has moved `maximum` intervals away from
+    /// where the simulation started — hundreds of percent for any ordinary
+    /// configuration — and quoting a subset of the pinned ladder would silently
+    /// break the guarantee the ladder exists to make, so it fails loudly
+    /// instead.
+    pub(crate) fn width_from(&self, spot: Positive, maximum: usize) -> Result<usize, ChainError> {
+        let centre = at_the_money(spot, self.interval).to_dec();
+        let interval = self.interval.to_dec();
+
+        let mut widest = 0_usize;
+        for strike in &self.strikes {
+            let distance = (strike.to_dec() - centre).abs();
+            let steps = distance
+                .checked_div(interval)
+                .map(|steps| steps.ceil())
+                .and_then(|steps| usize::try_from(steps).ok())
+                .ok_or_else(|| {
+                    ChainError::Internal(format!(
+                        "the pinned strike {strike} is unreachable from a spot of {spot}"
+                    ))
+                })?;
+            widest = widest.max(steps);
+        }
+
+        if widest > maximum {
+            return Err(ChainError::Internal(format!(
+                "a pinned ladder {widest} strikes from the spot exceeds the {maximum} a chain may \
+                 carry; the underlying has left the range this simulation pinned at creation"
+            )));
+        }
+        Ok(widest)
+    }
+
+    /// Drops from a built chain every strike this ladder does not name.
+    ///
+    /// The chain was built wide enough to contain all of them, so what is left
+    /// is exactly the pinned set, priced by upstream at the current spot.
+    pub(crate) fn keep_pinned(&self, chain: &mut optionstratlib::chains::chain::OptionChain) {
+        let strikes = &self.strikes;
+        let contracts = std::mem::take(&mut chain.options);
+        chain.options = contracts
+            .into_iter()
+            .filter(|contract| strikes.contains(&contract.strike_price))
+            .collect();
+    }
+}
+
+/// The strike upstream anchors a chain at, for a given underlying.
+///
+/// Mirrors `optionstratlib::chains::utils::rounder`, which is `pub(crate)`
+/// there: the nearest multiple of the interval, halves rounding up. It is
+/// mirrored rather than guessed, and
+/// `test_the_mirrored_anchor_matches_upstream` pins the two together by
+/// building a real chain and reading the strike upstream chose.
+#[must_use]
+pub(crate) fn at_the_money(underlying: Positive, interval: Positive) -> Positive {
+    if interval == Positive::ZERO {
+        return underlying;
+    }
+
+    let price = underlying.to_dec();
+    let interval = interval.to_dec();
+    let Some(remainder) = price.checked_rem(interval) else {
+        return underlying;
+    };
+    let base = price - remainder;
+
+    let rounded = if remainder + remainder >= interval {
+        base + interval
+    } else {
+        base
+    };
+    Positive::new_decimal(rounded).unwrap_or(underlying)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+
+    /// The anchor rounds to the nearest multiple, halves up.
+    #[test]
+    fn test_the_anchor_rounds_to_the_grid() {
+        let interval = pos_or_panic!(25.0);
+
+        for (underlying, expected) in [
+            (5000.0, 5000.0),
+            (5004.95, 5000.0),
+            (5013.54, 5025.0),
+            (5012.5, 5025.0),
+            (5012.49, 5000.0),
+        ] {
+            assert_eq!(
+                at_the_money(pos_or_panic!(underlying), interval),
+                pos_or_panic!(expected),
+                "for {underlying}"
+            );
+        }
+    }
+
+    /// A zero interval leaves the price alone rather than dividing by it.
+    #[test]
+    fn test_a_zero_interval_is_not_a_grid() {
+        assert_eq!(
+            at_the_money(pos_or_panic!(5000.0), Positive::ZERO),
+            pos_or_panic!(5000.0)
+        );
+    }
+
+    /// The ladder is the grid around the initial price, `2n + 1` wide.
+    #[test]
+    fn test_the_ladder_is_the_grid_around_the_initial_price() {
+        let ladder = ladder_of(5000.0, 25.0, 2);
+
+        assert_eq!(
+            ladder.strikes().iter().copied().collect::<Vec<_>>(),
+            vec![
+                pos_or_panic!(4950.0),
+                pos_or_panic!(4975.0),
+                pos_or_panic!(5000.0),
+                pos_or_panic!(5025.0),
+                pos_or_panic!(5050.0),
+            ]
+        );
+    }
+
+    /// A ladder wide enough to reach zero stops at the last positive strike.
+    #[test]
+    fn test_the_ladder_never_reaches_a_zero_strike() {
+        let ladder = ladder_of(50.0, 25.0, 4);
+
+        assert!(
+            ladder
+                .strikes()
+                .iter()
+                .all(|strike| *strike > Positive::ZERO),
+            "a strike of zero is not a contract: {:?}",
+            ladder.strikes()
+        );
+        assert!(ladder.strikes().contains(&pos_or_panic!(25.0)));
+    }
+
+    /// The width a chain needs grows with the distance the spot has moved.
+    #[test]
+    fn test_the_width_grows_with_the_distance_from_the_ladder() {
+        let ladder = ladder_of(5000.0, 25.0, 2);
+
+        // At the centre, the ladder's own half-width is enough.
+        match ladder.width_from(pos_or_panic!(5000.0), 500) {
+            Ok(width) => assert_eq!(width, 2),
+            Err(error) => panic!("the centre must resolve: {error}"),
+        }
+        // Four intervals up, the furthest strike is six intervals away.
+        match ladder.width_from(pos_or_panic!(5100.0), 500) {
+            Ok(width) => assert_eq!(width, 6),
+            Err(error) => panic!("a drifted spot must resolve: {error}"),
+        }
+    }
+
+    /// A spot that has left the pinned range entirely fails loudly.
+    #[test]
+    fn test_a_spot_beyond_the_maximum_is_refused() {
+        let ladder = ladder_of(5000.0, 25.0, 2);
+
+        match ladder.width_from(pos_or_panic!(9000.0), 10) {
+            Ok(width) => panic!("a spot 160 intervals away must not resolve, got {width}"),
+            Err(ChainError::Internal(message)) => assert!(
+                message.contains("left the range"),
+                "the failure must explain: {message}"
+            ),
+            Err(error) => panic!("expected an internal failure, got {error:?}"),
+        }
+    }
+
+    /// A pinned ladder needs an explicit interval, and says so.
+    #[test]
+    fn test_a_ladder_without_an_interval_is_refused() {
+        let mut parameters = parameters(5000.0, 25.0, 2);
+        parameters.strike_interval = None;
+
+        match PinnedLadder::resolve(&parameters) {
+            Ok(ladder) => panic!("a ladder with no grid must not resolve, got {ladder:?}"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "strike_interval");
+                assert!(reason.contains("per expiration"), "{reason}");
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
+    }
+
+    /// The default is the behaviour the service already had.
+    #[test]
+    fn test_rolling_is_the_default() {
+        assert_eq!(StrikeLadder::default(), StrikeLadder::Rolling);
+        assert!(!StrikeLadder::default().is_pinned());
+        assert!(StrikeLadder::Pinned.is_pinned());
+    }
+
+    /// The wire words are the ones the issue named.
+    #[test]
+    fn test_the_wire_form_is_snake_case() {
+        for (ladder, wire) in [
+            (StrikeLadder::Rolling, "\"rolling\""),
+            (StrikeLadder::Pinned, "\"pinned\""),
+        ] {
+            match serde_json::to_string(&ladder) {
+                Ok(json) => assert_eq!(json, wire),
+                Err(error) => panic!("must serialize: {error}"),
+            }
+            match serde_json::from_str::<StrikeLadder>(wire) {
+                Ok(parsed) => assert_eq!(parsed, ladder),
+                Err(error) => panic!("must deserialize: {error}"),
+            }
+        }
+    }
+
+    /// Effective parameters from a request, so the tests go through the same
+    /// conversion a client does rather than hand-building a state the request
+    /// path would refuse.
+    fn parameters(initial_price: f64, interval: f64, chain_size: usize) -> SimulationParametersV2 {
+        use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+        use crate::api::rest::requests_v2::CreateSimulationRequest;
+        use crate::session::{ExpiryRule, ExpiryRuleKind};
+        use chrono::{TimeZone, Utc};
+
+        let start_at = match Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).single() {
+            Some(instant) => instant,
+            None => panic!("the test instant must be valid"),
+        };
+        let rule = match ExpiryRule::new("zero_dte", ExpiryRuleKind::Daily, 1) {
+            Ok(rule) => rule,
+            Err(error) => panic!("the test rule must be valid: {error}"),
+        };
+
+        let request = CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 4,
+            start_at: Some(start_at),
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: None,
+            expiration_time: "17:00".to_string(),
+            schedules: vec![rule],
+            initial_price,
+            volatility: 0.2,
+            risk_free_rate: 0.04,
+            dividend_yield: 0.0,
+            method: ApiWalkType::Brownian {
+                dt: 1.0 / 252.0,
+                drift: 0.0,
+                volatility: 0.2,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(chain_size),
+            strike_interval: Some(interval),
+            skew_slope: None,
+            smile_curve: None,
+            spread: Some(0.02),
+            strike_ladder: Some(StrikeLadder::Pinned),
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
+            seed: Some(42),
+        };
+
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the request must convert: {error}"),
+        }
+    }
+
+    fn ladder_of(initial_price: f64, interval: f64, chain_size: usize) -> PinnedLadder {
+        match PinnedLadder::resolve(&parameters(initial_price, interval, chain_size)) {
+            Ok(ladder) => ladder,
+            Err(error) => panic!("the ladder must resolve: {error}"),
+        }
+    }
+
+    /// The mirrored anchor is the strike upstream actually chooses.
+    ///
+    /// `rounder` is `pub(crate)` upstream, so this mirrors it; the mirror is
+    /// only worth having if it agrees, and this builds a real chain to check.
+    #[test]
+    fn test_the_mirrored_anchor_matches_upstream() {
+        use optionstratlib::ExpirationDate;
+
+        let interval = pos_or_panic!(25.0);
+        for spot in [5000.0, 5004.95, 5013.54, 4987.5] {
+            let mut parameters = parameters(5000.0, 25.0, 1);
+            parameters.strike_ladder = StrikeLadder::Rolling;
+
+            let chain = match crate::domain::factors::build_chain(
+                &parameters,
+                pos_or_panic!(spot),
+                pos_or_panic!(0.2),
+                ExpirationDate::Days(pos_or_panic!(30.0)),
+                false,
+            ) {
+                Ok(chain) => chain,
+                Err(error) => panic!("the chain must build at {spot}: {error}"),
+            };
+
+            // A chain of half-width one is [atm - interval, atm, atm + interval],
+            // so the middle strike is upstream's anchor.
+            let strikes: Vec<Positive> =
+                chain.iter().map(|contract| contract.strike_price).collect();
+            let middle = strikes[strikes.len() / 2];
+
+            assert_eq!(
+                at_the_money(pos_or_panic!(spot), interval),
+                middle,
+                "the mirror disagrees with upstream at a spot of {spot}: {strikes:?}"
+            );
+        }
+        let _ = dec!(0);
+    }
+}

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -51,21 +51,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use utoipa::ToSchema;
 
-/// How far a pinned ladder may sit from the spot before a step refuses.
-///
-/// A pinned step asks upstream for a chain wide enough to REACH the pinned
-/// strikes from wherever the underlying is now, so this bounds the widening
-/// rather than the ladder: a simulation whose spot has drifted this many
-/// intervals from where it started would have the service price a thousand
-/// strikes to serve thirteen.
-///
-/// It lives here rather than being read from the request caps because it is
-/// not a request size. `OCS_MAX_CHAIN_SIZE` bounds what a client may ask for;
-/// this bounds what the domain will build on its behalf, and tying the two
-/// together would make lowering the request cap silently break simulations
-/// already running.
-pub(crate) const MAX_PINNED_WIDTH: usize = 500;
-
 /// Which strikes a simulation quotes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
 #[serde(rename_all = "snake_case")]
@@ -186,17 +171,43 @@ impl PinnedLadder {
     /// upstream: the distance in intervals from the spot's at-the-money strike
     /// to whichever pinned strike is furthest from it.
     ///
+    /// `maximum` is the widening the simulation's own snapshot budget allows,
+    /// derived by [`max_pinned_width`] from the same numbers
+    /// `validate_snapshot_work` checked at creation. A pinned step must not be
+    /// able to price more contracts than the configuration was validated for
+    /// simply because the underlying drifted.
+    ///
     /// # Errors
     ///
-    /// Returns [`ChainError::Validation`] naming `strike_ladder` when that
-    /// distance exceeds [`MAX_PINNED_WIDTH`]. Reaching it takes a spot that has
+    /// Returns [`ChainError::Validation`] naming `strike_ladder` when the spot
+    /// has fallen so far that its chain would be anchored at a strike of zero,
+    /// and when the distance exceeds `maximum`. Reaching it takes a spot that has
     /// moved that many intervals from where the simulation started, and quoting
     /// a subset of the pinned ladder would silently break the guarantee the
     /// ladder exists to make. It is a validation failure rather than an
     /// internal one because it is a foreseeable consequence of the
     /// configuration the client chose, and the message says which.
     pub(crate) fn width_from(&self, spot: Positive, maximum: usize) -> Result<usize, ChainError> {
-        let centre = at_the_money(spot, self.interval)?.to_dec();
+        let anchor = at_the_money(spot, self.interval)?;
+
+        // A spot below half the interval anchors at zero, and upstream refuses
+        // to build a chain around a strike of zero. Caught HERE, before
+        // anything is priced: the same failure raised during a build reaches
+        // an export after its 200 and its prologue have gone out, which leaves
+        // the client a truncated file rather than a rejection.
+        if anchor == Positive::ZERO {
+            return Err(ChainError::Validation {
+                field: "strike_ladder".to_string(),
+                reason: format!(
+                    "the underlying has fallen to {spot}, below half the {} interval this \
+                     simulation pinned, so its chain would have to be built around a strike of \
+                     zero; a pinned ladder cannot follow a move that far",
+                    self.interval
+                ),
+            });
+        }
+
+        let centre = anchor.to_dec();
         let interval = self.interval.to_dec();
 
         let mut widest = 0_usize;
@@ -322,6 +333,47 @@ pub(crate) fn at_the_money(
     };
 
     Positive::new_decimal(rounded).map_err(|_| unrepresentable())
+}
+
+/// The widest chain a pinned step may ask upstream for.
+///
+/// A pinned step builds wide enough to REACH its ladder and then filters, so
+/// the widening is work the client never asked for and the request caps never
+/// saw. Bounding it by a constant of its own would let a simulation validated
+/// for a handful of contracts per snapshot price a thousand strikes per
+/// expiration once its spot drifted.
+///
+/// The bound is therefore the simulation's own budget, computed from the same
+/// numbers `SimulationParametersV2::validate_snapshot_work` checked at
+/// creation: the per-snapshot contract cap divided by the expirations the
+/// schedule can carry, back through the `2n + 1` grid to a half-width.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] when the schedule's expiration count
+/// overflows, which the creation path also refuses.
+pub(crate) fn max_pinned_width(parameters: &SimulationParametersV2) -> Result<usize, ChainError> {
+    let expirations = parameters
+        .schedule
+        .rules()
+        .iter()
+        .try_fold(0usize, |total, rule| {
+            total.checked_add(rule.target_count().get())
+        })
+        .ok_or_else(|| ChainError::Validation {
+            field: "schedules".to_string(),
+            reason: "the requested expiration counts overflow".to_string(),
+        })?;
+
+    let cap = crate::infrastructure::max_snapshot_contracts();
+    // A schedule with no rules cannot produce a chain, so the width is
+    // irrelevant; one is the smallest answer that is not zero.
+    let strikes = cap.checked_div(expirations.max(1)).unwrap_or(cap);
+
+    // `strikes` covers `2n + 1`, so the half-width is what upstream calls
+    // `chain_size`. At least one, or a pinned ladder of a single strike could
+    // never be reached.
+    Ok(strikes.saturating_sub(1).checked_div(2).unwrap_or(0).max(1))
 }
 
 /// Refuses a pinned ladder whose lowest strike upstream cannot build.
@@ -517,6 +569,51 @@ mod tests {
             }
             Err(error) => panic!("expected a validation failure, got {error:?}"),
         }
+    }
+
+    /// A spot below half the interval anchors at zero, which upstream cannot
+    /// build a chain around. It has to fail as a validation error here, before
+    /// pricing, rather than as an internal one halfway through an export.
+    #[test]
+    fn test_a_spot_below_half_the_interval_is_refused() {
+        let ladder = ladder_of(5000.0, 25.0, 2);
+
+        match ladder.width_from(pos_or_panic!(0.01), usize::MAX) {
+            Ok(width) => panic!("a spot under the grid must not resolve, got {width}"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "strike_ladder");
+                assert!(
+                    reason.contains("strike of zero"),
+                    "the failure must say why: {reason}"
+                );
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
+
+        // Half an interval is the first spot that anchors on the grid.
+        match ladder.width_from(pos_or_panic!(12.5), usize::MAX) {
+            Ok(width) => assert_eq!(width, 201),
+            Err(error) => panic!("the first quotable spot must resolve: {error}"),
+        }
+    }
+
+    /// The widening ceiling is the simulation's own snapshot budget, so a
+    /// pinned step cannot price more contracts than the configuration was
+    /// validated for.
+    #[test]
+    fn test_the_widening_ceiling_comes_from_the_snapshot_budget() {
+        let parameters = parameters(5000.0, 25.0, 2);
+
+        let width = match max_pinned_width(&parameters) {
+            Ok(width) => width,
+            Err(error) => panic!("the budget must resolve: {error}"),
+        };
+
+        // One expiration, so the whole per-snapshot budget is one chain: the
+        // `2n + 1` grid must fit inside it.
+        let cap = crate::infrastructure::max_snapshot_contracts();
+        assert!(width * 2 < cap, "{width} strikes per side exceeds {cap}");
+        assert!(width >= 1, "a ladder of one strike must stay reachable");
     }
 
     /// A pinned ladder needs an explicit interval, and says so.

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -423,10 +423,12 @@ mod tests {
         );
     }
 
-    /// A ladder wide enough to reach zero stops at the last positive strike.
+    /// A ladder never carries a strike at or below zero.
     #[test]
     fn test_the_ladder_never_reaches_a_zero_strike() {
-        let ladder = ladder_of(50.0, 25.0, 4);
+        // Two below an anchor of 50 reaches exactly zero, which `checked_sub`
+        // refuses, so the ladder stops at 25.
+        let ladder = ladder_of(50.0, 25.0, 2);
 
         assert!(
             ladder
@@ -437,6 +439,49 @@ mod tests {
             ladder.strikes()
         );
         assert!(ladder.strikes().contains(&pos_or_panic!(25.0)));
+    }
+
+    /// A ladder that reaches past its anchor is refused at creation.
+    ///
+    /// Upstream stops building a chain once the offset passes the anchor, so
+    /// those strikes would never exist to be filtered to. The measured case:
+    /// an initial price of 100 with a 5-point interval and a chain size of 25
+    /// asks for strikes down to 5, and upstream builds only to 200 on the way
+    /// up.
+    #[test]
+    fn test_a_ladder_reaching_past_the_anchor_is_refused() {
+        match ensure_ladder_fits(pos_or_panic!(100.0), pos_or_panic!(5.0), 25) {
+            Ok(()) => panic!("a ladder wider than its anchor must be refused"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "chain_size");
+                assert!(reason.contains("never exist"), "{reason}");
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
+
+        // One that fits is accepted, including the exact boundary.
+        match ensure_ladder_fits(pos_or_panic!(100.0), pos_or_panic!(5.0), 20) {
+            Ok(()) => {}
+            Err(error) => panic!("a ladder that ends at the anchor must fit: {error}"),
+        }
+    }
+
+    /// The overflow guards hold on a ladder no grid can lay out.
+    ///
+    /// `strike_interval` is client input with no upper bound, and both
+    /// `Positive` and `Decimal` panic on overflow.
+    #[test]
+    fn test_an_unrepresentable_grid_is_refused_rather_than_panicking() {
+        let huge = match Positive::new_decimal(Decimal::MAX / Decimal::TWO) {
+            Ok(value) => value,
+            Err(error) => panic!("the fixture must be positive: {error}"),
+        };
+
+        match ensure_ladder_fits(huge, huge, 500) {
+            Ok(()) => panic!("a grid this wide cannot be laid out"),
+            Err(ChainError::Validation { .. }) => {}
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
     }
 
     /// The width a chain needs grows with the distance the spot has moved.
@@ -463,11 +508,14 @@ mod tests {
 
         match ladder.width_from(pos_or_panic!(9000.0), 10) {
             Ok(width) => panic!("a spot 160 intervals away must not resolve, got {width}"),
-            Err(ChainError::Internal(message)) => assert!(
-                message.contains("left the range"),
-                "the failure must explain: {message}"
-            ),
-            Err(error) => panic!("expected an internal failure, got {error:?}"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "strike_ladder");
+                assert!(
+                    reason.contains("pinned at creation"),
+                    "the failure must explain: {reason}"
+                );
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
         }
     }
 
@@ -481,7 +529,7 @@ mod tests {
             Ok(ladder) => panic!("a ladder with no grid must not resolve, got {ladder:?}"),
             Err(ChainError::Validation { field, reason }) => {
                 assert_eq!(field, "strike_interval");
-                assert!(reason.contains("per expiration"), "{reason}");
+                assert!(reason.contains("varies the chain size"), "{reason}");
             }
             Err(error) => panic!("expected a validation failure, got {error:?}"),
         }

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -51,6 +51,21 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use utoipa::ToSchema;
 
+/// How far a pinned ladder may sit from the spot before a step refuses.
+///
+/// A pinned step asks upstream for a chain wide enough to REACH the pinned
+/// strikes from wherever the underlying is now, so this bounds the widening
+/// rather than the ladder: a simulation whose spot has drifted this many
+/// intervals from where it started would have the service price a thousand
+/// strikes to serve thirteen.
+///
+/// It lives here rather than being read from the request caps because it is
+/// not a request size. `OCS_MAX_CHAIN_SIZE` bounds what a client may ask for;
+/// this bounds what the domain will build on its behalf, and tying the two
+/// together would make lowering the request cap silently break simulations
+/// already running.
+pub(crate) const MAX_PINNED_WIDTH: usize = 500;
+
 /// Which strikes a simulation quotes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
 #[serde(rename_all = "snake_case")]
@@ -102,7 +117,9 @@ impl PinnedLadder {
             return Err(ChainError::Validation {
                 field: "strike_interval".to_string(),
                 reason: "a pinned strike ladder needs an explicit strike_interval: without one \
-                         the interval is derived per expiration and there is no fixed grid to pin"
+                         upstream derives the interval from the expiration AND the chain size, \
+                         and the pinned path varies the chain size per step, so the grid would \
+                         move under the ladder it is meant to hold still"
                     .to_string(),
             });
         };
@@ -110,20 +127,44 @@ impl PinnedLadder {
         let chain_size = parameters
             .chain_size
             .unwrap_or(crate::domain::simulator::DEFAULT_CHAIN_SIZE);
-        let centre = at_the_money(parameters.initial_price, interval);
+        let centre = at_the_money(parameters.initial_price, interval)?;
 
+        // A centre of zero is not a strike, and every offset above it would be
+        // a ladder hanging off nothing. It happens when the initial price is
+        // below half an interval, which is a configuration to refuse rather
+        // than to round away.
+        if centre == Positive::ZERO {
+            return Err(ChainError::Validation {
+                field: "strike_interval".to_string(),
+                reason: format!(
+                    "an interval of {interval} rounds an initial price of {} to a strike of \
+                     zero, so there is no ladder to pin",
+                    parameters.initial_price
+                ),
+            });
+        }
+
+        // Checked throughout: `strike_interval` is client input with no upper
+        // bound, and both `Positive`'s operators and `Decimal`'s panic on
+        // overflow. Upstream's own loop guards the same multiplication and
+        // addition; the mirror keeps the guards rather than only the maths.
         let mut strikes = BTreeSet::new();
         strikes.insert(centre);
         for step in 1..=chain_size {
-            let offset = interval * Decimal::from(step as u64);
-            if let Ok(upper) = Positive::new_decimal(centre.to_dec() + offset.to_dec()) {
-                strikes.insert(upper);
-            }
-            // A strike at or below zero is not a contract; upstream stops
-            // extending downwards at the same point.
-            let lower = centre.to_dec() - offset.to_dec();
-            if lower > Decimal::ZERO
-                && let Ok(lower) = Positive::new_decimal(lower)
+            let offset = interval
+                .checked_mul_dec(Decimal::from(step))
+                .map_err(|error| ladder_overflow(interval, step, &error.to_string()))?;
+
+            let upper = centre
+                .checked_add(&offset)
+                .map_err(|error| ladder_overflow(interval, step, &error.to_string()))?;
+            strikes.insert(upper);
+
+            // A strike at or below zero is not a contract, and upstream stops
+            // extending downwards at the same point. `checked_sub` refuses to
+            // go negative, which is exactly that rule.
+            if let Ok(lower) = centre.checked_sub(&offset)
+                && lower > Positive::ZERO
             {
                 strikes.insert(lower);
             }
@@ -147,14 +188,15 @@ impl PinnedLadder {
     ///
     /// # Errors
     ///
-    /// Returns [`ChainError::Internal`] when that distance exceeds `maximum`.
-    /// Reaching it takes a spot that has moved `maximum` intervals away from
-    /// where the simulation started — hundreds of percent for any ordinary
-    /// configuration — and quoting a subset of the pinned ladder would silently
-    /// break the guarantee the ladder exists to make, so it fails loudly
-    /// instead.
+    /// Returns [`ChainError::Validation`] naming `strike_ladder` when that
+    /// distance exceeds [`MAX_PINNED_WIDTH`]. Reaching it takes a spot that has
+    /// moved that many intervals from where the simulation started, and quoting
+    /// a subset of the pinned ladder would silently break the guarantee the
+    /// ladder exists to make. It is a validation failure rather than an
+    /// internal one because it is a foreseeable consequence of the
+    /// configuration the client chose, and the message says which.
     pub(crate) fn width_from(&self, spot: Positive, maximum: usize) -> Result<usize, ChainError> {
-        let centre = at_the_money(spot, self.interval).to_dec();
+        let centre = at_the_money(spot, self.interval)?.to_dec();
         let interval = self.interval.to_dec();
 
         let mut widest = 0_usize;
@@ -164,34 +206,73 @@ impl PinnedLadder {
                 .checked_div(interval)
                 .map(|steps| steps.ceil())
                 .and_then(|steps| usize::try_from(steps).ok())
-                .ok_or_else(|| {
-                    ChainError::Internal(format!(
+                .ok_or_else(|| ChainError::Validation {
+                    field: "strike_ladder".to_string(),
+                    reason: format!(
                         "the pinned strike {strike} is unreachable from a spot of {spot}"
-                    ))
+                    ),
                 })?;
             widest = widest.max(steps);
         }
 
         if widest > maximum {
-            return Err(ChainError::Internal(format!(
-                "a pinned ladder {widest} strikes from the spot exceeds the {maximum} a chain may \
-                 carry; the underlying has left the range this simulation pinned at creation"
-            )));
+            return Err(ChainError::Validation {
+                field: "strike_ladder".to_string(),
+                reason: format!(
+                    "the underlying has moved {widest} strikes from the ladder this simulation \
+                     pinned at creation, past the {maximum} a chain may carry; a pinned ladder \
+                     does not follow a move that far, so widen it at creation with chain_size"
+                ),
+            });
         }
         Ok(widest)
     }
 
-    /// Drops from a built chain every strike this ladder does not name.
+    /// Drops from a built chain every strike this ladder does not name, and
+    /// refuses a chain that did not carry them all.
     ///
-    /// The chain was built wide enough to contain all of them, so what is left
-    /// is exactly the pinned set, priced by upstream at the current spot.
-    pub(crate) fn keep_pinned(&self, chain: &mut optionstratlib::chains::chain::OptionChain) {
+    /// The chain is built wide enough to contain the whole pinned set, but
+    /// "wide enough" is a request: upstream stops extending its ladder for
+    /// reasons of its own — a strike that would fall at or below zero, a
+    /// genuine pricing failure on both wings — and a filter cannot tell a
+    /// missing strike from one it dropped. Returning a partial ladder silently
+    /// would reproduce the exact hole this feature exists to close, so a short
+    /// chain is an error naming what is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Internal`] when a pinned strike is not in the
+    /// built chain.
+    pub(crate) fn keep_pinned(
+        &self,
+        chain: &mut optionstratlib::chains::chain::OptionChain,
+    ) -> Result<(), ChainError> {
         let strikes = &self.strikes;
         let contracts = std::mem::take(&mut chain.options);
         chain.options = contracts
             .into_iter()
             .filter(|contract| strikes.contains(&contract.strike_price))
             .collect();
+
+        if chain.options.len() == strikes.len() {
+            return Ok(());
+        }
+
+        let present: BTreeSet<Positive> = chain
+            .options
+            .iter()
+            .map(|contract| contract.strike_price)
+            .collect();
+        let missing: Vec<String> = strikes
+            .iter()
+            .filter(|strike| !present.contains(strike))
+            .map(ToString::to_string)
+            .collect();
+
+        Err(ChainError::Internal(format!(
+            "the pinned ladder is incomplete: the chain built at this step does not carry {}",
+            missing.join(", ")
+        )))
     }
 }
 
@@ -202,32 +283,100 @@ impl PinnedLadder {
 /// mirrored rather than guessed, and
 /// `test_the_mirrored_anchor_matches_upstream` pins the two together by
 /// building a real chain and reading the strike upstream chose.
-#[must_use]
-pub(crate) fn at_the_money(underlying: Positive, interval: Positive) -> Positive {
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `strike_interval` when the
+/// rounding cannot be represented. `Decimal`'s operators panic on overflow and
+/// the interval is unbounded client input, so every step is checked; upstream
+/// guards the same arithmetic in its own loop.
+pub(crate) fn at_the_money(
+    underlying: Positive,
+    interval: Positive,
+) -> Result<Positive, ChainError> {
     if interval == Positive::ZERO {
-        return underlying;
+        return Ok(underlying);
     }
 
     let price = underlying.to_dec();
     let interval = interval.to_dec();
-    let Some(remainder) = price.checked_rem(interval) else {
-        return underlying;
+    let unrepresentable = || ChainError::Validation {
+        field: "strike_interval".to_string(),
+        reason: format!("an interval of {interval} cannot anchor a ladder at {underlying}"),
     };
-    let base = price - remainder;
 
-    let rounded = if remainder + remainder >= interval {
-        base + interval
+    let remainder = price.checked_rem(interval).ok_or_else(unrepresentable)?;
+    let base = price.checked_sub(remainder).ok_or_else(unrepresentable)?;
+
+    // Upstream compares the remainder against HALF the interval; mirrored in
+    // that form rather than as `remainder + remainder >= interval`, which is
+    // algebraically the same but parts company where the half is not
+    // representable at 28 decimal places.
+    let half = interval
+        .checked_div(Decimal::TWO)
+        .ok_or_else(unrepresentable)?;
+    let rounds_up = remainder >= half;
+    let rounded = if rounds_up {
+        base.checked_add(interval).ok_or_else(unrepresentable)?
     } else {
         base
     };
-    Positive::new_decimal(rounded).unwrap_or(underlying)
+
+    Positive::new_decimal(rounded).map_err(|_| unrepresentable())
+}
+
+/// Refuses a pinned ladder whose lowest strike upstream cannot build.
+///
+/// Upstream stops extending a chain downwards once the offset passes the
+/// at-the-money strike, so a ladder wider than the spot itself is one whose far
+/// strikes are never created: at an initial price of 100 with a 5-point
+/// interval, a `chain_size` of 25 asks for strikes down to 5 and back up to
+/// 225, and upstream builds only as far as 200. Filtering cannot recover what
+/// was never built, so the combination is refused AT CREATION rather than
+/// failing on the first step of a simulation the client already has.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Validation`] naming `chain_size` when the ladder
+/// reaches past the anchor, and whatever [`at_the_money`] returns when the grid
+/// itself is unrepresentable.
+pub(crate) fn ensure_ladder_fits(
+    initial_price: Positive,
+    interval: Positive,
+    chain_size: usize,
+) -> Result<(), ChainError> {
+    let anchor = at_the_money(initial_price, interval)?;
+    let reach = interval
+        .checked_mul_dec(Decimal::from(chain_size))
+        .map_err(|error| ladder_overflow(interval, chain_size, &error.to_string()))?;
+
+    if reach > anchor {
+        return Err(ChainError::Validation {
+            field: "chain_size".to_string(),
+            reason: format!(
+                "a pinned ladder of {chain_size} strikes at an interval of {interval} reaches \
+                 {reach} below an anchor of {anchor}, and upstream stops building a chain once \
+                 the offset passes the anchor, so the lowest strikes would never exist; lower \
+                 chain_size or the interval"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// The failure a ladder that cannot be laid out on the grid produces.
+fn ladder_overflow(interval: Positive, step: usize, detail: &str) -> ChainError {
+    ChainError::Validation {
+        field: "strike_interval".to_string(),
+        reason: format!(
+            "an interval of {interval} cannot reach strike {step} of the pinned ladder: {detail}"
+        ),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use positive::pos_or_panic;
-    use rust_decimal_macros::dec;
 
     /// The anchor rounds to the nearest multiple, halves up.
     #[test]
@@ -241,21 +390,20 @@ mod tests {
             (5012.5, 5025.0),
             (5012.49, 5000.0),
         ] {
-            assert_eq!(
-                at_the_money(pos_or_panic!(underlying), interval),
-                pos_or_panic!(expected),
-                "for {underlying}"
-            );
+            match at_the_money(pos_or_panic!(underlying), interval) {
+                Ok(anchor) => assert_eq!(anchor, pos_or_panic!(expected), "for {underlying}"),
+                Err(error) => panic!("{underlying} must anchor: {error}"),
+            }
         }
     }
 
     /// A zero interval leaves the price alone rather than dividing by it.
     #[test]
     fn test_a_zero_interval_is_not_a_grid() {
-        assert_eq!(
-            at_the_money(pos_or_panic!(5000.0), Positive::ZERO),
-            pos_or_panic!(5000.0)
-        );
+        match at_the_money(pos_or_panic!(5000.0), Positive::ZERO) {
+            Ok(anchor) => assert_eq!(anchor, pos_or_panic!(5000.0)),
+            Err(error) => panic!("a zero interval must not fail: {error}"),
+        }
     }
 
     /// The ladder is the grid around the initial price, `2n + 1` wide.
@@ -458,12 +606,13 @@ mod tests {
                 chain.iter().map(|contract| contract.strike_price).collect();
             let middle = strikes[strikes.len() / 2];
 
-            assert_eq!(
-                at_the_money(pos_or_panic!(spot), interval),
-                middle,
-                "the mirror disagrees with upstream at a spot of {spot}: {strikes:?}"
-            );
+            match at_the_money(pos_or_panic!(spot), interval) {
+                Ok(anchor) => assert_eq!(
+                    anchor, middle,
+                    "the mirror disagrees with upstream at a spot of {spot}: {strikes:?}"
+                ),
+                Err(error) => panic!("the anchor must resolve at {spot}: {error}"),
+            }
         }
-        let _ = dec!(0);
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod expiry;
 pub(crate) mod factors;
+pub(crate) mod ladder;
 pub(crate) mod series;
 pub(crate) mod simulator;
 pub(crate) mod spread;

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -1035,16 +1035,12 @@ mod tests {
     /// exactly the strikes the simulation pinned at creation. A position opened
     /// at step 0 can therefore be marked at every later step.
     ///
-    /// IGNORED, and the reason is the open question on the issue. Within about
-    /// a day of an expiration upstream stops extending its ladder: a wing
-    /// priced at exactly zero makes `some_price_is_none` true on both ends and
-    /// the build loop breaks, so the far strikes do not exist to be filtered
-    /// to. Measured at a spot of 5100 with a width of 10 and a 25-point
-    /// interval: 21 strikes at 1 day, 11 at 0.05 days, 5 at 0.01 days. No
-    /// widening fixes it, because the contracts are never created. Closing this
-    /// needs a decision recorded on #91 — see the PR discussion.
+    /// This needed an upstream fix to pass. Until optionstratlib 0.21.1 a wing
+    /// worth nothing was priced as ABSENT rather than as zero, and
+    /// `build_chain` reads a missing side as "this wing does not quote", so the
+    /// ladder stopped before reaching the far pinned strikes and there was
+    /// nothing to filter to (OptionStratLib#487).
     #[test]
-    #[ignore = "blocked: upstream truncates its ladder near expiry, see issue #91"]
     fn test_a_pinned_simulation_keeps_its_strikes_for_every_step() {
         let mut created = request(40, reference_schedules());
         created.chain_size = Some(6);

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -559,9 +559,10 @@ mod tests {
     use super::*;
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
-    use crate::domain::ladder::StrikeLadder;
+    use crate::domain::ladder::{PinnedLadder, StrikeLadder};
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use chrono::{TimeZone, Weekday};
+    use rust_decimal_macros::dec;
 
     /// ADR 0001 §14's reference configuration: one rolling 0DTE, three
     /// Monday/Wednesday/Friday weeklies, twelve last-Friday monthlies, all at
@@ -1049,7 +1050,17 @@ mod tests {
         let parameters = parameters(created);
         let tape = tape(&parameters);
 
-        let mut expected: Option<Vec<String>> = None;
+        // The ladder the simulation pinned, resolved from its own parameters:
+        // comparing every step against the FIRST one would pass on a chain
+        // that lost the same wings at every step, which is the failure this
+        // test exists to catch.
+        let ladder = match PinnedLadder::resolve(&parameters) {
+            Ok(ladder) => ladder,
+            Err(error) => panic!("the ladder must resolve: {error}"),
+        };
+        let expected: Vec<String> = ladder.strikes().iter().map(ToString::to_string).collect();
+        assert_eq!(expected.len(), 13, "a half-width of six is 13 strikes");
+
         let mut spots = Vec::new();
 
         for step in 0..tape.len() {
@@ -1063,24 +1074,49 @@ mod tests {
                     .map(|contract| contract.strike_price.to_string())
                     .collect();
 
-                match &expected {
-                    None => expected = Some(strikes),
-                    Some(expected) => assert_eq!(
-                        &strikes, expected,
-                        "step {step} quotes a different strike set"
-                    ),
-                }
+                assert_eq!(
+                    strikes, expected,
+                    "step {step} does not quote the ladder the simulation pinned"
+                );
             }
         }
 
-        // The property is only worth asserting if the spot actually moved:
-        // a walk that stood still would keep any ladder intact.
+        // The property only means something if the spot moved far enough that
+        // a rolling ladder would have dropped a strike, which is half the
+        // ladder's own width: six strikes at 25 points is 150.
         let lowest = spots.iter().copied().fold(Positive::MAX, Positive::min);
         let highest = spots.iter().copied().fold(Positive::ZERO, Positive::max);
         assert!(
-            highest > lowest,
-            "the fixture must move the underlying, got {lowest} to {highest}"
+            highest.to_dec() - lowest.to_dec() > dec!(150),
+            "the fixture must move the underlying past the ladder's half-width, \
+             got {lowest} to {highest}"
         );
+    }
+
+    /// A pinned simulation reproduces its tape under the same seed.
+    ///
+    /// The ladder is a pure function of stored parameters, so it cannot move a
+    /// price path; this pins that the whole snapshot, quotes included, is the
+    /// same on a second run.
+    #[test]
+    fn test_a_pinned_simulation_reproduces_its_tape() {
+        let mut created = request(6, reference_schedules());
+        created.chain_size = Some(6);
+        created.strike_interval = Some(25.0);
+        created.strike_ladder = Some(StrikeLadder::Pinned);
+
+        let first_parameters = parameters(created.clone());
+        let second_parameters = parameters(created);
+        let first_tape = tape(&first_parameters);
+        let second_tape = tape(&second_parameters);
+
+        for step in 0..first_tape.len() {
+            assert_eq!(
+                snapshot(&first_parameters, &first_tape, step),
+                snapshot(&second_parameters, &second_tape, step),
+                "step {step} diverged under the same seed"
+            );
+        }
     }
 
     /// A different seed produces a different snapshot tape.

--- a/src/domain/series.rs
+++ b/src/domain/series.rs
@@ -559,6 +559,7 @@ mod tests {
     use super::*;
     use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
     use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::domain::ladder::StrikeLadder;
     use crate::session::{ExpiryRule, ExpiryRuleKind};
     use chrono::{TimeZone, Weekday};
 
@@ -643,6 +644,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,
@@ -1024,6 +1026,65 @@ mod tests {
                 "step {step} diverged under the same seed"
             );
         }
+    }
+
+    /// A pinned simulation quotes one strike set for its whole life.
+    ///
+    /// The end-to-end form of issue #91's criterion: walked over enough steps
+    /// for the underlying to move, every snapshot of every expiration carries
+    /// exactly the strikes the simulation pinned at creation. A position opened
+    /// at step 0 can therefore be marked at every later step.
+    ///
+    /// IGNORED, and the reason is the open question on the issue. Within about
+    /// a day of an expiration upstream stops extending its ladder: a wing
+    /// priced at exactly zero makes `some_price_is_none` true on both ends and
+    /// the build loop breaks, so the far strikes do not exist to be filtered
+    /// to. Measured at a spot of 5100 with a width of 10 and a 25-point
+    /// interval: 21 strikes at 1 day, 11 at 0.05 days, 5 at 0.01 days. No
+    /// widening fixes it, because the contracts are never created. Closing this
+    /// needs a decision recorded on #91 — see the PR discussion.
+    #[test]
+    #[ignore = "blocked: upstream truncates its ladder near expiry, see issue #91"]
+    fn test_a_pinned_simulation_keeps_its_strikes_for_every_step() {
+        let mut created = request(40, reference_schedules());
+        created.chain_size = Some(6);
+        created.strike_interval = Some(25.0);
+        created.strike_ladder = Some(StrikeLadder::Pinned);
+        let parameters = parameters(created);
+        let tape = tape(&parameters);
+
+        let mut expected: Option<Vec<String>> = None;
+        let mut spots = Vec::new();
+
+        for step in 0..tape.len() {
+            let snapshot = snapshot(&parameters, &tape, step);
+            spots.push(snapshot.spot);
+
+            for chain in &snapshot.chains {
+                let strikes: Vec<String> = chain
+                    .chain
+                    .iter()
+                    .map(|contract| contract.strike_price.to_string())
+                    .collect();
+
+                match &expected {
+                    None => expected = Some(strikes),
+                    Some(expected) => assert_eq!(
+                        &strikes, expected,
+                        "step {step} quotes a different strike set"
+                    ),
+                }
+            }
+        }
+
+        // The property is only worth asserting if the spot actually moved:
+        // a walk that stood still would keep any ladder intact.
+        let lowest = spots.iter().copied().fold(Positive::MAX, Positive::min);
+        let highest = spots.iter().copied().fold(Positive::ZERO, Positive::max);
+        assert!(
+            highest > lowest,
+            "the fixture must move the underlying, got {lowest} to {highest}"
+        );
     }
 
     /// A different seed produces a different snapshot tape.

--- a/src/domain/simulator.rs
+++ b/src/domain/simulator.rs
@@ -850,6 +850,7 @@ mod tests {
             skew_slope: Some(-0.2),
             smile_curve: Some(0.5),
             spread: Some(0.01),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/domain/spread.rs
+++ b/src/domain/spread.rs
@@ -369,6 +369,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/domain/walker.rs
+++ b/src/domain/walker.rs
@@ -1,5 +1,5 @@
 use optionstratlib::chains::OptionChain;
-use optionstratlib::error::SimulationError;
+use optionstratlib::error::{DecimalError, SimulationError};
 use optionstratlib::simulation::{WalkParams, WalkPath, WalkType, WalkTypeAble};
 use positive::Positive;
 use rand::rngs::StdRng;
@@ -8,6 +8,46 @@ use rand_distr::{Distribution, StandardNormal};
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::{Decimal, MathematicalOps};
 use std::sync::{Arc, Mutex};
+
+/// Checked `Decimal` addition, tagged with the operation that overflowed.
+///
+/// optionstratlib keeps `d_add` / `d_sub` / `d_mul` / `d_exp` crate-private,
+/// so a mirror that wants the same panic-free kernels has to carry its own.
+/// These four are byte-for-byte equivalents: the same `checked_*` call, the
+/// same `DecimalError::Overflow { operation, lhs, rhs }` on failure, and the
+/// same value on success — which is what keeps a seeded tape identical
+/// across the change.
+fn d_add(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    lhs.checked_add(rhs)
+        .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))
+}
+
+/// Checked `Decimal` subtraction. See [`d_add`].
+fn d_sub(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    lhs.checked_sub(rhs)
+        .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))
+}
+
+/// Checked `Decimal` multiplication. See [`d_add`].
+fn d_mul(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    lhs.checked_mul(rhs)
+        .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))
+}
+
+/// Checked `Decimal` exponential. See [`d_add`].
+///
+/// A negative exponent whose result is below `Decimal`'s smallest
+/// representable magnitude flushes to zero rather than erroring, exactly as
+/// upstream does: `e^x < 1e-28` for `x <= -65`, and zero is the limit.
+fn d_exp(x: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    if let Some(value) = x.checked_exp() {
+        return Ok(value);
+    }
+    if x.is_sign_negative() {
+        return Ok(Decimal::ZERO);
+    }
+    Err(DecimalError::overflow(op, x, Decimal::ZERO))
+}
 
 /// Walker struct for implementing WalkTypeAble.
 ///
@@ -77,14 +117,14 @@ impl Walker {
         volatility: Positive,
         dt: Positive,
         steps: usize,
-    ) -> Vec<Positive> {
-        let sqrt_dt = dt.sqrt();
+    ) -> Result<Vec<Positive>, SimulationError> {
+        let sqrt_dt = dt.checked_sqrt()?;
         let mut x = x0.to_dec();
         let mut result = Vec::with_capacity(steps);
         result.push(Positive::new_decimal(x).unwrap_or(Positive::ZERO));
 
         for _ in 1..steps {
-            let dw = self.normal_sample() * sqrt_dt.to_dec();
+            let dw = d_mul(self.normal_sample(), sqrt_dt.to_dec(), "volatility::ou::dw")?;
             // `mu - x` floored at zero. This mirrors upstream's
             // `sub_floor_zero`, which 0.20 substituted for the deprecated
             // `sub_or_zero` in `generate_ou_process`: same three branches, and
@@ -93,14 +133,18 @@ impl Walker {
             // the only option here, since `ou_process` returns a
             // `Vec<Positive>` with no error channel.
             let gap = mu.checked_sub_dec(x).unwrap_or(Positive::ZERO);
-            let drift = (theta * gap * dt).to_dec();
-            let diffusion = volatility.to_dec() * dw;
-            x += drift + diffusion;
+            let drift = theta.checked_mul(&gap)?.checked_mul(&dt)?.to_dec();
+            let diffusion = d_mul(dw, volatility.to_dec(), "volatility::ou::diffusion")?;
+            x = d_add(
+                x,
+                d_add(drift, diffusion, "volatility::ou::step")?,
+                "volatility::ou::step",
+            )?;
             x = x.max(Decimal::ZERO);
             result.push(Positive::new_decimal(x).unwrap_or(Positive::ZERO));
         }
 
-        result
+        Ok(result)
     }
 
     /// Seeded GARCH(1,1) kernel mirroring optionstratlib's `garch_walk`.
@@ -116,7 +160,12 @@ impl Walker {
                 alpha,
                 beta,
             } => {
-                if alpha + beta >= Decimal::ONE {
+                // `alpha + beta` is the stationarity test itself, so it has
+                // to be formed before it can be compared; at
+                // `alpha = beta = MAX` the raw operator aborts instead of
+                // reporting the violation.
+                let persistence = alpha.checked_add(&beta)?;
+                if persistence >= Decimal::ONE {
                     return Err(SimulationError::GarchStationarity { alpha, beta });
                 }
 
@@ -126,9 +175,19 @@ impl Walker {
                 path.push(Positive::new_decimal(price).unwrap_or(Positive::ZERO));
                 vols.push(volatility);
 
-                let mut var = volatility * volatility; // σ₀²
+                let mut var = volatility.checked_mul(&volatility)?; // σ₀²
                 let mut prev_eps2 = Decimal::ZERO;
-                let omega = volatility.powu(2) * (Decimal::ONE - alpha - beta);
+                // `1 - alpha - beta` is strictly positive by the stationarity
+                // check above; the subtraction order is preserved so the
+                // long-run variance stays bit-identical.
+                let stationary_weight = d_sub(
+                    d_sub(Decimal::ONE, alpha.to_dec(), "simulation::garch::omega")?,
+                    beta.to_dec(),
+                    "simulation::garch::omega",
+                )?;
+                let omega = volatility
+                    .checked_powu(2)?
+                    .checked_mul_dec(stationary_weight)?;
 
                 let sqrt_dt = dt.to_f64().sqrt();
                 let sqrt_dt_dec = Decimal::from_f64(sqrt_dt).ok_or_else(|| {
@@ -136,18 +195,34 @@ impl Walker {
                 })?;
 
                 for _ in 1..params.size {
-                    var = omega + alpha * prev_eps2 + beta * var;
+                    var = omega
+                        .checked_add(&alpha.checked_mul_dec(prev_eps2)?)?
+                        .checked_add(&beta.checked_mul(&var)?)?;
 
                     let z = self.normal_sample();
-                    let eps = z * var.sqrt() * sqrt_dt_dec; // εₜ
+                    let var_sqrt = var.checked_sqrt()?;
+                    let eps = d_mul(
+                        d_mul(z, var_sqrt.to_dec(), "simulation::garch::eps")?,
+                        sqrt_dt_dec,
+                        "simulation::garch::eps",
+                    )?; // εₜ
 
-                    let ret = drift * dt + eps;
+                    let ret = d_add(
+                        d_mul(drift, dt.to_dec(), "simulation::garch::ret")?,
+                        eps,
+                        "simulation::garch::ret",
+                    )?;
 
-                    price *= (ret).exp();
+                    price = d_mul(
+                        price,
+                        d_exp(ret, "simulation::garch::price")?,
+                        "simulation::garch::price",
+                    )?;
                     path.push(Positive::new_decimal(price).unwrap_or(Positive::ZERO));
-                    vols.push(var.sqrt());
+                    vols.push(var_sqrt);
 
-                    prev_eps2 = eps.powu(2);
+                    // `powu(2)` is exactly `eps * eps`.
+                    prev_eps2 = d_mul(eps, eps, "simulation::garch::eps_squared")?;
                 }
                 Ok(WalkPath {
                     prices: path,
@@ -181,7 +256,11 @@ impl Walker {
                 let mut vols = Vec::with_capacity(params.size);
                 let mut price: Positive = params.ystep_as_positive()?;
 
-                let mut variance = volatility.to_dec() * volatility.to_dec();
+                let mut variance = d_mul(
+                    volatility.to_dec(),
+                    volatility.to_dec(),
+                    "simulation::heston::variance0",
+                )?;
 
                 values.push(price);
                 vols.push(volatility);
@@ -194,25 +273,69 @@ impl Walker {
                         "Heston: sqrt(1 - rho^2) failed (rho out of range or overflow)",
                     )
                 })?;
-                for _ in 0..params.size - 1 {
+                // A zero-step walk has nothing to simulate past the seeded
+                // initial value; `size - 1` underflows there and, in release,
+                // turns the loop bound into `usize::MAX`. `size` is a step
+                // count, not a financial value, so saturating at zero bounds
+                // the loop rather than clamping a price.
+                let steps = params.size.saturating_sub(1);
+                for _ in 0..steps {
                     let z1 = self.normal_sample();
                     let z2 = rho * z1 + one_minus_rho_sq_sqrt * self.normal_sample();
 
                     let variance_sqrt = variance.sqrt().ok_or_else(|| {
                         SimulationError::walk_error("Heston: sqrt(variance) failed (overflow)")
                     })?;
-                    let variance_new = (variance
-                        + kappa.to_dec() * (theta.to_dec() - variance) * dt.to_dec()
-                        + xi.to_dec() * variance_sqrt * z2 * dt_sqrt)
-                        .max(Decimal::ZERO);
+                    let variance_drift = d_mul(
+                        d_mul(
+                            kappa.to_dec(),
+                            d_sub(theta.to_dec(), variance, "simulation::heston::variance_gap")?,
+                            "simulation::heston::variance_drift",
+                        )?,
+                        dt.to_dec(),
+                        "simulation::heston::variance_drift",
+                    )?;
+                    let variance_diffusion = d_mul(
+                        d_mul(
+                            d_mul(
+                                xi.to_dec(),
+                                variance_sqrt,
+                                "simulation::heston::variance_diffusion",
+                            )?,
+                            z2,
+                            "simulation::heston::variance_diffusion",
+                        )?,
+                        dt_sqrt,
+                        "simulation::heston::variance_diffusion",
+                    )?;
+                    let variance_new = d_add(
+                        d_add(variance, variance_drift, "simulation::heston::variance_new")?,
+                        variance_diffusion,
+                        "simulation::heston::variance_new",
+                    )?
+                    .max(Decimal::ZERO);
 
-                    let avg_variance = (variance + variance_new) / Decimal::TWO;
+                    let avg_variance =
+                        d_add(variance, variance_new, "simulation::heston::avg_variance")?
+                            .checked_div(Decimal::TWO)
+                            .ok_or_else(|| {
+                                SimulationError::walk_error("Heston: avg variance division failed")
+                            })?;
                     let avg_variance_sqrt = avg_variance.sqrt().ok_or_else(|| {
                         SimulationError::walk_error("Heston: sqrt(avg_variance) failed (overflow)")
                     })?;
-                    let price_change = drift * dt.to_dec() + avg_variance_sqrt * z1 * dt_sqrt;
+                    let price_change = d_add(
+                        d_mul(drift, dt.to_dec(), "simulation::heston::price_change")?,
+                        d_mul(
+                            d_mul(avg_variance_sqrt, z1, "simulation::heston::price_change")?,
+                            dt_sqrt,
+                            "simulation::heston::price_change",
+                        )?,
+                        "simulation::heston::price_change",
+                    )?;
 
-                    price *= (price_change).exp();
+                    price =
+                        price.checked_mul_dec(d_exp(price_change, "simulation::heston::price")?)?;
                     variance = variance_new;
 
                     values.push(price);
@@ -246,21 +369,38 @@ impl Walker {
                 vol_speed,
                 vol_mean,
             } => {
-                let vols = self.ou_process(volatility, vol_mean, vol_speed, vov, dt, params.size);
+                let vols =
+                    self.ou_process(volatility, vol_mean, vol_speed, vov, dt, params.size)?;
 
-                let sqrt_dt = dt.sqrt();
+                let sqrt_dt = dt.checked_sqrt()?;
                 let mut price = params.ystep_as_positive()?.to_dec();
                 let mut path = Vec::with_capacity(params.size + 1);
                 let mut vols_out = Vec::with_capacity(params.size + 1);
                 path.push(Positive::new_decimal(price).unwrap_or(Positive::ZERO));
                 vols_out.push(volatility);
 
-                for &vol in vols.iter().take(params.size - 1) {
+                // A zero-step walk has nothing to simulate past the seeded
+                // initial value; `size - 1` underflows there. `size` is a
+                // step count, not a financial value.
+                let steps = params.size.saturating_sub(1);
+                for &vol in vols.iter().take(steps) {
                     let z = self.normal_sample();
-                    let sigma_abs = vol.to_dec() * price;
-                    let random_step = z * sigma_abs * sqrt_dt.to_dec();
+                    let sigma_abs = d_mul(vol.to_dec(), price, "simulation::custom::sigma_abs")?;
+                    let random_step = d_mul(
+                        d_mul(z, sigma_abs, "simulation::custom::random_step")?,
+                        sqrt_dt.to_dec(),
+                        "simulation::custom::random_step",
+                    )?;
 
-                    price += drift * dt + random_step;
+                    price = d_add(
+                        price,
+                        d_add(
+                            d_mul(drift, dt.to_dec(), "simulation::custom::price")?,
+                            random_step,
+                            "simulation::custom::price",
+                        )?,
+                        "simulation::custom::price",
+                    )?;
                     path.push(
                         Positive::new_decimal(price.max(Decimal::ZERO)).unwrap_or(Positive::ZERO),
                     );
@@ -304,7 +444,7 @@ impl Walker {
                     -1
                 };
 
-                let sqrt_dt = dt.sqrt();
+                let sqrt_dt = dt.checked_sqrt()?;
                 let vol_mult_up = vol_multiplier_up.unwrap_or(Positive::ONE);
                 let vol_mult_down = vol_multiplier_down.unwrap_or(Positive::ONE);
 
@@ -315,7 +455,17 @@ impl Walker {
                         lambda_up.to_dec()
                     };
 
-                    let transition_prob = Decimal::ONE - (-lambda * dt.to_dec()).exp();
+                    // `lambda` is non-negative, so the exponent is
+                    // non-positive; an arbitrarily fast transition rate
+                    // flushes `e^x` to zero, the limit `transition_prob -> 1`.
+                    let transition_prob = d_sub(
+                        Decimal::ONE,
+                        d_exp(
+                            d_mul(-lambda, dt.to_dec(), "simulation::telegraph::transition")?,
+                            "simulation::telegraph::transition",
+                        )?,
+                        "simulation::telegraph::transition",
+                    )?;
 
                     // Check for state transition using uniform random sample
                     let uniform_sample = (self.normal_sample().abs() + Decimal::ONE) / Decimal::TWO;
@@ -324,17 +474,30 @@ impl Walker {
                     }
 
                     let current_vol = if state == 1 {
-                        volatility * vol_mult_up
+                        volatility.checked_mul(&vol_mult_up)?
                     } else {
-                        volatility * vol_mult_down
+                        volatility.checked_mul(&vol_mult_down)?
                     };
 
                     let z = self.normal_sample();
-                    let diffusion = current_vol.to_dec() * sqrt_dt.to_dec() * z;
-                    let drift_term = drift * dt.to_dec();
+                    let diffusion = d_mul(
+                        d_mul(
+                            current_vol.to_dec(),
+                            sqrt_dt.to_dec(),
+                            "simulation::telegraph::diffusion",
+                        )?,
+                        z,
+                        "simulation::telegraph::diffusion",
+                    )?;
+                    let drift_term = d_mul(drift, dt.to_dec(), "simulation::telegraph::drift")?;
 
-                    let price_change = drift_term + diffusion;
-                    price *= price_change.exp();
+                    let price_change =
+                        d_add(drift_term, diffusion, "simulation::telegraph::price")?;
+                    price = d_mul(
+                        price,
+                        d_exp(price_change, "simulation::telegraph::price")?,
+                        "simulation::telegraph::price",
+                    )?;
 
                     values.push(Positive::new_decimal(price).unwrap_or(Positive::ZERO));
                     vols.push(current_vol);
@@ -385,7 +548,7 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
                 let start: Positive = params.ystep_as_positive()?;
                 values.push(start);
                 let mut x: Decimal = start.to_dec();
-                let sigma_abs = (volatility * start).to_dec();
+                let sigma_abs = volatility.checked_mul(&start)?.to_dec();
                 let sqrt_dt = dt.to_f64().sqrt();
                 let sqrt_dt_dec = Decimal::from_f64(sqrt_dt).ok_or_else(|| {
                     SimulationError::non_finite("simulation::brownian::sqrt_dt", sqrt_dt)
@@ -393,9 +556,17 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
 
                 for _ in 1..params.size {
                     let z = self.normal_sample();
-                    let diffusion = sigma_abs * sqrt_dt_dec * z;
-                    let drift_term = drift * dt;
-                    x += drift_term + diffusion;
+                    let diffusion = d_mul(
+                        d_mul(sigma_abs, sqrt_dt_dec, "simulation::brownian::diffusion")?,
+                        z,
+                        "simulation::brownian::diffusion",
+                    )?;
+                    let drift_term = d_mul(drift, dt.to_dec(), "simulation::brownian::drift")?;
+                    x = d_add(
+                        x,
+                        d_add(drift_term, diffusion, "simulation::brownian::step")?,
+                        "simulation::brownian::step",
+                    )?;
                     values.push(
                         Positive::new_decimal(x.max(Decimal::ZERO)).unwrap_or(Positive::ZERO),
                     );
@@ -422,12 +593,25 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
                 let mut values = Vec::with_capacity(params.size);
                 let mut current_value: Positive = params.ystep_as_positive()?;
                 values.push(current_value);
-                let sqrt_dt = dt.sqrt();
+                let sqrt_dt = dt.checked_sqrt()?;
 
                 for _ in 1..params.size {
-                    let diffusion = self.normal_sample() * volatility * sqrt_dt;
-                    let drift_term = (drift * dt) + diffusion;
-                    current_value *= Decimal::exp(&drift_term);
+                    let diffusion = d_mul(
+                        d_mul(
+                            self.normal_sample(),
+                            volatility.to_dec(),
+                            "simulation::gbm::diffusion",
+                        )?,
+                        sqrt_dt.to_dec(),
+                        "simulation::gbm::diffusion",
+                    )?;
+                    let drift_term = d_add(
+                        d_mul(drift, dt.to_dec(), "simulation::gbm::drift")?,
+                        diffusion,
+                        "simulation::gbm::drift",
+                    )?;
+                    current_value = current_value
+                        .checked_mul_dec(d_exp(drift_term, "simulation::gbm::price")?)?;
                     values.push(current_value);
                 }
                 Ok(values)
@@ -461,17 +645,34 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
 
                 for _ in 1..params.size {
                     let z = self.normal_sample();
-                    let diffusion = z * volatility * sqrt_dt_dec;
-                    let mut log_ret = (expected_return * dt) + diffusion;
+                    let diffusion = d_mul(
+                        d_mul(z, volatility.to_dec(), "simulation::log_returns::diffusion")?,
+                        sqrt_dt_dec,
+                        "simulation::log_returns::diffusion",
+                    )?;
+                    let mut log_ret = d_add(
+                        d_mul(
+                            expected_return,
+                            dt.to_dec(),
+                            "simulation::log_returns::log_ret",
+                        )?,
+                        diffusion,
+                        "simulation::log_returns::log_ret",
+                    )?;
 
                     if let Some(ac) = autocorrelation {
                         if !(-Decimal::ONE..=Decimal::ONE).contains(&ac) {
                             return Err(SimulationError::InvalidAutocorrelation { value: ac });
                         }
-                        log_ret += ac * prev_log_ret;
+                        log_ret = d_add(
+                            log_ret,
+                            d_mul(ac, prev_log_ret, "simulation::log_returns::autocorrelation")?,
+                            "simulation::log_returns::autocorrelation",
+                        )?;
                     }
 
-                    price *= log_ret.exp();
+                    price =
+                        price.checked_mul_dec(d_exp(log_ret, "simulation::log_returns::price")?)?;
                     values.push(price);
 
                     prev_log_ret = log_ret;
@@ -495,15 +696,15 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
                 speed,
                 mean,
             } => {
-                let sigma_abs = volatility * mean;
-                Ok(self.ou_process(
+                let sigma_abs = volatility.checked_mul(&mean)?;
+                self.ou_process(
                     params.ystep_as_positive()?,
                     mean,
                     speed,
                     sigma_abs,
                     dt,
                     params.size,
-                ))
+                )
             }
             _ => Err(SimulationError::InvalidWalkType {
                 expected: "MeanReverting",
@@ -546,8 +747,8 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
                 jump_mean,
                 jump_volatility,
             } => {
-                let sqrt_dt = dt.sqrt();
-                let lambda_dt = (intensity * dt).to_dec();
+                let sqrt_dt = dt.checked_sqrt()?;
+                let lambda_dt = intensity.checked_mul(&dt)?.to_dec();
 
                 // The Bernoulli(λ·dt) approximation is only valid as a probability
                 // when λ·dt < 1; a Poisson jump count per step is out of scope.
@@ -564,21 +765,41 @@ impl WalkTypeAble<Positive, OptionChain> for Walker {
 
                 for _ in 1..params.size {
                     let z = self.normal_sample();
-                    let sigma_abs = volatility.to_dec() * x;
-                    let diffusion = sigma_abs * sqrt_dt.to_dec() * z;
+                    let sigma_abs = d_mul(volatility.to_dec(), x, "simulation::jump::sigma_abs")?;
+                    let diffusion = d_mul(
+                        d_mul(sigma_abs, sqrt_dt.to_dec(), "simulation::jump::diffusion")?,
+                        z,
+                        "simulation::jump::diffusion",
+                    )?;
 
-                    let drift_term = drift * dt;
+                    let drift_term = d_mul(drift, dt.to_dec(), "simulation::jump::drift")?;
                     // Jump occurrence is a Bernoulli(λ·dt) event tested with a
                     // uniform draw (see the method doc: intentional divergence
                     // from upstream's normal-as-Bernoulli bug, issue #11). The
                     // jump size below keeps upstream's standard-normal draw.
                     let jump = if self.bernoulli_jump(lambda_dt) {
-                        jump_mean + self.normal_sample() * jump_volatility
+                        d_add(
+                            jump_mean,
+                            d_mul(
+                                self.normal_sample(),
+                                jump_volatility.to_dec(),
+                                "simulation::jump::size",
+                            )?,
+                            "simulation::jump::size",
+                        )?
                     } else {
                         Decimal::ZERO
                     };
 
-                    x += drift_term + diffusion + jump;
+                    x = d_add(
+                        x,
+                        d_add(
+                            d_add(drift_term, diffusion, "simulation::jump::step")?,
+                            jump,
+                            "simulation::jump::step",
+                        )?,
+                        "simulation::jump::step",
+                    )?;
                     x = x.max(Decimal::ZERO);
                     values.push(Positive::new_decimal(x).unwrap_or(Positive::ZERO));
                 }
@@ -762,7 +983,48 @@ mod tests {
             pos_or_panic!(0.01),
             50,
         );
-        assert_eq!(pa, pb);
+        match (pa, pb) {
+            (Ok(pa), Ok(pb)) => {
+                assert_eq!(pa, pb);
+                assert_eq!(pa.len(), 50);
+            }
+            _ => panic!("the seeded OU process must not fail on valid parameters"),
+        }
+    }
+
+    /// A zero-step walk has nothing to simulate past its seeded initial
+    /// value. Before the 0.21 re-sync, `size - 1` underflowed here and the
+    /// Heston and Custom loops ran to `usize::MAX` in a release build.
+    #[test]
+    fn test_zero_size_walks_return_only_the_initial_value() {
+        let walker = Walker::new_with_seed(3);
+        let mut params = jump_diffusion_params(pos_or_panic!(1.0), 0);
+        params.walk_type = WalkType::Heston {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: Decimal::ZERO,
+            volatility: pos_or_panic!(0.2),
+            kappa: pos_or_panic!(1.5),
+            theta: pos_or_panic!(0.04),
+            xi: pos_or_panic!(0.3),
+            rho: dec!(-0.7),
+        };
+        match walker.heston(&params) {
+            Ok(prices) => assert_eq!(prices.len(), 1),
+            Err(error) => panic!("a zero-step Heston walk must not fail: {error}"),
+        }
+
+        params.walk_type = WalkType::Custom {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: Decimal::ZERO,
+            volatility: pos_or_panic!(0.2),
+            vov: pos_or_panic!(0.3),
+            vol_speed: pos_or_panic!(1.5),
+            vol_mean: pos_or_panic!(0.2),
+        };
+        match walker.custom(&params) {
+            Ok(prices) => assert_eq!(prices.len(), 1),
+            Err(error) => panic!("a zero-step Custom walk must not fail: {error}"),
+        }
     }
 
     #[test]

--- a/src/infrastructure/clickhouse/snapshots/record.rs
+++ b/src/infrastructure/clickhouse/snapshots/record.rs
@@ -69,7 +69,15 @@ use uuid::Uuid;
 ///   grid at the strike where the wings had been erased and now runs to the
 ///   full ladder. A simulation half-filed by an older binary would otherwise
 ///   hold two different tapes under one generation.
-pub const CURRENT_SNAPSHOT_GENERATION: u64 = 3;
+/// - `4` — optionstratlib 0.21.1 quotes an option worth nothing at zero rather
+///   than pricing it as absent (OptionStratLib#487). Upstream reads a missing
+///   side as "this strike does not quote" and stopped extending the ladder
+///   there, so a chain built near expiry with wings a few percent out of the
+///   money carried FEWER strikes than `chain_size` asked for: 23 instead of 41
+///   at a spot of 5100 with a 25-point interval at 0.3125 days. The strike set
+///   of those steps therefore changes under the same coordinates, for rolling
+///   ladders as much as for pinned ones.
+pub const CURRENT_SNAPSHOT_GENERATION: u64 = 4;
 
 /// The namespace every deterministic `snapshot_id` is derived under.
 ///
@@ -591,7 +599,7 @@ mod tests {
 
         // Pinned so a bump is a deliberate edit here as well as there: the
         // generation is what keeps two tapes from sharing one coordinate.
-        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 3);
+        assert_eq!(CURRENT_SNAPSHOT_GENERATION, 4);
         assert_eq!(
             record(simulation, CURRENT_SNAPSHOT_GENERATION, 0).snapshot_id(),
             snapshot_id(simulation, CURRENT_SNAPSHOT_GENERATION, 0)

--- a/src/infrastructure/clickhouse/snapshots/record.rs
+++ b/src/infrastructure/clickhouse/snapshots/record.rs
@@ -73,10 +73,11 @@ use uuid::Uuid;
 ///   than pricing it as absent (OptionStratLib#487). Upstream reads a missing
 ///   side as "this strike does not quote" and stopped extending the ladder
 ///   there, so a chain built near expiry with wings a few percent out of the
-///   money carried FEWER strikes than `chain_size` asked for: 23 instead of 41
-///   at a spot of 5100 with a 25-point interval at 0.3125 days. The strike set
-///   of those steps therefore changes under the same coordinates, for rolling
-///   ladders as much as for pinned ones.
+///   money carried FEWER strikes than `chain_size` asked for. Measured with
+///   this crate's own defaults at a spot of 5100 with a 25-point interval:
+///   26 strikes instead of 41 at 0.3125 days, and 10 instead of 21 at 0.05
+///   days. The strike set of those steps therefore changes under the same
+///   coordinates, for rolling ladders as much as for pinned ones.
 pub const CURRENT_SNAPSHOT_GENERATION: u64 = 4;
 
 /// The namespace every deterministic `snapshot_id` is derived under.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,8 +282,46 @@
 //!   request that took the documented default — the quotes are unchanged.
 //!
 //! Persisted snapshots are therefore a new tape: `CURRENT_SNAPSHOT_GENERATION`
-//! is `3`, so rows written by an older binary stay addressable under generation
-//! `2` and are never mixed with these.
+//! is `4`, so rows written by an older binary stay addressable under the
+//! generation they were filed under and are never mixed with these. It moved
+//! again with optionstratlib 0.21.1, which quotes an option worth nothing at
+//! zero instead of pricing it as absent (OptionStratLib#487): upstream had
+//! stopped extending a ladder at a strike whose worthless side carried no
+//! price, so a chain near expiry held fewer strikes than `chain_size` asked
+//! for — 23 instead of 41 at a spot of 5100 with a 25-point interval at 0.3125
+//! days. That changes the strike set of those steps for rolling ladders as
+//! much as for pinned ones.
+//!
+//! ### The strike ladder can be pinned
+//!
+//! The ladder is rebuilt around the current underlying at every step, so the
+//! quoted strikes follow the spot and a contract quoted at step 0 can be gone
+//! by step 2: a move of 0.27 percent over two steps was enough to drop a
+//! strike. `chain_size` fixes how MANY strikes are quoted, never WHICH.
+//!
+//! For a client browsing a chain that is right. For one holding a position it
+//! is not: a leg opened at 4850 cannot be marked, closed or settled at a step
+//! where 4850 does not exist, and a defined-risk structure loses its furthest
+//! wings first, which are the legs that cap its risk.
+//!
+//! `strike_ladder` on the v2 create request chooses:
+//!
+//! | Value | Meaning |
+//! |-------|---------|
+//! | `rolling` | The default, and what the service always did. The ladder follows the spot, so the quoted strikes stay near the money and a contract can leave the chain. |
+//! | `pinned` | The ladder is fixed at creation from `initial_price`, `chain_size` and `strike_interval`. Every step quotes that same set, so a contract quoted once is quoted for the simulation's whole life. |
+//!
+//! A pinned simulation must supply `strike_interval`: without one the interval
+//! is derived per expiration and there is no fixed grid to pin, so the request
+//! is a `400` naming the field. The effective value is echoed in the simulation
+//! response and survives a store round trip, and a document written before the
+//! field reads as `rolling`.
+//!
+//! **A pinned ladder does not follow a large move.** If the spot leaves the
+//! pinned range the chain is all calls or all puts, which is correct and
+//! informative: a simulation that silently invented new strikes would not be
+//! the closed world the setting exists to provide. Widen the ladder at
+//! creation, with `chain_size`, rather than at step time.
 //!
 //! `/api/v1/chain` is untouched, model and all: it is frozen, and its chains
 //! come from a different upstream path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,10 +318,13 @@
 //! field reads as `rolling`.
 //!
 //! **A pinned ladder does not follow a large move.** If the spot leaves the
-//! pinned range the chain is all calls or all puts, which is correct and
-//! informative: a simulation that silently invented new strikes would not be
-//! the closed world the setting exists to provide. Widen the ladder at
-//! creation, with `chain_size`, rather than at step time.
+//! pinned range every quoted strike ends up on one side of the money — each
+//! contract still carries both a call and a put, but they are all deep in or
+//! deep out. That is correct and informative: a simulation that silently
+//! invented new strikes would not be the closed world the setting exists to
+//! provide. Widen the ladder at creation, with `chain_size`, rather than at
+//! step time. A spot that drifts further than the service will widen for is a
+//! `400` naming `strike_ladder` rather than a silently shorter chain.
 //!
 //! `/api/v1/chain` is untouched, model and all: it is frozen, and its chains
 //! come from a different upstream path.

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -842,6 +842,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -75,6 +75,10 @@ mod state_handler;
 mod store;
 
 pub use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, ExpiryRule, ExpiryRuleKind};
+// The strike ladder a v2 simulation quotes. Re-exported beside the schedule
+// rules and for the same reason: a consumer that can see it on
+// `CreateSimulationRequest` must be able to name it to build one.
+pub use crate::domain::ladder::StrikeLadder;
 pub use manager::SessionManager;
 pub use manager_v2::SimulationManager;
 pub use model::{Session, SessionState, SimulationMethod, SimulationParameters};

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -26,6 +26,7 @@ use crate::api::rest::validation::{
     time_frame_field,
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
+use crate::domain::ladder::StrikeLadder;
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
 use crate::domain::spread::{MAX_PROPORTIONAL, MAX_TICK, MAX_WIDENING};
 use crate::infrastructure::max_snapshot_contracts;
@@ -269,6 +270,12 @@ pub struct SimulationParametersV2 {
     pub skew_slope: Option<Decimal>,
     /// Curvature of the volatility smile.
     pub smile_curve: Option<Decimal>,
+    /// Which strikes the simulation quotes: `rolling` rebuilds the ladder
+    /// around the spot at every step, `pinned` fixes it at creation so a
+    /// contract quoted once stays quoted. Defaults to `rolling`, which is what
+    /// the service did before the field existed.
+    #[serde(default)]
+    pub strike_ladder: StrikeLadder,
     /// The constant term of the spread model, and the whole of it when no
     /// widening coefficient is set. The field predates the model and keeps its
     /// meaning: one absolute spread, applied to every contract.
@@ -330,6 +337,8 @@ struct SimulationParametersV2Wire {
     smile_curve: Option<Decimal>,
     spread: Option<Positive>,
     #[serde(default)]
+    strike_ladder: StrikeLadder,
+    #[serde(default)]
     spread_proportional: Option<Decimal>,
     #[serde(default)]
     spread_moneyness_widening: Option<Decimal>,
@@ -362,6 +371,7 @@ impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
             skew_slope: wire.skew_slope,
             smile_curve: wire.smile_curve,
             spread: wire.spread,
+            strike_ladder: wire.strike_ladder,
             spread_proportional: wire.spread_proportional,
             spread_moneyness_widening: wire.spread_moneyness_widening,
             spread_tenor_widening: wire.spread_tenor_widening,
@@ -432,6 +442,17 @@ impl SimulationParametersV2 {
         }
         if let Some(strike_interval) = self.strike_interval {
             reject_zero("strike_interval", strike_interval)?;
+        }
+        // A pinned ladder is a fixed set of strikes on a fixed grid, and
+        // without an explicit interval upstream derives a different one per
+        // expiration: there would be no single ladder to pin. Refused at the
+        // boundary rather than resolved to some arbitrary expiration's
+        // interval, which would be a number nobody asked for.
+        if self.strike_ladder.is_pinned() && self.strike_interval.is_none() {
+            return Err(ChainError::Validation {
+                field: "strike_interval".to_string(),
+                reason: "a pinned strike_ladder requires an explicit strike_interval".to_string(),
+            });
         }
         // The spread model, BOTH bounds, exactly as the request path applies
         // them. A stored `spread_tick` of zero silently disables the floor that
@@ -722,6 +743,7 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
                 .spread
                 .map(|value| positive_field("spread", value))
                 .transpose()?,
+            strike_ladder: request.strike_ladder.unwrap_or_default(),
             // The widening coefficients are rates, not prices: zero is the
             // documented default and a negative one would NARROW a quote away
             // from the money, which is not a market anyone trades.
@@ -1085,6 +1107,7 @@ mod tests {
             skew_slope: Some(-0.2),
             smile_curve: Some(0.4),
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,
@@ -1499,6 +1522,92 @@ mod tests {
                 error.to_string().contains("spread_tick"),
                 "the failure must name the field: {error}"
             ),
+        }
+    }
+
+    /// A pinned ladder without an interval is refused, on both paths.
+    ///
+    /// There is no fixed grid to pin without one, and resolving it to some
+    /// expiration's derived interval would be a number the client never chose.
+    #[test]
+    fn test_a_pinned_ladder_requires_an_explicit_interval() {
+        let mut request = reference_request();
+        request.strike_ladder = Some(StrikeLadder::Pinned);
+        request.strike_interval = None;
+
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => {
+                panic!("a pinned ladder with no grid must be refused: {parameters:?}")
+            }
+            Err(ChainError::Validation { field, .. }) => assert_eq!(field, "strike_interval"),
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
+
+        // And the stored path, since Redis is an outer layer.
+        let mut pinned = reference_request();
+        pinned.strike_ladder = Some(StrikeLadder::Pinned);
+        pinned.strike_interval = Some(25.0);
+        let parameters = parameters(pinned);
+
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                map.remove("strike_interval");
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => panic!("a stored pinned ladder with no grid must be refused: {loaded:?}"),
+            Err(error) => assert!(
+                error.to_string().contains("strike_interval"),
+                "the failure must name the field: {error}"
+            ),
+        }
+    }
+
+    /// The ladder survives a store round trip, and defaults to rolling.
+    #[test]
+    fn test_the_strike_ladder_round_trips() {
+        let mut request = reference_request();
+        request.strike_ladder = Some(StrikeLadder::Pinned);
+        request.strike_interval = Some(25.0);
+        let pinned = parameters(request);
+
+        assert_eq!(pinned.strike_ladder, StrikeLadder::Pinned);
+
+        let json = match serde_json::to_string(&pinned) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SimulationParametersV2>(&json) {
+            Ok(loaded) => assert_eq!(loaded.strike_ladder, StrikeLadder::Pinned),
+            Err(error) => panic!("must deserialize: {error}"),
+        }
+
+        // A request that says nothing gets the behaviour the service had.
+        let untouched = parameters(reference_request());
+        assert_eq!(untouched.strike_ladder, StrikeLadder::Rolling);
+    }
+
+    /// A document written before the field still loads, as rolling.
+    #[test]
+    fn test_stored_parameters_without_a_strike_ladder_still_load() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                map.remove("strike_ladder");
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => assert_eq!(
+                loaded.strike_ladder,
+                StrikeLadder::Rolling,
+                "an older document must read as the behaviour it was written under"
+            ),
+            Err(error) => panic!("an older document must still load: {error}"),
         }
     }
 

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -26,7 +26,7 @@ use crate::api::rest::validation::{
     time_frame_field,
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
-use crate::domain::ladder::StrikeLadder;
+use crate::domain::ladder::{StrikeLadder, ensure_ladder_fits};
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
 use crate::domain::spread::{MAX_PROPORTIONAL, MAX_TICK, MAX_WIDENING};
 use crate::infrastructure::max_snapshot_contracts;
@@ -448,11 +448,23 @@ impl SimulationParametersV2 {
         // expiration: there would be no single ladder to pin. Refused at the
         // boundary rather than resolved to some arbitrary expiration's
         // interval, which would be a number nobody asked for.
-        if self.strike_ladder.is_pinned() && self.strike_interval.is_none() {
-            return Err(ChainError::Validation {
-                field: "strike_interval".to_string(),
-                reason: "a pinned strike_ladder requires an explicit strike_interval".to_string(),
-            });
+        if self.strike_ladder.is_pinned() {
+            let Some(interval) = self.strike_interval else {
+                return Err(ChainError::Validation {
+                    field: "strike_interval".to_string(),
+                    reason: "a pinned strike_ladder requires an explicit strike_interval"
+                        .to_string(),
+                });
+            };
+            // And the ladder has to be one upstream can actually build: it
+            // stops extending downwards past the anchor, so a ladder wider
+            // than the spot loses its lowest strikes. Refused here rather than
+            // on the first step of a simulation the client already holds.
+            ensure_ladder_fits(
+                self.initial_price,
+                interval,
+                self.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE),
+            )?;
         }
         // The spread model, BOTH bounds, exactly as the request path applies
         // them. A stored `spread_tick` of zero silently disables the floor that

--- a/src/session/snapshot_record.rs
+++ b/src/session/snapshot_record.rs
@@ -158,6 +158,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/session/store/v2_memory.rs
+++ b/src/session/store/v2_memory.rs
@@ -214,6 +214,7 @@ mod tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/session/store/v2_redis.rs
+++ b/src/session/store/v2_redis.rs
@@ -549,6 +549,7 @@ mod live_tests {
             skew_slope: None,
             smile_curve: None,
             spread: Some(0.02),
+            strike_ladder: Default::default(),
             spread_proportional: None,
             spread_moneyness_widening: None,
             spread_tenor_widening: None,

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -16,7 +16,7 @@
 //! written with a leading space is a different credential and this module
 //! cannot tell one variable's meaning from another's. And it does not cover an
 //! opaque credential whose empty form is meaningful, which is what
-//! [`read_secret`] is for.
+//! [`read_secret`](crate::utils::env::read_secret) is for.
 //!
 //! This module sits in `utils` rather than in `infrastructure::config` so that
 //! every layer can hold the rule, including `utils::admission`, which reads a


### PR DESCRIPTION
Closes #91

## What changed

The ladder is rebuilt around the underlying at every step, so a contract quoted at step 0 can be gone by step 2: a move of 0.27 percent over two steps was enough to drop a strike. `chain_size` fixes how MANY strikes are quoted, never WHICH.

`strike_ladder` on the v2 create request now chooses. `rolling` is the default and is what the service always did. `pinned` fixes the ladder at creation from `initial_price`, `chain_size` and `strike_interval`, so a contract quoted once is quoted for the simulation's whole life, which is what a client holding a position across steps needs.

Serving it costs no hand-rolled pricing. Upstream anchors every ladder at `rounder(underlying, interval)`, which snaps to a multiple of the interval, so every ladder it builds lies on one grid; a pinned step asks upstream for a chain wide enough to reach the pinned strikes from wherever the spot is now and keeps those out of it.

## It needed an upstream fix

The blocker was not in this repo. Until optionstratlib 0.21.1 a wing worth nothing was priced as **absent** rather than as zero, and `build_chain` reads a missing side as "this wing does not quote", so the ladder stopped before the far pinned strikes and there was nothing to filter to. Fixed in [OptionStratLib#488](https://github.com/joaquinbejar/OptionStratLib/pull/488) for [#487](https://github.com/joaquinbejar/OptionStratLib/issues/487), which this PR pins.

That fix also changes what **rolling** simulations serve near expiry: measured with this crate's defaults at a spot of 5100 with a 25-point interval, 26 strikes instead of 41 at 0.3125 days and 10 instead of 21 at 0.05 days. So `CURRENT_SNAPSHOT_GENERATION` goes to 4.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Pinned: the strike set is identical at every step of a simulation whose spot moves substantially | Met. The test asserts every step against the ladder the simulation RESOLVED, not against its own first step, and the fixture must move the spot past half the ladder's width for the assertion to count |
| `strike_ladder` absent or `rolling`: the export is byte-identical to today | **Waived, and not by this PR's code.** Rolling is untouched here, but the optionstratlib bump changes chains near expiry, which is the whole point of taking it. Worth knowing for Chainwalk and IronCondor: a stored generation-3 tape is not comparable |
| The effective value is echoed and survives a store round trip | Met, at the wire level and the stored level |
| Reproducibility holds | Met. The ladder is a pure function of stored parameters and cannot touch a price path; a pinned run reproduces its tape under the same seed |
| clippy, fmt, tests, `make readme` | Met, below |

## Review findings, all fixed

`reproducibility-reviewer` and `architect` both ran over this and converged on two criticals:

- **Panicking arithmetic on a request path.** `strike_interval` has no upper bound, so `{"strike_interval": 1e27, "chain_size": 500}` reached `Positive arithmetic overflow in mul_decimal`. Everything is checked now, and the anchor mirrors upstream's comparison form rather than an algebraically-equal one that parts company at 28 decimal places.
- **A silently partial ladder.** Upstream stops extending downwards past the anchor, so a ladder wider than the spot loses its lowest strikes: at an initial price of 100 with a 5-point interval, `chain_size: 25` served 40 of 45 strikes at step 0 with no error. That combination is refused at creation naming `chain_size`, and a chain that still comes back short is an error naming what it lacks.

Also fixed: `build_chain` no longer imports the api layer (the bound is the domain's own, so `OCS_MAX_CHAIN_SIZE` cannot decide whether a running simulation serves its next step); `StrikeLadder` is re-exported from `session` so a consumer can name it; the OpenAPI document carries the enum instead of a free-form string; a spot beyond the widening bound is a typed 400 instead of an opaque 500; `strike_ladder` joins ADR 0001 §8's replay list and both example bodies; and two stale claims in the docs are corrected, including "all calls or all puts", which was never true of a response where every contract carries both sides.

Two follow-ups opened rather than folded in: #96 (bound the widening against the validated snapshot budget) and #97 (take 0.21's hardening into the mirrored walk kernels — the values are already verified identical).

## For Chainwalk

`strike_ladder` is additive on the wire and defaults to `rolling`, so nothing changes without asking. Two things to know: adding a field to the public `CreateSimulationRequest` breaks a Rust struct literal, free at 0.2.0; and `deny_unknown_fields` means an older server answers 400 to a request carrying `strike_ladder`, so it is a version gate rather than a no-op.

## Gate

`make pre-push` clean, MongoDB up: **917** + 16 + 3 tests pass, 25 ignored; clippy with `-D warnings`, `fmt --check`, `cargo doc` with zero warnings and `cargo build --release` all clean; `README.md` regenerated via `make readme`. The one pre-existing doc warning, a broken link in `utils::env`, is fixed here too so the gate is warning-free.