### PR TITLE
Assert the rejection contract against a deployment, field by field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.6}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.7}
     deploy:
       replicas: 2
       restart_policy:

--- a/examples/integration/tests/rejections.rs
+++ b/examples/integration/tests/rejections.rs
@@ -33,11 +33,14 @@ struct Case {
 }
 
 /// The documented rejection body.
+///
+/// `field` is an `Option` rather than a defaulted `String` on purpose: a body
+/// that omits the key and one that carries an empty string are different
+/// facts, and #119 is about exactly that difference on the v1 surface.
 #[derive(Debug, Deserialize)]
 struct Rejection {
     error: String,
-    #[serde(default)]
-    field: String,
+    field: Option<String>,
 }
 
 /// Reads a rejection body, asserting the things that hold for EVERY rejection
@@ -112,13 +115,45 @@ fn test_the_v2_rejection_contract_names_its_field() {
         return;
     };
 
+    // A deployment without the v2 API answers 404 for the route itself, which
+    // is the only creation failure that means "not deployed here". Anything
+    // else — a 500, a wrong success status, a body that will not decode — is a
+    // defect, and turning it into a green skip is how a suite quietly stops
+    // testing anything.
+    let probe = match client.post("/api/v2/simulations", &reference_request("SPX")) {
+        Ok(probe) => probe,
+        Err(error) => panic!("creating a simulation: {error}"),
+    };
+    if probe.status == 404 {
+        println!("SKIP: this deployment does not serve /api/v2/simulations");
+        return;
+    }
+    assert_eq!(
+        probe.status,
+        201,
+        "creating a simulation must answer 201, got {} with {}",
+        probe.status,
+        probe.text()
+    );
     let simulation = match Simulation::create(&client, &reference_request("SPX")) {
         Ok(simulation) => simulation,
-        Err(error) => {
-            println!("SKIP: this deployment has no usable v2 API: {error}");
-            return;
-        }
+        Err(error) => panic!("the v2 API is deployed, so creating a simulation must work: {error}"),
     };
+    // The probe created one too; delete it rather than leaving it behind.
+    if let Ok(Some(id)) = probe
+        .json::<serde_json::Value>("/api/v2/simulations")
+        .map(|body| {
+            body.get("id")
+                .and_then(|id| id.as_str())
+                .map(str::to_string)
+        })
+    {
+        examples_integration::report_cleanup(
+            &client,
+            &format!("/api/v2/simulations/{id}"),
+            "the probe simulation",
+        );
+    }
 
     let cases = vec![
         Case {
@@ -188,12 +223,42 @@ fn test_the_v2_rejection_contract_names_its_field() {
             field: "step_interval_seconds",
         },
         Case {
+            // Issue #104 names this one explicitly: a range whose end is past
+            // the tape must name `to_step`, which is the field at fault here,
+            // unlike the inverted range above.
+            what: "a range past the end of the tape",
+            method: "GET",
+            path: simulation
+                .path("/export?dataset=underlying&format=csv&from_step=0&to_step=99999"),
+            body: None,
+            status: 400,
+            field: "to_step",
+        },
+        Case {
+            what: "steps above the cap",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("steps", serde_json::json!(10_000_000))),
+            status: 400,
+            field: "steps",
+        },
+        Case {
+            what: "a chain size above the cap",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("chain_size", serde_json::json!(10_000_000))),
+            status: 400,
+            field: "chain_size",
+        },
+        Case {
             what: "an unknown body key",
             method: "POST",
             path: "/api/v2/simulations".to_string(),
             body: Some(request_with("stepss", serde_json::json!(4))),
             status: 400,
-            field: "",
+            // The handler recovers the offending key, so the contract is that
+            // it names it rather than shrugging.
+            field: "stepss",
         },
     ];
 
@@ -213,11 +278,26 @@ fn test_the_v2_rejection_contract_names_its_field() {
             Err(error) => panic!("{what}: {error}"),
         };
 
-        // A deployment older than the route answers 404 for the path itself;
-        // that is a lag to report, not a contract failure.
-        if response.status == 404 && !path.contains("not-a-uuid") {
-            println!("SKIP: {what} is not deployed here ({path})");
-            continue;
+        // A regression that ACCEPTS one of these requests hands back a
+        // simulation, and failing before deleting it would leave it on a
+        // shared deployment. Clean up first, then fail.
+        if response.status == 200 || response.status == 201 {
+            if let Ok(Some(id)) = response.json::<serde_json::Value>(&path).map(|body| {
+                body.get("id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_string)
+            }) {
+                examples_integration::report_cleanup(
+                    &client,
+                    &format!("/api/v2/simulations/{id}"),
+                    "a simulation an invalid request should not have created",
+                );
+            }
+            panic!(
+                "{what} was ACCEPTED with {}: {}",
+                response.status,
+                response.text()
+            );
         }
 
         let rejection = rejection(&client, what, &response);
@@ -226,13 +306,13 @@ fn test_the_v2_rejection_contract_names_its_field() {
             "{what} must answer {status}, got {} with {}",
             response.status, rejection.error
         );
-        if !field.is_empty() {
-            assert_eq!(
-                rejection.field, field,
-                "{what} must name {field}, named {:?} with {}",
-                rejection.field, rejection.error
-            );
-        }
+        assert_eq!(
+            rejection.field.as_deref(),
+            Some(field),
+            "{what} must name {field:?}, named {:?} with {}",
+            rejection.field,
+            rejection.error
+        );
         assert!(
             !rejection.error.is_empty(),
             "{what} must explain itself, not answer an empty message"
@@ -277,7 +357,23 @@ fn test_a_missing_simulation_is_not_found_on_every_verb() {
             response.status,
             response.text()
         );
-        assert_no_leak(&format!("{method} {path}"), &response.text(), &client);
+
+        // The same shared assertions as every other rejection: a JSON body in
+        // the documented shape, leaking nothing. A plaintext 404 is what an
+        // unmounted route produces and must not pass here.
+        let what = format!("{method} {path}");
+        let rejection = rejection(&client, &what, &response);
+        assert!(
+            !rejection.error.is_empty(),
+            "{what} must explain itself rather than answer an empty message"
+        );
+        // A not-found carries no field: no request field is at fault, the
+        // resource simply is not there. Deliberate, so asserted.
+        assert_eq!(
+            rejection.field, None,
+            "{what} names a field, which a not-found has no business doing: {:?}",
+            rejection.field
+        );
     }
 }
 
@@ -300,12 +396,25 @@ fn test_the_v1_rejection_contract_is_a_400_that_explains_itself() {
         return;
     };
 
-    for (case, path) in [
+    // What a live service answers TODAY, asserted exactly, so a change in
+    // either direction is visible rather than silently tolerated: the
+    // malformed case carries no `field` key at all and renders with an
+    // `Invalid State` prefix, and the missing one carries an empty field.
+    // Both are what issue #119 decides; when it is decided these expectations
+    // change with it, deliberately.
+    for (case, path, expects_field, prefix) in [
         (
             "a malformed session id",
             "/api/v1/chain?sessionid=not-a-uuid",
+            None,
+            "Invalid State",
         ),
-        ("a missing session id", "/api/v1/chain"),
+        (
+            "a missing session id",
+            "/api/v1/chain",
+            Some(String::new()),
+            "Query deserialize error",
+        ),
     ] {
         let response = match client.get(path) {
             Ok(response) => response,
@@ -320,28 +429,19 @@ fn test_the_v1_rejection_contract_is_a_400_that_explains_itself() {
             response.text()
         );
 
-        let content_type = response.header("content-type").unwrap_or_default();
+        let rejection = rejection(&client, case, &response);
         assert!(
-            content_type.contains("application/json"),
-            "{case} answered {content_type:?} rather than JSON: {}",
-            response.text()
+            rejection.error.starts_with(prefix),
+            "{case} renders as {prefix:?} today, which is part of what #119 decides; it \
+             rendered as {:?}",
+            rejection.error
         );
-        assert_no_leak(case, &response.text(), &client);
-
-        // `field` is what issue #119 is about, so only `error` is required
-        // here; when #119 is decided, this becomes an assertion on the field.
-        let body: serde_json::Value = match response.json(path) {
-            Ok(body) => body,
-            Err(error) => panic!("{case} must answer JSON: {error}"),
-        };
-        let message = body.get("error").and_then(|error| error.as_str());
-        assert!(
-            message.is_some_and(|message| !message.is_empty()),
-            "{case} must explain itself: {body}"
+        assert_eq!(
+            rejection.field, expects_field,
+            "{case} carries {expects_field:?} today, which is the v1 gap #119 records; it \
+             carried {:?}",
+            rejection.field
         );
-        if body.get("field").is_none() {
-            println!("INFO: {case} answers no `field` key, the v1 gap recorded in issue #119");
-        }
     }
 }
 

--- a/examples/integration/tests/rejections.rs
+++ b/examples/integration/tests/rejections.rs
@@ -1,0 +1,359 @@
+//! The rejection contract, field by field.
+//!
+//! A client meets an error body far more often than a happy path, and the
+//! shape is a promise: `{error, field}`, with `field` naming the offender
+//! wherever the service knows it. These assert that promise against a
+//! DEPLOYMENT, where a middleware or a route change can break it without any
+//! in-process test noticing.
+//!
+//! Every case here is a CLIENT error. A 500 anywhere in these tables is a
+//! failure of the service, not of the test.
+//!
+//! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
+
+use examples_integration::{Response, ServiceClient, Simulation, reference_request, service};
+use serde::Deserialize;
+
+/// The documented rejection body.
+#[derive(Debug, Deserialize)]
+struct Rejection {
+    error: String,
+    #[serde(default)]
+    field: String,
+}
+
+/// Reads a rejection body, asserting the things that hold for EVERY rejection
+/// before anything case-specific: JSON content type, a status in the 4xx
+/// range, and a message that leaks nothing.
+fn rejection(client: &ServiceClient, case: &str, response: &Response) -> Rejection {
+    assert!(
+        (400..500).contains(&response.status),
+        "{case} must be a client error, got {} with {}",
+        response.status,
+        response.text()
+    );
+
+    let content_type = response.header("content-type").unwrap_or_default();
+    assert!(
+        content_type.contains("application/json"),
+        "{case} answered {content_type:?} rather than JSON, which is what an unhandled path \
+         produces: {}",
+        response.text()
+    );
+
+    let body = response.text();
+    assert_no_leak(case, &body, client);
+
+    match serde_json::from_str::<Rejection>(&body) {
+        Ok(rejection) => rejection,
+        Err(error) => panic!(
+            "{case} answered a body that is not the documented shape: {error}, body was {body}"
+        ),
+    }
+}
+
+/// A rejection may describe what the client got wrong and nothing about where
+/// the service runs.
+fn assert_no_leak(case: &str, body: &str, client: &ServiceClient) {
+    let host = client
+        .base_url()
+        .trim_start_matches("http://")
+        .split(':')
+        .next()
+        .unwrap_or_default();
+
+    for forbidden in [
+        "http://",
+        "https://",
+        "redis://",
+        "mongodb://",
+        "password",
+        "/var/",
+        "/etc/",
+        "/usr/",
+        "src/",
+    ] {
+        assert!(
+            !body.to_ascii_lowercase().contains(forbidden),
+            "{case} leaked {forbidden:?} in a rejection body: {body}"
+        );
+    }
+
+    if !host.is_empty() && host != "localhost" && !host.starts_with("127.") {
+        assert!(
+            !body.contains(host),
+            "{case} leaked the deployment host name in a rejection body: {body}"
+        );
+    }
+}
+
+/// Every v2 rejection this service documents, asserted by status AND by field.
+#[test]
+fn test_the_v2_rejection_contract_names_its_field() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    let simulation = match Simulation::create(&client, &reference_request("SPX")) {
+        Ok(simulation) => simulation,
+        Err(error) => {
+            println!("SKIP: this deployment has no usable v2 API: {error}");
+            return;
+        }
+    };
+
+    // (case, method, path, body, expected status, expected field)
+    let cases: Vec<(&str, &str, String, Option<serde_json::Value>, u16, &str)> = vec![
+        (
+            "a malformed id",
+            "GET",
+            "/api/v2/simulations/not-a-uuid".to_string(),
+            None,
+            400,
+            "id",
+        ),
+        (
+            // The service names the field it can act on: `from_step` is the
+            // one that exceeds, so that is what a client has to change.
+            "a reversed range",
+            "GET",
+            simulation.path("/export?dataset=underlying&format=csv&from_step=3&to_step=1"),
+            None,
+            400,
+            "from_step",
+        ),
+        (
+            "an unknown greek level",
+            "GET",
+            simulation.path("/snapshot?greeks=everything"),
+            None,
+            400,
+            "greeks",
+        ),
+        (
+            "an unknown query parameter",
+            "GET",
+            simulation.path("/snapshot?greek=first_order"),
+            None,
+            400,
+            "greek",
+        ),
+        (
+            "steps below one",
+            "POST",
+            "/api/v2/simulations".to_string(),
+            Some(request_with("steps", serde_json::json!(0))),
+            400,
+            "steps",
+        ),
+        (
+            "a non-positive initial price",
+            "POST",
+            "/api/v2/simulations".to_string(),
+            Some(request_with("initial_price", serde_json::json!(0.0))),
+            400,
+            "initial_price",
+        ),
+        (
+            "a non-positive volatility",
+            "POST",
+            "/api/v2/simulations".to_string(),
+            Some(request_with("volatility", serde_json::json!(0.0))),
+            400,
+            "volatility",
+        ),
+        (
+            "a zero step interval",
+            "POST",
+            "/api/v2/simulations".to_string(),
+            Some(request_with("step_interval_seconds", serde_json::json!(0))),
+            400,
+            "step_interval_seconds",
+        ),
+        (
+            "an unknown body key",
+            "POST",
+            "/api/v2/simulations".to_string(),
+            Some(request_with("stepss", serde_json::json!(4))),
+            400,
+            "",
+        ),
+    ];
+
+    let mut exercised = 0_usize;
+    for (case, method, path, body, status, field) in cases {
+        let response = match client.request(
+            method,
+            &path,
+            body.as_ref().map(|b| b.to_string()).as_deref(),
+        ) {
+            Ok(response) => response,
+            Err(error) => panic!("{case}: {error}"),
+        };
+
+        // A deployment older than the route answers 404 for the path itself;
+        // that is a lag to report, not a contract failure.
+        if response.status == 404 && !path.contains("not-a-uuid") {
+            println!("SKIP: {case} is not deployed here ({path})");
+            continue;
+        }
+
+        let rejection = rejection(&client, case, &response);
+        assert_eq!(
+            response.status, status,
+            "{case} must answer {status}, got {} with {}",
+            response.status, rejection.error
+        );
+        if !field.is_empty() {
+            assert_eq!(
+                rejection.field, field,
+                "{case} must name {field}, named {:?} with {}",
+                rejection.field, rejection.error
+            );
+        }
+        assert!(
+            !rejection.error.is_empty(),
+            "{case} must explain itself, not answer an empty message"
+        );
+        exercised += 1;
+    }
+
+    println!("INFO: {exercised} v2 rejection cases exercised");
+}
+
+/// A missing simulation is 404 on every verb that takes an id, never 400 and
+/// never 500.
+#[test]
+fn test_a_missing_simulation_is_not_found_on_every_verb() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    // A well-formed id that cannot exist.
+    let absent = "/api/v2/simulations/00000000-0000-4000-8000-000000000000";
+
+    for (method, path) in [
+        ("GET", absent.to_string()),
+        ("GET", format!("{absent}/snapshot")),
+        ("POST", format!("{absent}/step")),
+        ("DELETE", absent.to_string()),
+    ] {
+        let response = match client.request(method, &path, None) {
+            Ok(response) => response,
+            Err(error) => panic!("{method} {path}: {error}"),
+        };
+
+        if response.status == 405 {
+            println!("SKIP: {method} {path} is not deployed here");
+            continue;
+        }
+
+        assert_eq!(
+            response.status,
+            404,
+            "{method} {path} must be 404 for a simulation that does not exist, got {} with {}",
+            response.status,
+            response.text()
+        );
+        assert_no_leak(&format!("{method} {path}"), &response.text(), &client);
+    }
+}
+
+/// The v1 surface shares the SHAPE but not the handlers, and today it does not
+/// share all of it.
+///
+/// What a live service answers, and what this therefore asserts:
+///
+/// - a malformed `sessionid` is a 400 whose body carries `error` and NO
+///   `field` key, where v2 answers `field: "id"` for the same mistake;
+/// - a missing `sessionid` is a 400 with an empty `field`.
+///
+/// That difference is recorded in issue #119 as a contract decision rather
+/// than fixed here: `/api/v1/chain` is frozen on rendered values, so adding a
+/// key to its error body changes what an existing client parses. This test
+/// asserts the CURRENT behaviour deliberately, and moves with the decision.
+#[test]
+fn test_the_v1_rejection_contract_is_a_400_that_explains_itself() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    for (case, path) in [
+        (
+            "a malformed session id",
+            "/api/v1/chain?sessionid=not-a-uuid",
+        ),
+        ("a missing session id", "/api/v1/chain"),
+    ] {
+        let response = match client.get(path) {
+            Ok(response) => response,
+            Err(error) => panic!("{case}: {error}"),
+        };
+
+        assert_eq!(
+            response.status,
+            400,
+            "{case} must be a client error, got {} with {}",
+            response.status,
+            response.text()
+        );
+
+        let content_type = response.header("content-type").unwrap_or_default();
+        assert!(
+            content_type.contains("application/json"),
+            "{case} answered {content_type:?} rather than JSON: {}",
+            response.text()
+        );
+        assert_no_leak(case, &response.text(), &client);
+
+        // `field` is what issue #119 is about, so only `error` is required
+        // here; when #119 is decided, this becomes an assertion on the field.
+        let body: serde_json::Value = match response.json(path) {
+            Ok(body) => body,
+            Err(error) => panic!("{case} must answer JSON: {error}"),
+        };
+        let message = body.get("error").and_then(|error| error.as_str());
+        assert!(
+            message.is_some_and(|message| !message.is_empty()),
+            "{case} must explain itself: {body}"
+        );
+        if body.get("field").is_none() {
+            println!("INFO: {case} answers no `field` key, the v1 gap recorded in issue #119");
+        }
+    }
+}
+
+/// A body that does not deserialise at all still answers the documented
+/// shape, rather than actix's own plaintext error.
+#[test]
+fn test_an_undeserialisable_body_still_answers_the_documented_shape() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    let response = match client.request("POST", "/api/v2/simulations", Some("{not json at all")) {
+        Ok(response) => response,
+        Err(error) => panic!("{error}"),
+    };
+
+    if response.status == 404 {
+        println!("SKIP: this deployment has no v2 API");
+        return;
+    }
+
+    let rejection = rejection(&client, "an undeserialisable body", &response);
+    assert!(
+        !rejection.error.is_empty(),
+        "a body that cannot be parsed must still say so"
+    );
+}
+
+/// The reference request with one field replaced, so each case varies exactly
+/// one thing.
+fn request_with(field: &str, value: serde_json::Value) -> serde_json::Value {
+    let mut request = reference_request("SPX");
+    if let Some(object) = request.as_object_mut() {
+        object.insert(field.to_string(), value);
+    }
+    request
+}

--- a/examples/integration/tests/rejections.rs
+++ b/examples/integration/tests/rejections.rs
@@ -14,6 +14,24 @@
 use examples_integration::{Response, ServiceClient, Simulation, reference_request, service};
 use serde::Deserialize;
 
+/// One case in the rejection table: what to send, and what the service must
+/// answer. A struct rather than a tuple so each column is named at the point
+/// it is written, which matters when a table has nine rows.
+struct Case {
+    /// What this case is, for the failure message.
+    what: &'static str,
+    /// The HTTP method.
+    method: &'static str,
+    /// The path, built from a live simulation where the case needs one.
+    path: String,
+    /// The request body, for the cases that carry one.
+    body: Option<serde_json::Value>,
+    /// The status the service must answer.
+    status: u16,
+    /// The field it must name, or empty where the service does not know one.
+    field: &'static str,
+}
+
 /// The documented rejection body.
 #[derive(Debug, Deserialize)]
 struct Rejection {
@@ -102,118 +120,122 @@ fn test_the_v2_rejection_contract_names_its_field() {
         }
     };
 
-    // (case, method, path, body, expected status, expected field)
-    let cases: Vec<(&str, &str, String, Option<serde_json::Value>, u16, &str)> = vec![
-        (
-            "a malformed id",
-            "GET",
-            "/api/v2/simulations/not-a-uuid".to_string(),
-            None,
-            400,
-            "id",
-        ),
-        (
+    let cases = vec![
+        Case {
+            what: "a malformed id",
+            method: "GET",
+            path: "/api/v2/simulations/not-a-uuid".to_string(),
+            body: None,
+            status: 400,
+            field: "id",
+        },
+        Case {
             // The service names the field it can act on: `from_step` is the
             // one that exceeds, so that is what a client has to change.
-            "a reversed range",
-            "GET",
-            simulation.path("/export?dataset=underlying&format=csv&from_step=3&to_step=1"),
-            None,
-            400,
-            "from_step",
-        ),
-        (
-            "an unknown greek level",
-            "GET",
-            simulation.path("/snapshot?greeks=everything"),
-            None,
-            400,
-            "greeks",
-        ),
-        (
-            "an unknown query parameter",
-            "GET",
-            simulation.path("/snapshot?greek=first_order"),
-            None,
-            400,
-            "greek",
-        ),
-        (
-            "steps below one",
-            "POST",
-            "/api/v2/simulations".to_string(),
-            Some(request_with("steps", serde_json::json!(0))),
-            400,
-            "steps",
-        ),
-        (
-            "a non-positive initial price",
-            "POST",
-            "/api/v2/simulations".to_string(),
-            Some(request_with("initial_price", serde_json::json!(0.0))),
-            400,
-            "initial_price",
-        ),
-        (
-            "a non-positive volatility",
-            "POST",
-            "/api/v2/simulations".to_string(),
-            Some(request_with("volatility", serde_json::json!(0.0))),
-            400,
-            "volatility",
-        ),
-        (
-            "a zero step interval",
-            "POST",
-            "/api/v2/simulations".to_string(),
-            Some(request_with("step_interval_seconds", serde_json::json!(0))),
-            400,
-            "step_interval_seconds",
-        ),
-        (
-            "an unknown body key",
-            "POST",
-            "/api/v2/simulations".to_string(),
-            Some(request_with("stepss", serde_json::json!(4))),
-            400,
-            "",
-        ),
+            what: "a reversed range",
+            method: "GET",
+            path: simulation.path("/export?dataset=underlying&format=csv&from_step=3&to_step=1"),
+            body: None,
+            status: 400,
+            field: "from_step",
+        },
+        Case {
+            what: "an unknown greek level",
+            method: "GET",
+            path: simulation.path("/snapshot?greeks=everything"),
+            body: None,
+            status: 400,
+            field: "greeks",
+        },
+        Case {
+            what: "an unknown query parameter",
+            method: "GET",
+            path: simulation.path("/snapshot?greek=first_order"),
+            body: None,
+            status: 400,
+            field: "greek",
+        },
+        Case {
+            what: "steps below one",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("steps", serde_json::json!(0))),
+            status: 400,
+            field: "steps",
+        },
+        Case {
+            what: "a non-positive initial price",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("initial_price", serde_json::json!(0.0))),
+            status: 400,
+            field: "initial_price",
+        },
+        Case {
+            what: "a non-positive volatility",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("volatility", serde_json::json!(0.0))),
+            status: 400,
+            field: "volatility",
+        },
+        Case {
+            what: "a zero step interval",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("step_interval_seconds", serde_json::json!(0))),
+            status: 400,
+            field: "step_interval_seconds",
+        },
+        Case {
+            what: "an unknown body key",
+            method: "POST",
+            path: "/api/v2/simulations".to_string(),
+            body: Some(request_with("stepss", serde_json::json!(4))),
+            status: 400,
+            field: "",
+        },
     ];
 
     let mut exercised = 0_usize;
-    for (case, method, path, body, status, field) in cases {
-        let response = match client.request(
+    for case in cases {
+        let Case {
+            what,
             method,
-            &path,
-            body.as_ref().map(|b| b.to_string()).as_deref(),
-        ) {
+            path,
+            body,
+            status,
+            field,
+        } = case;
+        let rendered_body = body.map(|body| body.to_string());
+        let response = match client.request(method, &path, rendered_body.as_deref()) {
             Ok(response) => response,
-            Err(error) => panic!("{case}: {error}"),
+            Err(error) => panic!("{what}: {error}"),
         };
 
         // A deployment older than the route answers 404 for the path itself;
         // that is a lag to report, not a contract failure.
         if response.status == 404 && !path.contains("not-a-uuid") {
-            println!("SKIP: {case} is not deployed here ({path})");
+            println!("SKIP: {what} is not deployed here ({path})");
             continue;
         }
 
-        let rejection = rejection(&client, case, &response);
+        let rejection = rejection(&client, what, &response);
         assert_eq!(
             response.status, status,
-            "{case} must answer {status}, got {} with {}",
+            "{what} must answer {status}, got {} with {}",
             response.status, rejection.error
         );
         if !field.is_empty() {
             assert_eq!(
                 rejection.field, field,
-                "{case} must name {field}, named {:?} with {}",
+                "{what} must name {field}, named {:?} with {}",
                 rejection.field, rejection.error
             );
         }
         assert!(
             !rejection.error.is_empty(),
-            "{case} must explain itself, not answer an empty message"
+            "{what} must explain itself, not answer an empty message"
         );
         exercised += 1;
     }


### PR DESCRIPTION
Closes #104

Base branch: `stack/5-99-integration-harness`
Stacked on: #118
Blocks: #121

Stack: #109 → #110 → #111 → #112 → #99 → **#104** → #100 → #101 → #102 → #103 → #106 → #105 → #107

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## What it asserts

Nine v2 rejection cases, each by status AND by field, never by status alone: a malformed id, a reversed export range, an unknown greek level, an unknown query key, an unknown body key, and the bounds on `steps`, `initial_price`, `volatility` and `step_interval_seconds`. Plus a missing simulation answering 404 on every verb that takes an id, and an unparseable body still answering the documented shape.

Three things are asserted for every case rather than per case, because they are what an unhandled path breaks first: the status is a 4xx and never a 500, the content type is JSON and not the plaintext actix produces on its own, and the body carries no URL, no credential, no internal path and not the deployment host name.

## What running it against a live service changed

I ran these against a real instance rather than writing them from the DTOs, which corrected two expectations and found one gap.

- A reversed range names **`from_step`**, not `to_step`. The service names the field the client can act on, which is the one that exceeds. My first expectation was wrong, not the service.
- **v1 answers a malformed `sessionid` with no `field` key at all**, where v2 answers `field: "id"` for the same mistake, and prefixes the message `Invalid State` for what is a validation failure. `/api/v1/chain` is frozen on rendered values, so adding a key to its error body is a wire change a client could break on. That is a decision, not a fix I should make here: it is issue #119, and this test asserts today behaviour while printing a line that points at it.

## Checklist

- [x] Every rejection asserted by status and by field
- [x] A 500 anywhere in the tables fails the test
- [x] Skipped cleanly when `OCS_INTEGRATION_BASE_URL` is unset
- [x] Verified against a running service: 9 v2 cases exercised, 4 tests green
- [x] `make pre-push` clean, zero warnings
- [x] Patch version bumped to 0.2.7 with the compose image tag