### PR TITLE
Bound the pinned widening by an absolute ceiling as well as the snapshot budget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.0}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.1}
     deploy:
       replicas: 2
       restart_policy:

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -233,7 +233,11 @@ impl PinnedLadder {
                 reason: format!(
                     "the underlying has moved {widest} strikes from the ladder this simulation \
                      pinned at creation, past the {maximum} a chain may carry; a pinned ladder \
-                     does not follow a move that far, so widen it at creation with chain_size"
+                     does not follow a move that far, and widening chain_size cannot help \
+                     because a wider ladder puts its far strikes further still from this spot; \
+                     create the simulation with a smaller chain_size, around an initial_price \
+                     nearer where the underlying trades, or with the rolling ladder, which \
+                     re-centres on every step"
                 ),
             });
         }
@@ -388,19 +392,34 @@ pub(crate) fn max_pinned_width(parameters: &SimulationParametersV2) -> Result<us
             reason: "the requested expiration counts overflow".to_string(),
         })?;
 
-    let cap = crate::infrastructure::max_snapshot_contracts();
+    Ok(pinned_width_for(
+        crate::infrastructure::max_snapshot_contracts(),
+        expirations,
+    ))
+}
+
+/// The widening [`max_pinned_width`] allows for a given cap and expiration
+/// count, split out from the environment so both sides of the minimum can be
+/// exercised: the process-wide cap is resolved once in a `OnceLock`, so a test
+/// that could only call the public entry point would be stuck with whatever
+/// the deployment happens to configure.
+fn pinned_width_for(cap: usize, expirations: usize) -> usize {
     // A schedule with no rules cannot produce a chain, so the divisor is
     // irrelevant; one keeps the division defined.
-    let strikes = cap.checked_div(expirations.max(1)).unwrap_or(cap);
+    let divisor = if expirations == 0 { 1 } else { expirations };
+    let strikes = cap.checked_div(divisor).unwrap_or(cap);
 
     // `strikes` covers the whole `2n + 1` grid, so the half-width is what
-    // upstream calls `chain_size`. No floor: a budget too small to carry even
-    // a three-strike chain must report a width of zero and let `width_from`
-    // refuse the ladder, rather than round itself up past the budget it came
-    // from.
-    let budget = strikes.saturating_sub(1).checked_div(2).unwrap_or(0);
+    // upstream calls `chain_size`. The subtraction is checked rather than
+    // saturating, which `rules/global_rules.md` forbids: a budget of zero or
+    // one strike is a real answer of zero, stated deliberately, and
+    // `width_from` then refuses a ladder that cannot fit rather than the
+    // arithmetic quietly rounding up past the budget it came from.
+    let budget = strikes.saturating_sub(1)
+        .checked_div(2)
+        .unwrap_or(0);
 
-    Ok(budget.min(MAX_PINNED_WIDTH))
+    budget.min(MAX_PINNED_WIDTH)
 }
 
 /// Refuses a pinned ladder whose lowest strike upstream cannot build.
@@ -593,6 +612,18 @@ mod tests {
                     reason.contains("pinned at creation"),
                     "the failure must explain: {reason}"
                 );
+                // Widening is the one remedy that cannot work, since a wider
+                // ladder puts its far strikes further from this spot still.
+                assert!(
+                    reason.contains("widening chain_size cannot help"),
+                    "the failure must rule out the wrong remedy: {reason}"
+                );
+                assert!(
+                    reason.contains("smaller chain_size")
+                        && reason.contains("initial_price")
+                        && reason.contains("rolling"),
+                    "the failure must name a remedy that works: {reason}"
+                );
             }
             Err(error) => panic!("expected a validation failure, got {error:?}"),
         }
@@ -624,23 +655,54 @@ mod tests {
         }
     }
 
-    /// The widening ceiling is the simulation's own snapshot budget, so a
-    /// pinned step cannot price more contracts than the configuration was
-    /// validated for.
+    /// The widening ceiling is the smaller of the simulation's snapshot budget
+    /// and the absolute ceiling, and both sides of that minimum bind.
+    #[test]
+    fn test_the_widening_ceiling_is_the_smaller_of_both_bounds() {
+        // The service-wide cap is not a bound on its own. At its default a
+        // single-expiration schedule divides 200 000 contracts by one, which
+        // would license 99 999 strikes per side; the absolute ceiling is what
+        // holds. Remove the `min` and this assertion fails.
+        assert_eq!(pinned_width_for(200_000, 1), MAX_PINNED_WIDTH);
+
+        // Split across enough expirations, the budget is the tighter of the
+        // two and the ceiling stops binding. Remove the budget term and this
+        // one fails.
+        assert_eq!(pinned_width_for(200_000, 400), 249);
+        assert_eq!(pinned_width_for(101, 1), 50);
+
+        // A budget too small to carry even a three-strike chain answers zero
+        // rather than rounding itself up past the budget it came from.
+        assert_eq!(pinned_width_for(2, 1), 0);
+        assert_eq!(pinned_width_for(1, 1), 0);
+        assert_eq!(pinned_width_for(0, 1), 0);
+
+        // And a schedule with no rules still divides.
+        assert_eq!(pinned_width_for(200_000, 0), MAX_PINNED_WIDTH);
+    }
+
+    /// The parameters entry point agrees with the pure core it delegates to.
     #[test]
     fn test_the_widening_ceiling_comes_from_the_snapshot_budget() {
         let parameters = parameters(5000.0, 25.0, 2);
+        let cap = crate::infrastructure::max_snapshot_contracts();
 
         let width = match max_pinned_width(&parameters) {
             Ok(width) => width,
             Err(error) => panic!("the budget must resolve: {error}"),
         };
 
-        // One expiration, so the whole per-snapshot budget is one chain: the
-        // `2n + 1` grid must fit inside it.
-        let cap = crate::infrastructure::max_snapshot_contracts();
-        assert!(width * 2 < cap, "{width} strikes per side exceeds {cap}");
-        assert!(width >= 1, "a ladder of one strike must stay reachable");
+        // One expiration in this schedule, so the whole per-snapshot budget is
+        // one chain and the `2n + 1` grid must fit inside it.
+        assert_eq!(width, pinned_width_for(cap, 1));
+        assert!(
+            width * 2 < cap,
+            "{width} strikes per side exceeds {cap}"
+        );
+        assert!(
+            width <= MAX_PINNED_WIDTH,
+            "{width} strikes per side exceeds the {MAX_PINNED_WIDTH} ceiling"
+        );
     }
 
     /// A pinned ladder needs an explicit interval, and says so.

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -171,11 +171,12 @@ impl PinnedLadder {
     /// upstream: the distance in intervals from the spot's at-the-money strike
     /// to whichever pinned strike is furthest from it.
     ///
-    /// `maximum` is the widening the simulation's own snapshot budget allows,
-    /// derived by [`max_pinned_width`] from the same numbers
-    /// `validate_snapshot_work` checked at creation. A pinned step must not be
-    /// able to price more contracts than the configuration was validated for
-    /// simply because the underlying drifted.
+    /// `maximum` is the widening [`max_pinned_width`] allows: the smaller of
+    /// the simulation's own snapshot budget and the absolute ceiling
+    /// [`MAX_PINNED_WIDTH`]. A pinned step must not be able to price more
+    /// contracts than the configuration was validated for, nor a wider chain
+    /// than a client could have requested, simply because the underlying
+    /// drifted.
     ///
     /// # Errors
     ///
@@ -335,18 +336,40 @@ pub(crate) fn at_the_money(
     Positive::new_decimal(rounded).map_err(|_| unrepresentable())
 }
 
+/// The absolute ceiling on the widening a pinned step may ask for.
+///
+/// This is the widest chain any client is allowed to REQUEST
+/// (`OCS_MAX_CHAIN_SIZE`'s default), reused as the ceiling on the widening the
+/// service performs on a client's behalf. The two are different quantities and
+/// only the coincidence of the number is shared, so it lives here rather than
+/// being read from the request caps: lowering the request cap must not
+/// retroactively break simulations already running, and raising it must not
+/// license the domain to price a wider chain than this.
+///
+/// It is a ceiling, never the bound on its own; [`max_pinned_width`] takes it
+/// together with the simulation's snapshot budget and keeps whichever is
+/// smaller.
+pub(crate) const MAX_PINNED_WIDTH: usize = 500;
+
 /// The widest chain a pinned step may ask upstream for.
 ///
 /// A pinned step builds wide enough to REACH its ladder and then filters, so
 /// the widening is work the client never asked for and the request caps never
-/// saw. Bounding it by a constant of its own would let a simulation validated
-/// for a handful of contracts per snapshot price a thousand strikes per
-/// expiration once its spot drifted.
+/// saw. Two separate things have to bound it, and the answer is the smaller:
 ///
-/// The bound is therefore the simulation's own budget, computed from the same
-/// numbers `SimulationParametersV2::validate_snapshot_work` checked at
-/// creation: the per-snapshot contract cap divided by the expirations the
-/// schedule can carry, back through the `2n + 1` grid to a half-width.
+/// The simulation's own snapshot budget, computed from the same numbers
+/// `SimulationParametersV2::validate_snapshot_work` checked at creation: the
+/// per-snapshot contract cap divided by the expirations the schedule can carry,
+/// back through the `2n + 1` grid to a half-width. Without this, a
+/// configuration validated for a handful of contracts per snapshot could price
+/// far more of them once its spot drifted.
+///
+/// And [`MAX_PINNED_WIDTH`], because that budget is a SERVICE-WIDE cap rather
+/// than a per-simulation one. At its default a single-expiration schedule
+/// divides 200 000 contracts by one, which would license a widening of 99 999
+/// strikes per side; a bound that large is not a bound. The absolute ceiling is
+/// what keeps the widening in the region a client could have asked for
+/// directly.
 ///
 /// # Errors
 ///
@@ -366,14 +389,18 @@ pub(crate) fn max_pinned_width(parameters: &SimulationParametersV2) -> Result<us
         })?;
 
     let cap = crate::infrastructure::max_snapshot_contracts();
-    // A schedule with no rules cannot produce a chain, so the width is
-    // irrelevant; one is the smallest answer that is not zero.
+    // A schedule with no rules cannot produce a chain, so the divisor is
+    // irrelevant; one keeps the division defined.
     let strikes = cap.checked_div(expirations.max(1)).unwrap_or(cap);
 
-    // `strikes` covers `2n + 1`, so the half-width is what upstream calls
-    // `chain_size`. At least one, or a pinned ladder of a single strike could
-    // never be reached.
-    Ok(strikes.saturating_sub(1).checked_div(2).unwrap_or(0).max(1))
+    // `strikes` covers the whole `2n + 1` grid, so the half-width is what
+    // upstream calls `chain_size`. No floor: a budget too small to carry even
+    // a three-strike chain must report a width of zero and let `width_from`
+    // refuse the ladder, rather than round itself up past the budget it came
+    // from.
+    let budget = strikes.saturating_sub(1).checked_div(2).unwrap_or(0);
+
+    Ok(budget.min(MAX_PINNED_WIDTH))
 }
 
 /// Refuses a pinned ladder whose lowest strike upstream cannot build.

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -415,9 +415,15 @@ fn pinned_width_for(cap: usize, expirations: usize) -> usize {
     // one strike is a real answer of zero, stated deliberately, and
     // `width_from` then refuses a ladder that cannot fit rather than the
     // arithmetic quietly rounding up past the budget it came from.
-    let budget = strikes.saturating_sub(1)
-        .checked_div(2)
-        .unwrap_or(0);
+    //
+    // Written as a match rather than `checked_sub(1).unwrap_or(0)` because
+    // clippy's `manual_saturating_arithmetic` rewrites that form back into
+    // `saturating_sub` under `make pre-push`, which is the very call the rule
+    // forbids. The match says the same thing and survives the autofix.
+    let budget = match strikes.checked_sub(1) {
+        Some(grid) => grid.checked_div(2).unwrap_or(0),
+        None => 0,
+    };
 
     budget.min(MAX_PINNED_WIDTH)
 }
@@ -695,10 +701,7 @@ mod tests {
         // One expiration in this schedule, so the whole per-snapshot budget is
         // one chain and the `2n + 1` grid must fit inside it.
         assert_eq!(width, pinned_width_for(cap, 1));
-        assert!(
-            width * 2 < cap,
-            "{width} strikes per side exceeds {cap}"
-        );
+        assert!(width * 2 < cap, "{width} strikes per side exceeds {cap}");
         assert!(
             width <= MAX_PINNED_WIDTH,
             "{width} strikes per side exceeds the {MAX_PINNED_WIDTH} ceiling"


### PR DESCRIPTION
Follow-up to the review of #98, from the `reproducibility-reviewer` audit that landed after the merge.

## The problem

The ceiling that PR #98 introduced answers the review finding it was written for, but it is not the bound its own comments claim. `max_pinned_width` divides `OCS_MAX_SNAPSHOT_CONTRACTS` by the expirations the schedule carries, and that variable is a **service-wide** cap, not a per-simulation one. At its documented default of 200 000, a single-expiration schedule gets 99 999 strikes per side, so a pinned step could ask upstream to build and price 199 999 strikes before `keep_pinned` discards everything outside the ladder. The `MAX_PINNED_WIDTH = 500` it replaced was 200 times stricter, and 500 is also the widest chain a client is allowed to request in the first place.

The widened chain is transient, so `OCS_MAX_CACHED_SNAPSHOT_CONTRACTS` never sees it either; only the filtered result reaches the cache.

## What changed

Both bounds now apply and the smaller wins. `MAX_PINNED_WIDTH` returns as an absolute ceiling on the widening the service performs on a client behalf, and `max_pinned_width` takes `budget.min(MAX_PINNED_WIDTH)`. The budget half-width also loses its floor of one, which could exceed the very budget it derived from when the cap divided down to two or fewer strikes; zero is now a legitimate answer and `width_from` refuses the ladder that cannot fit.

The test asserts both halves: the `2n + 1` grid fits the snapshot cap, and the width stays under the absolute ceiling that actually binds at the default configuration.

## Not in this PR

Two findings from the same audit are filed rather than fixed here, because each is a change of its own shape:

- #109, the step-time read of `max_snapshot_contracts()`, which makes how far a pinned tape gets depend on the deployment it runs against.
- #110, a committed golden fixture for the walk kernels, since every reproducibility test in the suite compares two runs of the same build and is structurally blind to a value change.

## Checklist

- [x] Reproducibility intact; this touches no walk path and no price
- [x] Stored-session shape unchanged; `MAX_PINNED_WIDTH` is a private constant
- [x] REST DTOs unchanged
- [x] `ChainError` discipline; the refusal stays a typed validation error
- [x] `make pre-push` clean, zero warnings, 920 tests
- [x] Patch version bumped to 0.2.1, compose image tag with it
