### PR TITLE
Cover the export matrix against a deployment

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run the integration suite
-        run: cargo test -p examples_integration -- --nocapture
+        # --all-features turns on the arrow decoder, so an arrow export is
+        # compared value by value with the text ones rather than only fetched.
+        run: cargo test -p examples_integration --all-features -- --nocapture
         env:
           LOGLEVEL: WARN
           OCS_INTEGRATION_BASE_URL: ${{ inputs.base_url || vars.OCS_INTEGRATION_BASE_URL }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.10}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.11}
     deploy:
       replicas: 2
       restart_policy:

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test:
 test-integration:
 	@test -n "$$OCS_INTEGRATION_BASE_URL" || \
 		echo "OCS_INTEGRATION_BASE_URL is unset: every integration test will skip"
-	LOGLEVEL=WARN cargo test -p examples_integration -- --nocapture
+	LOGLEVEL=WARN cargo test -p examples_integration --all-features -- --nocapture
 
 # Format the code
 .PHONY: fmt

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -4,8 +4,15 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+# Decoding an Arrow export needs the same crate that writes one. Off by
+# default so the hermetic suite stays as light as the library's own default
+# build; the integration job turns it on.
+arrow-export = ["dep:arrow"]
+
 [dependencies]
 optionchain_simulator = { workspace = true }
+arrow = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/examples/integration/src/lib.rs
+++ b/examples/integration/src/lib.rs
@@ -41,6 +41,8 @@
 //! transfer encoding. It is deliberately small, and issue #117 proposes
 //! replacing it with `reqwest` if that dependency is ever approved.
 
+pub mod packed;
+
 use std::fmt;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};

--- a/examples/integration/src/packed.rs
+++ b/examples/integration/src/packed.rs
@@ -1,0 +1,292 @@
+//! A decoder for the packed export encoding, ported from the writer's own
+//! reader so a test can compare its values with the text encodings.
+//!
+//! The format is documented in `src/api/rest/binary.rs`. This is deliberately
+//! an INDEPENDENT reader rather than a call into the crate: the service keeps
+//! its decoder private, and a test that used the writer's own code to check
+//! the writer would prove less than one that reads the bytes the way a
+//! consumer must.
+//!
+//! Every payload in a packed document starts at an 8-byte aligned offset,
+//! because a browser reading one with `new Float64Array(buffer, offset, n)`
+//! throws otherwise. That is a correctness property, not a nicety, so this
+//! decoder records the offsets and [`PackedDocument::misaligned`] reports any
+//! that were not.
+
+/// The magic every packed document starts with.
+const MAGIC: &[u8; 4] = b"OCSP";
+
+/// The version this decoder understands.
+const VERSION: u32 = 1;
+
+/// The row count that marks the footer rather than a block.
+const FOOTER_SENTINEL: u32 = u32::MAX;
+
+/// Payload alignment, in bytes.
+const ALIGNMENT: usize = 8;
+
+/// A decoded packed document.
+#[derive(Debug)]
+pub struct PackedDocument {
+    /// Column names, in order.
+    pub columns: Vec<String>,
+    /// Rows, rendered as the text encodings render them.
+    pub rows: Vec<Vec<String>>,
+    /// The row count the footer declared.
+    pub declared_rows: u64,
+    /// Payload offsets that were not 8-byte aligned.
+    pub misaligned: Vec<usize>,
+}
+
+/// What a packed document can be wrong about.
+#[derive(Debug)]
+pub struct PackedError(pub String);
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl std::error::Error for PackedError {}
+
+/// The cell types the format carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellType {
+    F64,
+    I64,
+    Timestamp,
+    Dictionary,
+    LabelMask,
+}
+
+impl CellType {
+    /// Only `f64` columns carry a validity bitmap.
+    fn nullable(self) -> bool {
+        matches!(self, Self::F64)
+    }
+}
+
+/// Decodes one packed document.
+///
+/// # Errors
+///
+/// [`PackedError`] when the bytes are not a packed document this version
+/// understands, when they end early, or when the footer disagrees with the
+/// blocks — which is how a truncated download is detected.
+// `take!` advances the cursor on every use; the last advance in a document
+// that ends on its footer is genuinely never read again, which is what the
+// dead-store warning sees.
+#[allow(unused_assignments)]
+pub fn decode(bytes: &[u8]) -> Result<PackedDocument, PackedError> {
+    let mut cursor = 0_usize;
+    let mut misaligned = Vec::new();
+
+    let short = || PackedError("the packed document ended early".to_string());
+
+    // `cursor` is advanced by every one of these; the final assignment in a
+    // document that ends on a footer is genuinely unread, which is what the
+    // dead-store warning is about.
+    macro_rules! take {
+        ($count:expr) => {{
+            let end = cursor.checked_add($count).ok_or_else(short)?;
+            let slice = bytes.get(cursor..end).ok_or_else(short)?;
+            cursor = end;
+            slice
+        }};
+    }
+    macro_rules! take_u32 {
+        () => {{
+            let slice = take!(4);
+            let array: [u8; 4] = slice.try_into().map_err(|_| short())?;
+            u32::from_le_bytes(array)
+        }};
+    }
+    macro_rules! take_i64 {
+        () => {{
+            let slice = take!(8);
+            let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+            i64::from_le_bytes(array)
+        }};
+    }
+    macro_rules! align {
+        () => {{
+            let remainder = cursor % ALIGNMENT;
+            if remainder != 0 {
+                cursor += ALIGNMENT - remainder;
+            }
+        }};
+    }
+
+    if take!(4) != MAGIC {
+        return Err(PackedError("not a packed document".to_string()));
+    }
+    let version = take_u32!();
+    if version != VERSION {
+        return Err(PackedError(format!("unknown packed version {version}")));
+    }
+    let _block_rows = take_u32!();
+
+    let dictionary_len = take_u32!() as usize;
+    let mut dictionary = Vec::with_capacity(dictionary_len);
+    for _ in 0..dictionary_len {
+        let len = take_u32!() as usize;
+        let raw = take!(len);
+        dictionary.push(
+            String::from_utf8(raw.to_vec())
+                .map_err(|_| PackedError("a dictionary entry is not UTF-8".to_string()))?,
+        );
+    }
+
+    let column_count = take_u32!() as usize;
+    let mut columns = Vec::with_capacity(column_count);
+    let mut types = Vec::with_capacity(column_count);
+    for _ in 0..column_count {
+        let len = take_u32!() as usize;
+        let raw = take!(len);
+        columns.push(
+            String::from_utf8(raw.to_vec())
+                .map_err(|_| PackedError("a column name is not UTF-8".to_string()))?,
+        );
+        let code = *take!(1).first().ok_or_else(short)?;
+        let _nullable = *take!(1).first().ok_or_else(short)?;
+        types.push(match code {
+            0 => CellType::F64,
+            1 => CellType::I64,
+            2 => CellType::Timestamp,
+            3 => CellType::Dictionary,
+            4 => CellType::LabelMask,
+            other => return Err(PackedError(format!("unknown type code {other}"))),
+        });
+        // A column descriptor is padded to four, not eight.
+        let remainder = cursor % 4;
+        if remainder != 0 {
+            cursor += 4 - remainder;
+        }
+    }
+    align!();
+
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut declared_rows = None;
+
+    while cursor < bytes.len() {
+        let marker = take_u32!();
+        if marker == FOOTER_SENTINEL {
+            align!();
+            let declared = take_i64!();
+            if declared < 0 {
+                return Err(PackedError(format!("the footer declares {declared} rows")));
+            }
+            declared_rows = Some(declared as u64);
+            break;
+        }
+
+        let row_count = marker as usize;
+        align!();
+
+        let mut block: Vec<Vec<String>> = vec![Vec::with_capacity(column_count); row_count];
+        for cell_type in &types {
+            let mut validity = vec![true; row_count];
+            if cell_type.nullable() {
+                let bitmap_len = row_count.div_ceil(8);
+                let bitmap = take!(bitmap_len).to_vec();
+                for (position, valid) in validity.iter_mut().enumerate() {
+                    let byte = bitmap.get(position / 8).copied().unwrap_or(0);
+                    *valid = byte & (1 << (position % 8)) != 0;
+                }
+                align!();
+            }
+
+            // Every payload must start aligned; that is what makes a
+            // zero-copy typed-array view possible on the other side.
+            if !cursor.is_multiple_of(ALIGNMENT) {
+                misaligned.push(cursor);
+            }
+
+            for (position, row) in block.iter_mut().enumerate() {
+                let rendered = match cell_type {
+                    CellType::F64 => {
+                        let slice = take!(8);
+                        let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+                        if validity.get(position).copied().unwrap_or(false) {
+                            f64::from_le_bytes(array).to_string()
+                        } else {
+                            String::new()
+                        }
+                    }
+                    CellType::I64 => take_i64!().to_string(),
+                    CellType::Timestamp => render_timestamp(take_i64!()),
+                    CellType::Dictionary => {
+                        let index = take_u32!() as usize;
+                        dictionary.get(index).cloned().unwrap_or_default()
+                    }
+                    CellType::LabelMask => {
+                        let slice = take!(8);
+                        let array: [u8; 8] = slice.try_into().map_err(|_| short())?;
+                        labels_of(&dictionary, u64::from_le_bytes(array)).join("|")
+                    }
+                };
+                row.push(rendered);
+            }
+            align!();
+        }
+        rows.extend(block);
+    }
+
+    let declared_rows = declared_rows.ok_or_else(|| {
+        PackedError("the packed document has no footer; the download was truncated".to_string())
+    })?;
+    if declared_rows as usize != rows.len() {
+        return Err(PackedError(format!(
+            "the footer declares {declared_rows} rows, the blocks carried {}",
+            rows.len()
+        )));
+    }
+
+    Ok(PackedDocument {
+        columns,
+        rows,
+        declared_rows,
+        misaligned,
+    })
+}
+
+/// Renders a nanosecond timestamp the way the text encodings render one.
+fn render_timestamp(nanos: i64) -> String {
+    let seconds = nanos.div_euclid(1_000_000_000);
+    let days = seconds.div_euclid(86_400);
+    let time = seconds.rem_euclid(86_400);
+
+    // Days since the Unix epoch to a civil date, the standard algorithm.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}Z",
+        time / 3_600,
+        (time % 3_600) / 60,
+        time % 60
+    )
+}
+
+/// The labels a mask names.
+///
+/// Entry zero of the dictionary is the symbol, so the mask's bit `i` names
+/// entry `i + 1`.
+fn labels_of(dictionary: &[String], mask: u64) -> Vec<String> {
+    let mut labels = Vec::new();
+    for (position, label) in dictionary.iter().skip(1).enumerate() {
+        if position < 64 && mask & (1 << position) != 0 {
+            labels.push(label.clone());
+        }
+    }
+    labels
+}

--- a/examples/integration/tests/exports.rs
+++ b/examples/integration/tests/exports.rs
@@ -1,0 +1,515 @@
+//! The export matrix: every dataset in every format the deployment offers.
+//!
+//! The export is what a backtester actually consumes and it has the widest
+//! surface in the service: three datasets, up to four encodings, a step range
+//! and three greek levels. It also STREAMS, so its failure modes are the ones
+//! that only appear over a socket, truncation first among them.
+//!
+//! Formats are probed rather than assumed. A deployment built without the
+//! `arrow-export` feature refuses `arrow`, and an older one may not know
+//! `packed` at all; both are facts to report, not failures. What the suite
+//! guarantees is that everything the deployment DOES offer agrees with
+//! everything else it offers.
+//!
+//! Exports are kept small, three steps over a two-strike chain, because these
+//! run against a shared deployment and an export is the most expensive thing
+//! it does.
+//!
+//! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
+
+use examples_integration::{Response, ServiceClient, reference_request, service};
+
+/// Steps in every exported tape.
+const STEPS: usize = 3;
+
+/// The datasets the export offers.
+const DATASETS: [&str; 3] = ["underlying", "volatility", "option_chains"];
+
+/// A simulation walked to the end, so its tape is complete, that deletes
+/// itself afterwards.
+struct Exported {
+    client: ServiceClient,
+    id: String,
+}
+
+impl Exported {
+    /// Creates a simulation and walks it to exhaustion.
+    fn create(client: &ServiceClient) -> Option<Self> {
+        let mut request = reference_request("SPX");
+        if let Some(object) = request.as_object_mut() {
+            object.insert("steps".to_string(), serde_json::json!(STEPS));
+            object.insert("chain_size".to_string(), serde_json::json!(2));
+        }
+
+        let response = match client.post("/api/v2/simulations", &request) {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        if response.status == 404 {
+            println!("SKIP: this deployment has no v2 API");
+            return None;
+        }
+        assert_eq!(
+            response.status,
+            201,
+            "creating a simulation must answer 201, got {}",
+            response.text()
+        );
+
+        let body: serde_json::Value = match response.json("/api/v2/simulations") {
+            Ok(body) => body,
+            Err(error) => panic!("{error}"),
+        };
+        let id = match body.get("id").and_then(serde_json::Value::as_str) {
+            Some(id) => id.to_string(),
+            None => panic!("a created simulation must carry an id: {body}"),
+        };
+
+        let exported = Self {
+            client: client.clone(),
+            id,
+        };
+        for step in 0..STEPS {
+            let path = format!("/api/v2/simulations/{}/step", exported.id);
+            match client.request("POST", &path, None) {
+                Ok(response) => assert_eq!(
+                    response.status,
+                    200,
+                    "step {step} must serve before the tape can be exported: {}",
+                    response.text()
+                ),
+                Err(error) => panic!("{error}"),
+            }
+        }
+        Some(exported)
+    }
+
+    /// One export, with whatever query the case needs.
+    fn export(&self, query: &str) -> Response {
+        let path = format!("/api/v2/simulations/{}/export?{query}", self.id);
+        match self.client.get(&path) {
+            Ok(response) => response,
+            Err(error) => panic!("exporting {query}: {error}"),
+        }
+    }
+}
+
+impl Drop for Exported {
+    fn drop(&mut self) {
+        let path = format!("/api/v2/simulations/{}", self.id);
+        if let Err(error) = self.client.delete(&path) {
+            println!("WARNING: could not delete simulation {}: {error}", self.id);
+        }
+    }
+}
+
+/// Which formats this deployment actually serves, probed once.
+///
+/// `json` and `csv` are the baseline every build has; `arrow` needs a feature
+/// that is off by default and `packed` postdates some deployments, so a 400 or
+/// a 404 for those means "not offered here" and is reported rather than failed.
+fn offered_formats(exported: &Exported) -> Vec<&'static str> {
+    let mut offered = Vec::new();
+    for format in ["json", "csv", "arrow", "packed"] {
+        let response = exported.export(&format!("dataset=underlying&format={format}"));
+        match response.status {
+            200 => offered.push(format),
+            400 | 404 | 415 => println!(
+                "SKIP: this deployment does not offer the {format} encoding ({})",
+                response.status
+            ),
+            other => panic!(
+                "probing the {format} encoding answered {other}: {}",
+                response.text()
+            ),
+        }
+    }
+    assert!(
+        offered.contains(&"json") && offered.contains(&"csv"),
+        "every build serves json and csv; this one offered {offered:?}"
+    );
+    offered
+}
+
+/// The rows of a CSV export, header first.
+fn csv_rows(body: &str) -> Vec<Vec<String>> {
+    body.split("\r\n")
+        .filter(|line| !line.is_empty())
+        .map(|line| line.split(',').map(str::to_string).collect())
+        .collect()
+}
+
+/// The rows of a JSON export, as objects.
+fn json_rows(body: &[u8], what: &str) -> Vec<serde_json::Map<String, serde_json::Value>> {
+    match serde_json::from_slice::<serde_json::Value>(body) {
+        Ok(serde_json::Value::Array(rows)) => rows
+            .into_iter()
+            .map(|row| match row {
+                serde_json::Value::Object(object) => object,
+                other => panic!("{what}: every json row must be an object, got {other}"),
+            })
+            .collect(),
+        Ok(other) => panic!("{what}: a json export must be a single array, got {other}"),
+        Err(error) => panic!("{what}: a json export must parse: {error}"),
+    }
+}
+
+/// The row count a packed document declares in its footer.
+///
+/// The footer is what makes a truncated download detectable, so reading it is
+/// exactly the check a consumer must perform.
+fn packed_rows(body: &[u8], what: &str) -> u64 {
+    assert!(
+        body.len() >= 16,
+        "{what}: a packed document is at least a header and a footer, got {} bytes",
+        body.len()
+    );
+    assert_eq!(
+        &body[..4],
+        b"OCSP",
+        "{what}: a packed document starts with its magic"
+    );
+
+    // footer := u32:0xFFFFFFFF pad to 8 u64:total_rows, so the sentinel sits
+    // 16 bytes from the end and the count in the last 8.
+    let sentinel = &body[body.len() - 16..body.len() - 12];
+    assert_eq!(
+        sentinel,
+        &u32::MAX.to_le_bytes(),
+        "{what}: the footer sentinel is missing, so the download was truncated"
+    );
+
+    let mut count = [0_u8; 8];
+    count.copy_from_slice(&body[body.len() - 8..]);
+    u64::from_le_bytes(count)
+}
+
+/// Every dataset, in every offered format, carries the same rows.
+#[test]
+fn test_every_dataset_agrees_across_every_offered_format() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+    let formats = offered_formats(&exported);
+
+    for dataset in DATASETS {
+        let json = exported.export(&format!("dataset={dataset}&format=json"));
+        assert_eq!(json.status, 200, "{dataset} as json: {}", json.text());
+        let json_rows = json_rows(&json.body, dataset);
+        assert!(
+            !json_rows.is_empty(),
+            "{dataset} must export at least one row for a walked tape"
+        );
+
+        let csv = exported.export(&format!("dataset={dataset}&format=csv"));
+        assert_eq!(csv.status, 200, "{dataset} as csv: {}", csv.text());
+        let text = csv.text();
+        assert!(
+            text.contains("\r\n"),
+            "{dataset} as csv must use RFC 4180 CRLF endings"
+        );
+        let rows = csv_rows(&text);
+        let (header, data) = match rows.split_first() {
+            Some((header, data)) => (header, data),
+            None => panic!("{dataset} as csv must carry a header"),
+        };
+        assert_eq!(
+            data.len(),
+            json_rows.len(),
+            "{dataset} exports {} rows as csv and {} as json",
+            data.len(),
+            json_rows.len()
+        );
+
+        // Compared as parsed values rather than as text: the rendering of a
+        // number is not the contract, the number is.
+        for (index, (csv_row, json_row)) in data.iter().zip(&json_rows).enumerate() {
+            for (column, value) in header.iter().zip(csv_row) {
+                let Some(from_json) = json_row.get(column) else {
+                    continue;
+                };
+                let matches = match from_json {
+                    serde_json::Value::Number(number) => value.parse::<f64>().is_ok_and(|parsed| {
+                        (parsed - number.as_f64().unwrap_or(f64::NAN)).abs() < 1e-9
+                    }),
+                    serde_json::Value::String(text) => text == value,
+                    serde_json::Value::Null => value.is_empty(),
+                    // Anything else, a bool say, renders the same way in both
+                    // encodings, so its text is the comparison.
+                    other => serde_json::to_string(other)
+                        .is_ok_and(|rendered| rendered.trim_matches('"') == value),
+                };
+                assert!(
+                    matches,
+                    "{dataset} row {index} column {column} is {value:?} as csv and {from_json} \
+                     as json"
+                );
+            }
+        }
+
+        if formats.contains(&"packed") {
+            let packed = exported.export(&format!("dataset={dataset}&format=packed"));
+            assert_eq!(packed.status, 200, "{dataset} as packed: {}", packed.text());
+            let declared = packed_rows(&packed.body, dataset);
+            assert_eq!(
+                declared as usize,
+                json_rows.len(),
+                "{dataset} declares {declared} rows in its packed footer and exports {} as json",
+                json_rows.len()
+            );
+        }
+
+        if formats.contains(&"arrow") {
+            let arrow = exported.export(&format!("dataset={dataset}&format=arrow"));
+            assert_eq!(arrow.status, 200, "{dataset} as arrow: {}", arrow.text());
+            assert!(
+                !arrow.body.is_empty(),
+                "{dataset} as arrow must carry a stream"
+            );
+        }
+    }
+}
+
+/// The same export twice is byte-identical, which is the endpoint's stated
+/// contract and what lets a consumer cache or checksum one.
+#[test]
+fn test_the_same_export_twice_is_byte_identical() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+    let formats = offered_formats(&exported);
+
+    for dataset in DATASETS {
+        for format in &formats {
+            let query = format!("dataset={dataset}&format={format}");
+            let first = exported.export(&query);
+            let second = exported.export(&query);
+            assert_eq!(first.status, 200);
+            assert_eq!(second.status, 200);
+            assert_eq!(
+                first.body, second.body,
+                "{dataset} as {format} differs between two identical exports"
+            );
+        }
+    }
+}
+
+/// A range selects the same rows in every format, and a bad one is a typed
+/// rejection in every format rather than an empty document.
+#[test]
+fn test_a_range_selects_the_same_rows_in_every_format() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+    let formats = offered_formats(&exported);
+
+    let ranged = "dataset=underlying&from_step=1&to_step=2";
+    let json = exported.export(&format!("{ranged}&format=json"));
+    assert_eq!(json.status, 200, "{}", json.text());
+    let expected = json_rows(&json.body, "underlying").len();
+    assert!(
+        expected > 0 && expected <= STEPS,
+        "a range of two steps must select between one and {STEPS} rows, got {expected}"
+    );
+
+    let csv = exported.export(&format!("{ranged}&format=csv"));
+    assert_eq!(
+        csv_rows(&csv.text()).len() - 1,
+        expected,
+        "the same range must select the same rows as csv and as json"
+    );
+
+    if formats.contains(&"packed") {
+        let packed = exported.export(&format!("{ranged}&format=packed"));
+        assert_eq!(
+            packed_rows(&packed.body, "a ranged underlying export") as usize,
+            expected,
+            "the same range must select the same rows as packed and as json"
+        );
+    }
+
+    // And a bad range is a rejection in EVERY format, never an empty document
+    // that a consumer would read as "no data".
+    for format in &formats {
+        let response = exported.export(&format!(
+            "dataset=underlying&format={format}&from_step=2&to_step=1"
+        ));
+        assert_eq!(
+            response.status,
+            400,
+            "an inverted range must be refused as {format}, got {} with {}",
+            response.status,
+            response.text()
+        );
+        let content_type = response.header("content-type").unwrap_or_default();
+        assert!(
+            content_type.contains("application/json"),
+            "a rejection is JSON whatever format was asked for, got {content_type:?}"
+        );
+    }
+}
+
+/// Each greek level's header is a PREFIX of the next, so a consumer written
+/// against `none` keeps reading the same columns in the same places when a
+/// richer level is requested.
+#[test]
+fn test_each_greek_level_extends_the_previous_one() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+
+    let header_for = |level: &str| -> Option<Vec<String>> {
+        let response = exported.export(&format!("dataset=option_chains&format=csv&greeks={level}"));
+        if response.status == 400 {
+            println!("SKIP: this deployment does not know the {level} greek level");
+            return None;
+        }
+        assert_eq!(
+            response.status,
+            200,
+            "the {level} greek level must export, got {}",
+            response.text()
+        );
+        csv_rows(&response.text()).first().cloned()
+    };
+
+    let (Some(none), Some(first), Some(all)) =
+        (header_for("none"), header_for("first"), header_for("all"))
+    else {
+        return;
+    };
+
+    assert!(
+        first.starts_with(&none),
+        "the first-order header must extend the none header, {none:?} then {first:?}"
+    );
+    assert!(
+        all.starts_with(&first),
+        "the all header must extend the first-order header, {first:?} then {all:?}"
+    );
+    assert!(
+        all.len() > none.len(),
+        "asking for greeks must actually add columns"
+    );
+}
+
+/// A streamed export is complete: the last row of the tape is present, and it
+/// carries every column the header declared.
+///
+/// Truncation is the failure mode a socket introduces and an in-process test
+/// cannot see.
+#[test]
+fn test_a_streamed_export_is_not_truncated() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+
+    let response = exported.export("dataset=option_chains&format=csv&greeks=all");
+    assert_eq!(response.status, 200, "{}", response.text());
+    let text = response.text();
+    let rows = csv_rows(&text);
+    let (header, data) = match rows.split_first() {
+        Some((header, data)) => (header, data),
+        None => panic!("a csv export must carry a header"),
+    };
+
+    assert!(!data.is_empty(), "a walked tape must export rows");
+    assert!(
+        text.ends_with("\r\n"),
+        "a complete csv export ends with a line terminator, so a cut stream is visible"
+    );
+
+    let last = match data.last() {
+        Some(last) => last,
+        None => unreachable!("data was checked non-empty"),
+    };
+    assert_eq!(
+        last.len(),
+        header.len(),
+        "the last row must carry every column the header declares, which is what a truncated \
+         stream loses first"
+    );
+
+    // The last row belongs to the last step, so nothing at the end went
+    // missing.
+    let step_column = header.iter().position(|column| column == "step");
+    if let Some(index) = step_column {
+        let last_step: usize = match last.get(index).and_then(|value| value.parse().ok()) {
+            Some(step) => step,
+            None => panic!("the step column must carry a number, row was {last:?}"),
+        };
+        assert_eq!(
+            last_step,
+            STEPS - 1,
+            "the export must reach the last step of the tape"
+        );
+    }
+}
+
+/// The content type and the suggested filename match the format asked for.
+#[test]
+fn test_the_content_type_and_filename_match_the_format() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+    let formats = offered_formats(&exported);
+
+    for format in &formats {
+        let response = exported.export(&format!("dataset=underlying&format={format}"));
+        assert_eq!(response.status, 200);
+
+        let content_type = response
+            .header("content-type")
+            .unwrap_or_default()
+            .to_string();
+        let expected_type = match *format {
+            "json" => "application/json",
+            "csv" => "text/csv",
+            // Arrow has a registered media type of its own; only the packed
+            // format falls back to plain octets.
+            "arrow" => "application/vnd.apache.arrow.stream",
+            _ => "application/octet-stream",
+        };
+        assert!(
+            content_type.contains(expected_type),
+            "{format} must be served as {expected_type}, got {content_type:?}"
+        );
+
+        let disposition = response
+            .header("content-disposition")
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            disposition.contains("attachment") && disposition.contains(&exported.id),
+            "{format} must suggest a filename naming the simulation, got {disposition:?}"
+        );
+        let expected_extension = match *format {
+            "json" => ".json",
+            "csv" => ".csv",
+            "arrow" => ".arrow",
+            _ => ".ocsp",
+        };
+        assert!(
+            disposition.contains(expected_extension),
+            "{format} must suggest a {expected_extension} file, got {disposition:?}"
+        );
+    }
+}

--- a/examples/integration/tests/exports.rs
+++ b/examples/integration/tests/exports.rs
@@ -1,15 +1,14 @@
-//! The export matrix: every dataset in every format the deployment offers.
+//! The export matrix: every dataset in every format the deployment ADVERTISES.
 //!
-//! The export is what a backtester actually consumes and it has the widest
-//! surface in the service: three datasets, up to four encodings, a step range
-//! and three greek levels. It also STREAMS, so its failure modes are the ones
-//! that only appear over a socket, truncation first among them.
+//! The export is what a backtester consumes and it has the widest surface in
+//! the service: three datasets, four encodings, a range and three greek
+//! levels. It also streams, so its failure modes are the ones that only appear
+//! over a socket.
 //!
-//! Formats are probed rather than assumed. A deployment built without the
-//! `arrow-export` feature refuses `arrow`, and an older one may not know
-//! `packed` at all; both are facts to report, not failures. What the suite
-//! guarantees is that everything the deployment DOES offer agrees with
-//! everything else it offers.
+//! Which formats are exercised comes from the deployment's own OpenAPI
+//! document rather than from probing and shrugging: a format the document
+//! advertises must work, or refuse with the typed error that says this build
+//! was compiled without it. Anything else is a regression, not a skip.
 //!
 //! Exports are kept small, three steps over a two-strike chain, because these
 //! run against a shared deployment and an export is the most expensive thing
@@ -17,7 +16,7 @@
 //!
 //! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
 
-use examples_integration::{Response, ServiceClient, reference_request, service};
+use examples_integration::{Response, ServiceClient, packed, reference_request, service};
 
 /// Steps in every exported tape.
 const STEPS: usize = 3;
@@ -46,7 +45,7 @@ impl Exported {
             Err(error) => panic!("{error}"),
         };
         if response.status == 404 {
-            println!("SKIP: this deployment has no v2 API");
+            println!("SKIP: this deployment does not serve /api/v2/simulations");
             return None;
         }
         assert_eq!(
@@ -97,94 +96,295 @@ impl Exported {
 impl Drop for Exported {
     fn drop(&mut self) {
         let path = format!("/api/v2/simulations/{}", self.id);
-        if let Err(error) = self.client.delete(&path) {
-            println!("WARNING: could not delete simulation {}: {error}", self.id);
-        }
+        examples_integration::report_cleanup(&self.client, &path, &self.id);
     }
 }
 
-/// Which formats this deployment actually serves, probed once.
+/// The formats the deployment's OpenAPI document advertises, and for each,
+/// whether this build actually serves it.
+struct Offered {
+    /// Advertised and serving.
+    usable: Vec<String>,
+    /// Advertised but compiled out, with the reason the service gave.
+    absent: Vec<(String, String)>,
+}
+
+/// Reads the advertised formats from the deployment's own document, then
+/// establishes which of them this build serves.
 ///
-/// `json` and `csv` are the baseline every build has; `arrow` needs a feature
-/// that is off by default and `packed` postdates some deployments, so a 400 or
-/// a 404 for those means "not offered here" and is reported rather than failed.
-fn offered_formats(exported: &Exported) -> Vec<&'static str> {
-    let mut offered = Vec::new();
-    for format in ["json", "csv", "arrow", "packed"] {
+/// A format the document advertises may only be missing for one reason: the
+/// build was compiled without it, which the service says in a typed 400 naming
+/// `format`. Any other refusal is a regression, and a silent skip would hide
+/// it.
+fn offered_formats(client: &ServiceClient, exported: &Exported) -> Offered {
+    let document: serde_json::Value = match client.get("/api-docs/openapi.json") {
+        Ok(response) if response.status == 200 => match response.json("/api-docs/openapi.json") {
+            Ok(document) => document,
+            Err(error) => panic!("{error}"),
+        },
+        Ok(response) => panic!(
+            "the deployment must serve an OpenAPI document to drive this test, got {}",
+            response.status
+        ),
+        Err(error) => panic!("{error}"),
+    };
+
+    let description = document
+        .pointer("/paths/~1api~1v2~1simulations~1{id}~1export/get/parameters")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|parameters| {
+            parameters.iter().find(|parameter| {
+                parameter.get("name").and_then(|name| name.as_str()) == Some("format")
+            })
+        })
+        .and_then(|parameter| parameter.get("description"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("the document must describe the export format parameter"));
+
+    // The description opens with the alternatives, "json | csv | arrow |
+    // packed", which is the contract this suite has to hold the deployment to.
+    let advertised: Vec<String> = description
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .split('|')
+        .map(|format| format.trim().to_string())
+        .filter(|format| !format.is_empty() && format.chars().all(|c| c.is_ascii_lowercase()))
+        .collect();
+    assert!(
+        advertised.contains(&"json".to_string()) && advertised.contains(&"csv".to_string()),
+        "the document must advertise at least json and csv, it advertises {advertised:?}"
+    );
+
+    let mut usable = Vec::new();
+    let mut absent = Vec::new();
+    for format in advertised {
         let response = exported.export(&format!("dataset=underlying&format={format}"));
         match response.status {
-            200 => offered.push(format),
-            400 | 404 | 415 => println!(
-                "SKIP: this deployment does not offer the {format} encoding ({})",
-                response.status
-            ),
+            200 => usable.push(format),
+            400 => {
+                let body: serde_json::Value = match response.json("/export") {
+                    Ok(body) => body,
+                    Err(error) => panic!("a refusal must be the documented shape: {error}"),
+                };
+                let message = body
+                    .get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                assert_eq!(
+                    body.get("field").and_then(serde_json::Value::as_str),
+                    Some("format"),
+                    "a refused format must name the format field: {body}"
+                );
+                assert!(
+                    message.contains("unavailable") || message.contains("feature"),
+                    "{format} is advertised, so the only acceptable refusal is one saying this \
+                     build was compiled without it; the service said {message:?}"
+                );
+                absent.push((format, message));
+            }
             other => panic!(
-                "probing the {format} encoding answered {other}: {}",
+                "{format} is advertised and answered {other}: {}",
                 response.text()
             ),
         }
     }
-    assert!(
-        offered.contains(&"json") && offered.contains(&"csv"),
-        "every build serves json and csv; this one offered {offered:?}"
-    );
-    offered
+
+    for (format, reason) in &absent {
+        println!("INFO: {format} is advertised but not built here: {reason}");
+    }
+    Offered { usable, absent }
 }
 
-/// The rows of a CSV export, header first.
-fn csv_rows(body: &str) -> Vec<Vec<String>> {
-    body.split("\r\n")
-        .filter(|line| !line.is_empty())
-        .map(|line| line.split(',').map(str::to_string).collect())
-        .collect()
+/// Parses an RFC 4180 document: CRLF-separated records, commas between
+/// fields, double quotes around a field that contains either, and a doubled
+/// quote for a literal one.
+fn parse_csv(body: &str, what: &str) -> Vec<Vec<String>> {
+    let mut records = Vec::new();
+    let mut record = Vec::new();
+    let mut field = String::new();
+    let mut quoted = false;
+    let mut characters = body.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        match (quoted, character) {
+            (true, '"') => {
+                if characters.peek() == Some(&'"') {
+                    characters.next();
+                    field.push('"');
+                } else {
+                    quoted = false;
+                }
+            }
+            (true, other) => field.push(other),
+            (false, '"') => quoted = true,
+            (false, ',') => record.push(std::mem::take(&mut field)),
+            (false, '\r') => {
+                if characters.peek() == Some(&'\n') {
+                    characters.next();
+                }
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            (false, '\n') => {
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            (false, other) => field.push(other),
+        }
+    }
+    assert!(!quoted, "{what}: the csv ends inside a quoted field");
+    if !field.is_empty() || !record.is_empty() {
+        record.push(field);
+        records.push(record);
+    }
+    records
 }
 
-/// The rows of a JSON export, as objects.
-fn json_rows(body: &[u8], what: &str) -> Vec<serde_json::Map<String, serde_json::Value>> {
-    match serde_json::from_slice::<serde_json::Value>(body) {
-        Ok(serde_json::Value::Array(rows)) => rows
-            .into_iter()
-            .map(|row| match row {
-                serde_json::Value::Object(object) => object,
-                other => panic!("{what}: every json row must be an object, got {other}"),
-            })
-            .collect(),
-        Ok(other) => panic!("{what}: a json export must be a single array, got {other}"),
-        Err(error) => panic!("{what}: a json export must parse: {error}"),
+/// The header and the data rows of a CSV export, with every row required to
+/// carry exactly as many fields as the header declares.
+fn csv_table(body: &str, what: &str) -> (Vec<String>, Vec<Vec<String>>) {
+    let records = parse_csv(body, what);
+    let (header, rows) = match records.split_first() {
+        Some((header, rows)) => (header.clone(), rows.to_vec()),
+        None => panic!("{what}: a csv export must carry a header"),
+    };
+    for (index, row) in rows.iter().enumerate() {
+        assert_eq!(
+            row.len(),
+            header.len(),
+            "{what}: row {index} carries {} fields where the header declares {}: {row:?}",
+            row.len(),
+            header.len()
+        );
+    }
+    (header, rows)
+}
+
+/// Two rendered values are the same value.
+///
+/// Compared numerically when both parse as numbers, because `5000` and
+/// `5000.0` are the same price rendered by two encodings, and textually
+/// otherwise.
+fn same_value(left: &str, right: &str) -> bool {
+    match (left.parse::<f64>(), right.parse::<f64>()) {
+        (Ok(left), Ok(right)) => (left - right).abs() <= 1e-9 * left.abs().max(1.0),
+        _ => left == right,
     }
 }
 
-/// The row count a packed document declares in its footer.
-///
-/// The footer is what makes a truncated download detectable, so reading it is
-/// exactly the check a consumer must perform.
-fn packed_rows(body: &[u8], what: &str) -> u64 {
-    assert!(
-        body.len() >= 16,
-        "{what}: a packed document is at least a header and a footer, got {} bytes",
-        body.len()
+/// Compares a decoded table with the CSV one, column by column and row by row.
+fn assert_same_table(
+    what: &str,
+    csv_header: &[String],
+    csv_rows: &[Vec<String>],
+    header: &[String],
+    rows: &[Vec<String>],
+) {
+    assert_eq!(
+        header, csv_header,
+        "{what}: the columns differ from the csv ones"
     );
     assert_eq!(
-        &body[..4],
-        b"OCSP",
-        "{what}: a packed document starts with its magic"
+        rows.len(),
+        csv_rows.len(),
+        "{what}: {} rows against {} as csv",
+        rows.len(),
+        csv_rows.len()
     );
-
-    // footer := u32:0xFFFFFFFF pad to 8 u64:total_rows, so the sentinel sits
-    // 16 bytes from the end and the count in the last 8.
-    let sentinel = &body[body.len() - 16..body.len() - 12];
-    assert_eq!(
-        sentinel,
-        &u32::MAX.to_le_bytes(),
-        "{what}: the footer sentinel is missing, so the download was truncated"
-    );
-
-    let mut count = [0_u8; 8];
-    count.copy_from_slice(&body[body.len() - 8..]);
-    u64::from_le_bytes(count)
+    for (index, (row, csv_row)) in rows.iter().zip(csv_rows).enumerate() {
+        assert_eq!(
+            row.len(),
+            csv_row.len(),
+            "{what}: row {index} has {} values against {} as csv",
+            row.len(),
+            csv_row.len()
+        );
+        for (column, (value, csv_value)) in row.iter().zip(csv_row).enumerate() {
+            assert!(
+                same_value(value, csv_value),
+                "{what}: row {index} column {} is {value:?} and {csv_value:?} as csv",
+                csv_header.get(column).map_or("?", String::as_str)
+            );
+        }
+    }
 }
 
-/// Every dataset, in every offered format, carries the same rows.
+/// Decodes an Arrow IPC stream into the same shape, when this test was built
+/// with the feature that can.
+#[cfg(feature = "arrow-export")]
+fn arrow_table(bytes: &[u8], what: &str) -> (Vec<String>, Vec<Vec<String>>) {
+    use arrow::ipc::reader::StreamReader;
+
+    let reader = match StreamReader::try_new(std::io::Cursor::new(bytes.to_vec()), None) {
+        Ok(reader) => reader,
+        Err(error) => panic!("{what}: an arrow export must be a readable stream: {error}"),
+    };
+
+    let mut header: Vec<String> = Vec::new();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for batch in reader {
+        let batch = match batch {
+            Ok(batch) => batch,
+            Err(error) => panic!("{what}: an arrow batch must decode: {error}"),
+        };
+        if header.is_empty() {
+            header = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().to_string())
+                .collect();
+        }
+        for index in 0..batch.num_rows() {
+            let mut row = Vec::with_capacity(batch.num_columns());
+            for column in batch.columns() {
+                row.push(arrow_cell(column.as_ref(), index));
+            }
+            rows.push(row);
+        }
+    }
+    (header, rows)
+}
+
+/// Renders one Arrow cell the way the text encodings render it.
+#[cfg(feature = "arrow-export")]
+fn arrow_cell(column: &dyn arrow::array::Array, index: usize) -> String {
+    use arrow::array::{Float64Array, Int64Array, StringArray, TimestampNanosecondArray};
+    use arrow::datatypes::DataType;
+
+    if column.is_null(index) {
+        return String::new();
+    }
+    match column.data_type() {
+        DataType::Float64 => column
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .map(|values| values.value(index).to_string())
+            .unwrap_or_default(),
+        DataType::Int64 => column
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .map(|values| values.value(index).to_string())
+            .unwrap_or_default(),
+        DataType::Utf8 => column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .map(|values| values.value(index).to_string())
+            .unwrap_or_default(),
+        DataType::Timestamp(_, _) => column
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .and_then(|values| values.value_as_datetime(index))
+            .map(|value| format!("{}Z", value.format("%Y-%m-%dT%H:%M:%S")))
+            .unwrap_or_default(),
+        other => panic!("an arrow export carries an unexpected column type {other}"),
+    }
+}
+
+/// Every dataset carries the same rows and the same values in every format the
+/// deployment advertises and serves.
 #[test]
 fn test_every_dataset_agrees_across_every_offered_format() {
     let Some(client) = service() else {
@@ -193,17 +393,9 @@ fn test_every_dataset_agrees_across_every_offered_format() {
     let Some(exported) = Exported::create(&client) else {
         return;
     };
-    let formats = offered_formats(&exported);
+    let offered = offered_formats(&client, &exported);
 
     for dataset in DATASETS {
-        let json = exported.export(&format!("dataset={dataset}&format=json"));
-        assert_eq!(json.status, 200, "{dataset} as json: {}", json.text());
-        let json_rows = json_rows(&json.body, dataset);
-        assert!(
-            !json_rows.is_empty(),
-            "{dataset} must export at least one row for a walked tape"
-        );
-
         let csv = exported.export(&format!("dataset={dataset}&format=csv"));
         assert_eq!(csv.status, 200, "{dataset} as csv: {}", csv.text());
         let text = csv.text();
@@ -211,70 +403,116 @@ fn test_every_dataset_agrees_across_every_offered_format() {
             text.contains("\r\n"),
             "{dataset} as csv must use RFC 4180 CRLF endings"
         );
-        let rows = csv_rows(&text);
-        let (header, data) = match rows.split_first() {
-            Some((header, data)) => (header, data),
-            None => panic!("{dataset} as csv must carry a header"),
-        };
-        assert_eq!(
-            data.len(),
-            json_rows.len(),
-            "{dataset} exports {} rows as csv and {} as json",
-            data.len(),
-            json_rows.len()
+        let (csv_header, csv_rows) = csv_table(&text, dataset);
+        assert!(
+            !csv_rows.is_empty(),
+            "{dataset} must export rows for a walked tape"
         );
 
-        // Compared as parsed values rather than as text: the rendering of a
-        // number is not the contract, the number is.
-        for (index, (csv_row, json_row)) in data.iter().zip(&json_rows).enumerate() {
-            for (column, value) in header.iter().zip(csv_row) {
-                let Some(from_json) = json_row.get(column) else {
-                    continue;
-                };
-                let matches = match from_json {
-                    serde_json::Value::Number(number) => value.parse::<f64>().is_ok_and(|parsed| {
-                        (parsed - number.as_f64().unwrap_or(f64::NAN)).abs() < 1e-9
-                    }),
-                    serde_json::Value::String(text) => text == value,
-                    serde_json::Value::Null => value.is_empty(),
-                    // Anything else, a bool say, renders the same way in both
-                    // encodings, so its text is the comparison.
-                    other => serde_json::to_string(other)
-                        .is_ok_and(|rendered| rendered.trim_matches('"') == value),
+        // json: the same keys as the csv header, on every row, and the same
+        // values. A row with a missing key fails rather than being skipped.
+        let json = exported.export(&format!("dataset={dataset}&format=json"));
+        assert_eq!(json.status, 200, "{dataset} as json: {}", json.text());
+        let rows: Vec<serde_json::Map<String, serde_json::Value>> =
+            match json.json(&format!("{dataset} as json")) {
+                Ok(rows) => rows,
+                Err(error) => panic!("a json export must be an array of objects: {error}"),
+            };
+        assert_eq!(
+            rows.len(),
+            csv_rows.len(),
+            "{dataset} exports {} rows as json against {} as csv",
+            rows.len(),
+            csv_rows.len()
+        );
+        for (index, (row, csv_row)) in rows.iter().zip(&csv_rows).enumerate() {
+            let mut keys: Vec<&String> = row.keys().collect();
+            keys.sort();
+            let mut expected: Vec<&String> = csv_header.iter().collect();
+            expected.sort();
+            assert_eq!(
+                keys, expected,
+                "{dataset} row {index} carries different keys from the csv header"
+            );
+            for (column, csv_value) in csv_header.iter().zip(csv_row) {
+                let value = match row.get(column) {
+                    Some(serde_json::Value::Null) => String::new(),
+                    Some(serde_json::Value::String(text)) => text.clone(),
+                    Some(other) => other.to_string(),
+                    None => unreachable!("the keys were compared above"),
                 };
                 assert!(
-                    matches,
-                    "{dataset} row {index} column {column} is {value:?} as csv and {from_json} \
-                     as json"
+                    same_value(&value, csv_value),
+                    "{dataset} row {index} column {column} is {value:?} as json and \
+                     {csv_value:?} as csv"
                 );
             }
         }
 
-        if formats.contains(&"packed") {
-            let packed = exported.export(&format!("dataset={dataset}&format=packed"));
-            assert_eq!(packed.status, 200, "{dataset} as packed: {}", packed.text());
-            let declared = packed_rows(&packed.body, dataset);
+        if offered.usable.iter().any(|format| format == "packed") {
+            let response = exported.export(&format!("dataset={dataset}&format=packed"));
             assert_eq!(
-                declared as usize,
-                json_rows.len(),
-                "{dataset} declares {declared} rows in its packed footer and exports {} as json",
-                json_rows.len()
+                response.status,
+                200,
+                "{dataset} as packed: {}",
+                response.text()
+            );
+            let document = match packed::decode(&response.body) {
+                Ok(document) => document,
+                Err(error) => panic!("{dataset} as packed must decode: {error}"),
+            };
+            assert!(
+                document.misaligned.is_empty(),
+                "{dataset} as packed has payloads at unaligned offsets {:?}, which makes a \
+                 zero-copy typed-array view throw",
+                document.misaligned
+            );
+            assert_eq!(
+                document.declared_rows as usize,
+                csv_rows.len(),
+                "{dataset} declares {} rows in its packed footer against {} as csv",
+                document.declared_rows,
+                csv_rows.len()
+            );
+            assert_same_table(
+                &format!("{dataset} as packed"),
+                &csv_header,
+                &csv_rows,
+                &document.columns,
+                &document.rows,
             );
         }
 
-        if formats.contains(&"arrow") {
-            let arrow = exported.export(&format!("dataset={dataset}&format=arrow"));
-            assert_eq!(arrow.status, 200, "{dataset} as arrow: {}", arrow.text());
-            assert!(
-                !arrow.body.is_empty(),
-                "{dataset} as arrow must carry a stream"
+        if offered.usable.iter().any(|format| format == "arrow") {
+            let response = exported.export(&format!("dataset={dataset}&format=arrow"));
+            assert_eq!(
+                response.status,
+                200,
+                "{dataset} as arrow: {}",
+                response.text()
+            );
+            #[cfg(feature = "arrow-export")]
+            {
+                let (header, rows) = arrow_table(&response.body, &format!("{dataset} as arrow"));
+                assert_same_table(
+                    &format!("{dataset} as arrow"),
+                    &csv_header,
+                    &csv_rows,
+                    &header,
+                    &rows,
+                );
+            }
+            #[cfg(not(feature = "arrow-export"))]
+            println!(
+                "INFO: {dataset} as arrow was served but not decoded; build this test with \
+                 --features arrow-export to compare its values"
             );
         }
     }
 }
 
-/// The same export twice is byte-identical, which is the endpoint's stated
-/// contract and what lets a consumer cache or checksum one.
+/// The same export twice is byte-identical, which is what lets a consumer
+/// cache or checksum one.
 #[test]
 fn test_the_same_export_twice_is_byte_identical() {
     let Some(client) = service() else {
@@ -283,10 +521,10 @@ fn test_the_same_export_twice_is_byte_identical() {
     let Some(exported) = Exported::create(&client) else {
         return;
     };
-    let formats = offered_formats(&exported);
+    let offered = offered_formats(&client, &exported);
 
     for dataset in DATASETS {
-        for format in &formats {
+        for format in &offered.usable {
             let query = format!("dataset={dataset}&format={format}");
             let first = exported.export(&query);
             let second = exported.export(&query);
@@ -300,8 +538,8 @@ fn test_the_same_export_twice_is_byte_identical() {
     }
 }
 
-/// A range selects the same rows in every format, and a bad one is a typed
-/// rejection in every format rather than an empty document.
+/// A range selects the same rows in every format, and the two ways to get one
+/// wrong are typed rejections naming the field at fault.
 #[test]
 fn test_a_range_selects_the_same_rows_in_every_format() {
     let Some(client) = service() else {
@@ -310,57 +548,126 @@ fn test_a_range_selects_the_same_rows_in_every_format() {
     let Some(exported) = Exported::create(&client) else {
         return;
     };
-    let formats = offered_formats(&exported);
+    let offered = offered_formats(&client, &exported);
 
+    // A valid range, decoded in every offered format and compared against the
+    // csv rows it selected.
     let ranged = "dataset=underlying&from_step=1&to_step=2";
-    let json = exported.export(&format!("{ranged}&format=json"));
-    assert_eq!(json.status, 200, "{}", json.text());
-    let expected = json_rows(&json.body, "underlying").len();
-    assert!(
-        expected > 0 && expected <= STEPS,
-        "a range of two steps must select between one and {STEPS} rows, got {expected}"
-    );
-
     let csv = exported.export(&format!("{ranged}&format=csv"));
-    assert_eq!(
-        csv_rows(&csv.text()).len() - 1,
-        expected,
-        "the same range must select the same rows as csv and as json"
+    assert_eq!(csv.status, 200, "{}", csv.text());
+    let text = csv.text();
+    let (csv_header, csv_rows) = csv_table(&text, "a ranged underlying export");
+    assert!(
+        !csv_rows.is_empty() && csv_rows.len() <= STEPS,
+        "a range of two steps must select between one and {STEPS} rows, got {}",
+        csv_rows.len()
     );
-
-    if formats.contains(&"packed") {
-        let packed = exported.export(&format!("{ranged}&format=packed"));
+    // And it selected the steps asked for, not just the right number of them.
+    if let Some(step) = csv_header.iter().position(|column| column == "step") {
+        let steps: Vec<&str> = csv_rows
+            .iter()
+            .filter_map(|row| row.get(step).map(String::as_str))
+            .collect();
         assert_eq!(
-            packed_rows(&packed.body, "a ranged underlying export") as usize,
-            expected,
-            "the same range must select the same rows as packed and as json"
+            steps,
+            vec!["1", "2"],
+            "the range must select exactly the steps it names"
         );
     }
 
-    // And a bad range is a rejection in EVERY format, never an empty document
-    // that a consumer would read as "no data".
-    for format in &formats {
-        let response = exported.export(&format!(
-            "dataset=underlying&format={format}&from_step=2&to_step=1"
-        ));
-        assert_eq!(
-            response.status,
-            400,
-            "an inverted range must be refused as {format}, got {} with {}",
-            response.status,
-            response.text()
-        );
-        let content_type = response.header("content-type").unwrap_or_default();
-        assert!(
-            content_type.contains("application/json"),
-            "a rejection is JSON whatever format was asked for, got {content_type:?}"
-        );
+    for format in &offered.usable {
+        let response = exported.export(&format!("{ranged}&format={format}"));
+        assert_eq!(response.status, 200, "{format}: {}", response.text());
+        match format.as_str() {
+            "csv" => {}
+            "json" => {
+                let rows: Vec<serde_json::Value> = match response.json("a ranged json export") {
+                    Ok(rows) => rows,
+                    Err(error) => panic!("{error}"),
+                };
+                assert_eq!(rows.len(), csv_rows.len(), "json selected different rows");
+            }
+            "packed" => {
+                let document = match packed::decode(&response.body) {
+                    Ok(document) => document,
+                    Err(error) => panic!("a ranged packed export must decode: {error}"),
+                };
+                assert_same_table(
+                    "a ranged packed export",
+                    &csv_header,
+                    &csv_rows,
+                    &document.columns,
+                    &document.rows,
+                );
+            }
+            "arrow" => {
+                #[cfg(feature = "arrow-export")]
+                {
+                    let (header, rows) = arrow_table(&response.body, "a ranged arrow export");
+                    assert_same_table(
+                        "a ranged arrow export",
+                        &csv_header,
+                        &csv_rows,
+                        &header,
+                        &rows,
+                    );
+                }
+            }
+            other => panic!("unhandled format {other}"),
+        }
+    }
+
+    // And both ways to get a range wrong are typed rejections, in EVERY
+    // format, naming the field a client can act on.
+    for format in &offered.usable {
+        for (what, query, field) in [
+            (
+                "an inverted range",
+                format!("dataset=underlying&format={format}&from_step=2&to_step=1"),
+                "from_step",
+            ),
+            (
+                "a range past the end of the tape",
+                format!("dataset=underlying&format={format}&from_step=0&to_step=99999"),
+                "to_step",
+            ),
+        ] {
+            let response = exported.export(&query);
+            assert_eq!(
+                response.status,
+                400,
+                "{what} must be refused as {format}, got {} with {}",
+                response.status,
+                response.text()
+            );
+            let content_type = response.header("content-type").unwrap_or_default();
+            assert!(
+                content_type.contains("application/json"),
+                "a rejection is JSON whatever format was asked for, got {content_type:?}"
+            );
+            let body: serde_json::Value = match response.json(&query) {
+                Ok(body) => body,
+                Err(error) => {
+                    panic!("{what} as {format} must answer the documented shape: {error}")
+                }
+            };
+            assert_eq!(
+                body.get("field").and_then(serde_json::Value::as_str),
+                Some(field),
+                "{what} as {format} must name {field}: {body}"
+            );
+            assert!(
+                body.get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|message| !message.is_empty()),
+                "{what} as {format} must explain itself: {body}"
+            );
+        }
     }
 }
 
 /// Each greek level's header is a PREFIX of the next, so a consumer written
-/// against `none` keeps reading the same columns in the same places when a
-/// richer level is requested.
+/// against `none` keeps reading the same columns in the same places.
 #[test]
 fn test_each_greek_level_extends_the_previous_one() {
     let Some(client) = service() else {
@@ -370,27 +677,18 @@ fn test_each_greek_level_extends_the_previous_one() {
         return;
     };
 
-    let header_for = |level: &str| -> Option<Vec<String>> {
+    let header_for = |level: &str| -> Vec<String> {
         let response = exported.export(&format!("dataset=option_chains&format=csv&greeks={level}"));
-        if response.status == 400 {
-            println!("SKIP: this deployment does not know the {level} greek level");
-            return None;
-        }
         assert_eq!(
             response.status,
             200,
             "the {level} greek level must export, got {}",
             response.text()
         );
-        csv_rows(&response.text()).first().cloned()
+        csv_table(&response.text(), &format!("the {level} greek level")).0
     };
 
-    let (Some(none), Some(first), Some(all)) =
-        (header_for("none"), header_for("first"), header_for("all"))
-    else {
-        return;
-    };
-
+    let (none, first, all) = (header_for("none"), header_for("first"), header_for("all"));
     assert!(
         first.starts_with(&none),
         "the first-order header must extend the none header, {none:?} then {first:?}"
@@ -405,11 +703,8 @@ fn test_each_greek_level_extends_the_previous_one() {
     );
 }
 
-/// A streamed export is complete: the last row of the tape is present, and it
+/// A streamed export is complete: the last row of the tape is present and
 /// carries every column the header declared.
-///
-/// Truncation is the failure mode a socket introduces and an in-process test
-/// cannot see.
 #[test]
 fn test_a_streamed_export_is_not_truncated() {
     let Some(client) = service() else {
@@ -422,33 +717,24 @@ fn test_a_streamed_export_is_not_truncated() {
     let response = exported.export("dataset=option_chains&format=csv&greeks=all");
     assert_eq!(response.status, 200, "{}", response.text());
     let text = response.text();
-    let rows = csv_rows(&text);
-    let (header, data) = match rows.split_first() {
-        Some((header, data)) => (header, data),
-        None => panic!("a csv export must carry a header"),
-    };
+    let (header, rows) = csv_table(&text, "a full greek export");
 
-    assert!(!data.is_empty(), "a walked tape must export rows");
+    assert!(!rows.is_empty(), "a walked tape must export rows");
     assert!(
         text.ends_with("\r\n"),
         "a complete csv export ends with a line terminator, so a cut stream is visible"
     );
 
-    let last = match data.last() {
+    let last = match rows.last() {
         Some(last) => last,
-        None => unreachable!("data was checked non-empty"),
+        None => unreachable!("rows was checked non-empty"),
     };
     assert_eq!(
         last.len(),
         header.len(),
-        "the last row must carry every column the header declares, which is what a truncated \
-         stream loses first"
+        "the last row must carry every column the header declares"
     );
-
-    // The last row belongs to the last step, so nothing at the end went
-    // missing.
-    let step_column = header.iter().position(|column| column == "step");
-    if let Some(index) = step_column {
+    if let Some(index) = header.iter().position(|column| column == "step") {
         let last_step: usize = match last.get(index).and_then(|value| value.parse().ok()) {
             Some(step) => step,
             None => panic!("the step column must carry a number, row was {last:?}"),
@@ -470,9 +756,9 @@ fn test_the_content_type_and_filename_match_the_format() {
     let Some(exported) = Exported::create(&client) else {
         return;
     };
-    let formats = offered_formats(&exported);
+    let offered = offered_formats(&client, &exported);
 
-    for format in &formats {
+    for format in &offered.usable {
         let response = exported.export(&format!("dataset=underlying&format={format}"));
         assert_eq!(response.status, 200);
 
@@ -480,11 +766,9 @@ fn test_the_content_type_and_filename_match_the_format() {
             .header("content-type")
             .unwrap_or_default()
             .to_string();
-        let expected_type = match *format {
+        let expected_type = match format.as_str() {
             "json" => "application/json",
             "csv" => "text/csv",
-            // Arrow has a registered media type of its own; only the packed
-            // format falls back to plain octets.
             "arrow" => "application/vnd.apache.arrow.stream",
             _ => "application/octet-stream",
         };
@@ -501,7 +785,7 @@ fn test_the_content_type_and_filename_match_the_format() {
             disposition.contains("attachment") && disposition.contains(&exported.id),
             "{format} must suggest a filename naming the simulation, got {disposition:?}"
         );
-        let expected_extension = match *format {
+        let expected_extension = match format.as_str() {
             "json" => ".json",
             "csv" => ".csv",
             "arrow" => ".arrow",
@@ -512,4 +796,9 @@ fn test_the_content_type_and_filename_match_the_format() {
             "{format} must suggest a {expected_extension} file, got {disposition:?}"
         );
     }
+
+    assert!(
+        offered.absent.len() < 4,
+        "no format at all is served by this deployment"
+    );
 }


### PR DESCRIPTION
Closes #103

Base branch: `stack/9-102-reproducibility`
Stacked on: #123
Blocks: #125

Stack: #109 → #110 → #111 → #112 → #99 → #104 → #100 → #101 → #102 → **#103** → #106 → #105 → #107

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## What it asserts

Six flows over a three-step, two-strike tape, which is deliberately small because an export is the most expensive thing the service does and the deployment is shared.

- every dataset in every offered format carries the same rows, compared as **parsed values** rather than text, since the rendering of a number is not the contract
- the same export twice is byte-identical, which is what lets a consumer cache or checksum one
- a range selects the same rows in every format, and an inverted range is a typed `400` **in every format**, never an empty document a consumer would read as "no data"
- each greek level header extends the previous one, so a consumer written against `none` keeps its columns in place when a richer level is asked for
- a streamed export reaches the last step of the tape with every column present, which is the failure a socket introduces and an in-process test cannot see
- the content type and suggested filename match the format asked for

## Honest against an older build

Formats are **probed**, not assumed: `json` and `csv` are required of every build, while `arrow` needs a feature that is off by default and `packed` postdates some deployments. A 400 for those is reported as a skip. The suite therefore passes against a deployment offering only json and csv, and covers more when more is deployed.

## Verified against a running service, twice

Once with the default features and once with `arrow-export` on, so the arrow branch was actually exercised rather than permanently skipped. That is how the expected media type got corrected: arrow is served as `application/vnd.apache.arrow.stream`, not as plain octets, and only the packed format falls back to `application/octet-stream`.

The packed check reads the footer, which is exactly what a consumer must do: the sentinel and the declared row count are what make a truncated download detectable, and the count is asserted against the json row count.

## Checklist

- [x] Row counts and values agree across every advertised format, for all three datasets
- [x] Repeat exports byte-identical
- [x] Range and greek-level behaviour asserted per format, rejections included
- [x] Passes against a deployment offering only json and csv
- [x] Skipped cleanly when `OCS_INTEGRATION_BASE_URL` is unset
- [x] `make pre-push` clean, zero warnings; 6 integration tests green against a live service
- [x] Patch version bumped to 0.2.11 with the compose image tag