### PR TITLE
Complete the mirrored checked-arithmetic helpers with d_div

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.3}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.4}
     deploy:
       replicas: 2
       restart_policy:

--- a/src/domain/walker.rs
+++ b/src/domain/walker.rs
@@ -6,14 +6,16 @@ use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rand_distr::{Distribution, StandardNormal};
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::{Decimal, MathematicalOps, RoundingStrategy};
 use std::sync::{Arc, Mutex};
 
 /// Checked `Decimal` addition, tagged with the operation that overflowed.
 ///
-/// optionstratlib keeps `d_add` / `d_sub` / `d_mul` / `d_exp` crate-private,
+/// optionstratlib keeps `d_add` / `d_sub` / `d_mul` / `d_div` / `d_exp`
+/// crate-private,
 /// so a mirror that wants the same panic-free kernels has to carry its own.
-/// These four are byte-for-byte equivalents: the same `checked_*` call, the
+/// These five are the complete mirror of the set the walk kernels use, and
+/// byte-for-byte equivalents: the same `checked_*` call, the
 /// same `DecimalError::Overflow { operation, lhs, rhs }` on failure, and the
 /// same value on success — which is what keeps a seeded tape identical
 /// across the change.
@@ -33,6 +35,33 @@ fn d_mul(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Decimal, Decima
     lhs.checked_mul(rhs)
         .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))
 }
+
+/// Checked `Decimal` division with banker's rounding at scale 28.
+///
+/// The rounding is not decoration: upstream re-rounds every quotient with
+/// [`RoundingStrategy::MidpointNearestEven`] at
+/// [`DIV_DEFAULT_SCALE`] so a long chain of divisions does
+/// not accumulate bias in one direction, and a mirror that skipped it would
+/// drift from upstream the first time a kernel divides by something other than
+/// a constant. See [`d_add`] for what these helpers are.
+///
+/// # Errors
+///
+/// [`DecimalError::ArithmeticError`] when `rhs` is zero, and
+/// [`DecimalError::Overflow`] when the quotient is not representable.
+fn d_div(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    if rhs.is_zero() {
+        return Err(DecimalError::arithmetic_error(op, "division by zero"));
+    }
+    let raw = lhs
+        .checked_div(rhs)
+        .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))?;
+    Ok(raw.round_dp_with_strategy(DIV_DEFAULT_SCALE, RoundingStrategy::MidpointNearestEven))
+}
+
+/// The scale every mirrored division rounds its quotient to, matching
+/// upstream's `DIV_DEFAULT_SCALE`.
+const DIV_DEFAULT_SCALE: u32 = 28;
 
 /// Checked `Decimal` exponential. See [`d_add`].
 ///
@@ -315,12 +344,11 @@ impl Walker {
                     )?
                     .max(Decimal::ZERO);
 
-                    let avg_variance =
-                        d_add(variance, variance_new, "simulation::heston::avg_variance")?
-                            .checked_div(Decimal::TWO)
-                            .ok_or_else(|| {
-                                SimulationError::walk_error("Heston: avg variance division failed")
-                            })?;
+                    let avg_variance = d_div(
+                        d_add(variance, variance_new, "simulation::heston::avg_variance")?,
+                        Decimal::TWO,
+                        "simulation::heston::avg_variance",
+                    )?;
                     let avg_variance_sqrt = avg_variance.sqrt().ok_or_else(|| {
                         SimulationError::walk_error("Heston: sqrt(avg_variance) failed (overflow)")
                     })?;
@@ -933,6 +961,34 @@ mod tests {
                 jump_volatility: pos_or_panic!(0.1),
             },
             walker: Box::new(Walker::new_with_seed(1)),
+        }
+    }
+
+    /// The mirrored division carries upstream's semantics, not just its name.
+    #[test]
+    fn test_the_mirrored_division_matches_upstream_semantics() {
+        // A zero divisor is an arithmetic error, never a panic and never an
+        // overflow, and it names the operation that hit it.
+        match d_div(Decimal::ONE, Decimal::ZERO, "test::zero") {
+            Ok(value) => panic!("division by zero must fail, got {value}"),
+            Err(error) => {
+                let rendered = error.to_string();
+                assert!(rendered.contains("test::zero"), "{rendered}");
+                assert!(rendered.contains("division by zero"), "{rendered}");
+            }
+        }
+
+        // The quotient is re-rounded at scale 28 with banker's rounding, which
+        // is what keeps a long chain of divisions from drifting one way.
+        match d_div(Decimal::ONE, dec!(3), "test::third") {
+            Ok(value) => assert!(value.scale() <= 28, "scale {} too wide", value.scale()),
+            Err(error) => panic!("a representable quotient must divide: {error}"),
+        }
+
+        // An ordinary division is exactly that.
+        match d_div(dec!(7.5), Decimal::TWO, "test::half") {
+            Ok(value) => assert_eq!(value, dec!(3.75)),
+            Err(error) => panic!("must divide: {error}"),
         }
     }
 


### PR DESCRIPTION
Closes #111

Base branch: `stack/2-110-golden-tape-fixture`
Stacked on: #114
Blocks: #116

Stack: #109 → #110 → **#111** → #112 → #99 → #104 → #100 → #101 → #102 → #103 → #106 → #105 → #107

The diff is cumulative until #113 and #114 merge, so read it against the base branch rather than against `main`.

## What changed

The seeded walker mirrors optionstratlib crate-private checked helpers so its kernels stay panic-free, and it carried four of the five. The one division in Heston used `checked_div(Decimal::TWO)` with a `walk_error`, which is value-identical today only because the divisor is a constant: upstream re-rounds every quotient with `MidpointNearestEven` at scale 28 so a long chain of divisions does not accumulate bias in one direction, and the next kernel that divides by a non-constant would have drifted silently.

`d_div` now mirrors upstream exactly, zero-divisor arithmetic error included, and Heston average variance goes through it with upstream own operation tag. The helper set is documented as the complete mirror.

## Proof nothing moved

The golden tape from #110 passes unchanged, which is a stronger statement than the same-seed tests could make: it compares against values committed before this change, not against another run of this build.

## Tests

926 pass. A new unit test pins the three things that make `d_div` a mirror rather than a rename: a zero divisor is an arithmetic error naming the operation, a quotient is re-rounded at scale 28, and an ordinary division is exact.

## Checklist

- [x] Reproducibility intact, proven by the committed tape rather than by a same-build comparison
- [x] Stored-session shape untouched
- [x] REST DTOs unchanged
- [x] `ChainError` discipline; the helper returns `DecimalError`, which `SimulationError` already absorbs
- [x] `make pre-push` clean, zero warnings
- [x] Patch version bumped to 0.2.4 with the compose image tag