### PR TITLE
Take the current service images, on alpine where they publish one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,23 +53,27 @@ jobs:
     name: Integration (live services)
     runs-on: ubuntu-latest
     services:
+      # Pinned by immutable digest, the same way the compose files are: a
+      # mutable tag can be republished, and a job testing different bytes from
+      # the ones a deployment runs proves nothing about that deployment.
+      #
       # Credentials must match the code's env-driven config defaults
       # (MONGODB_URI / REDIS_* / CLICKHOUSE_* in src/infrastructure/config/*),
       # so the ignored live tests authenticate successfully and can ASSERT
       # success instead of tolerating connection failures.
       mongodb:
-        image: mongo:8.2.12
+        image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
         env:
           MONGO_INITDB_ROOT_USERNAME: admin
           MONGO_INITDB_ROOT_PASSWORD: password
         ports:
           - 27017:27017
       redis:
-        image: redis:8.10.1-alpine
+        image: redis:8.10.1-alpine@sha256:becdda6c7f4b3fb42e42fd7f120bbf5c54c4caaaf16f26da24e4563d2c1f0576
         ports:
           - 6379:6379
       clickhouse:
-        image: clickhouse/clickhouse-server:26.8.1.2041-alpine
+        image: clickhouse/clickhouse-server:26.8.1.2041-alpine@sha256:fd037d424da807c1b36517f3ff6c739286c60a34c928279c229fc1faa0cadaa8
         env:
           CLICKHOUSE_USER: admin
           CLICKHOUSE_PASSWORD: password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,18 +58,18 @@ jobs:
       # so the ignored live tests authenticate successfully and can ASSERT
       # success instead of tolerating connection failures.
       mongodb:
-        image: mongo:8.0.29
+        image: mongo:8.2.12
         env:
           MONGO_INITDB_ROOT_USERNAME: admin
           MONGO_INITDB_ROOT_PASSWORD: password
         ports:
           - 27017:27017
       redis:
-        image: redis:8.10.0
+        image: redis:8.10.1-alpine
         ports:
           - 6379:6379
       clickhouse:
-        image: clickhouse/clickhouse-server:26.3.17.110
+        image: clickhouse/clickhouse-server:26.8.1.2041-alpine
         env:
           CLICKHOUSE_USER: admin
           CLICKHOUSE_PASSWORD: password

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -70,6 +70,22 @@ services:
 
   # MongoDB service configuration
   mongodb:
+    # UPGRADING AN EXISTING DEPLOYMENT from the 8.0 line: MongoDB refuses to
+    # start on a data directory whose feature compatibility version is higher
+    # than the binary, and it will not jump an FCV on its own. The order is:
+    #
+    #   1. on the RUNNING 8.0 instance, confirm the FCV is 8.0
+    #      db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1})
+    #   2. stop it, swap the image to this one, start it. The data directory
+    #      keeps FCV 8.0, which 8.2 serves happily, so this step is
+    #      reversible: putting the 8.0 image back still starts
+    #   3. once the deployment is trusted, raise it, which is the point of no
+    #      easy return
+    #      db.adminCommand({setFeatureCompatibilityVersion: "8.2", confirm: true})
+    #
+    # Verified on this exact digest against a persisted volume: 8.0.29 with
+    # FCV 8.0, binary swapped, 8.2.12 started, documents intact, FCV still 8.0,
+    # then raised to 8.2. A fresh volume needs none of this.
     image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
     volumes:
       - mongodb-data:/data/db

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -49,7 +49,7 @@ version: '3.8'
 services:
   # Redis service configuration
   redis:
-    image: redis:8.10.0@sha256:344e3945a0b431c8ff1eecd58c5573538126bd756f02fc7e218ddf1fc2546366
+    image: redis:8.10.1-alpine@sha256:becdda6c7f4b3fb42e42fd7f120bbf5c54c4caaaf16f26da24e4563d2c1f0576
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-password}
     volumes:
       - redis-data:/data
@@ -70,7 +70,7 @@ services:
 
   # MongoDB service configuration
   mongodb:
-    image: mongo:8.0.29@sha256:de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06
+    image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
@@ -92,7 +92,7 @@ services:
         delay: 5s
 
   clickhouse:
-    image: clickhouse/clickhouse-server:26.3.17.110@sha256:2ef11bbe2e44ab7022f37ff3019b3f2125ed09e919ea6194660be6130b7ca4b7
+    image: clickhouse/clickhouse-server:26.8.1.2041-alpine@sha256:fd037d424da807c1b36517f3ff6c739286c60a34c928279c229fc1faa0cadaa8
     environment:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-admin}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-password}
@@ -111,7 +111,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.4}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.5}
     deploy:
       replicas: 2
       restart_policy:


### PR DESCRIPTION
Closes #112

Base branch: `stack/3-111-mirror-d-div`
Stacked on: #115
Blocks: #118

Stack: #109 → #110 → #111 → **#112** → #99 → #104 → #100 → #101 → #102 → #103 → #106 → #105 → #107

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## What changed

| Image | Was | Now |
|---|---|---|
| redis | 8.10.0 | 8.10.1-alpine |
| mongo | 8.0.29 | 8.2.12 |
| clickhouse-server | 26.3.17.110 | 26.8.1.2041-alpine |

Every digest was re-resolved with `docker buildx imagetools inspect` rather than copied from anywhere, and tag and digest move together. Redis and ClickHouse take their alpine variants; MongoDB publishes none, so it stays on its own base. `Docker/Dockerfile` already builds on `rust:1.97.1-alpine3.24` over `alpine:3.24`, so nothing there needed changing.

The CI service containers move with the compose file, so the live-service job runs against what an operator would deploy.

## Verified rather than assumed

Each image was run locally with the credentials the compose file and the CI job actually supply. Worth knowing: **ClickHouse 26.8 refuses a query with no credentials** where the previous generation answered, so an environment that relied on the anonymous default user would break. Ours does not, both places set `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD`, and with them the server answers `26.8.1.2041`. Redis replies `PONG`, MongoDB reports `8.2.12`.

## On the dev compose file

`Docker/docker-compose.dev.yml` carries no pins for these three services: it is an override that adds ports, container names and the UIs, and inherits the images from the base file, so there is exactly one place where each service image is pinned. Its own two images, mongo-express and redis-commander, are outside this issue.

## Checklist

- [x] Hermetic suite untouched; `make pre-push` clean, zero warnings
- [x] The Integration job on this PR is the proof the new service containers work
- [x] Images pinned by immutable digest, tags kept as readable prefixes
- [x] Patch version bumped to 0.2.5 with the compose image tag