### PR TITLE
Fix a pinned simulation's widening ceiling at creation (replaces #113)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.1}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.2}
     deploy:
       replicas: 2
       restart_policy:

--- a/src/api/rest/responses_v2.rs
+++ b/src/api/rest/responses_v2.rs
@@ -136,6 +136,19 @@ pub struct SimulationParametersResponse {
     pub smile_curve: Option<f64>,
     /// Which strikes the simulation quotes: `rolling` or `pinned`.
     pub strike_ladder: StrikeLadder,
+    /// How far a pinned ladder may make a step widen the chain, in strikes per
+    /// side, resolved once at creation.
+    ///
+    /// Echoed because it is a replay input like the seed: it decides the first
+    /// step at which a pinned simulation refuses a drift, so a replay that
+    /// resolved a different one is a different tape boundary. A client
+    /// recreating a run on another instance can compare this value and know
+    /// whether the boundary moved, rather than discovering it at step k.
+    ///
+    /// It is not accepted on a request. The number bounds what the service
+    /// will build on a client's behalf, so letting a client raise it would
+    /// turn a resource guard into a suggestion.
+    pub pinned_width_ceiling: usize,
     /// The constant term of the spread model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spread: Option<f64>,
@@ -352,6 +365,7 @@ impl From<&SessionV2> for SimulationParametersResponse {
             skew_slope: parameters.skew_slope.and_then(|value| value.to_f64()),
             smile_curve: parameters.smile_curve.and_then(|value| value.to_f64()),
             strike_ladder: parameters.strike_ladder,
+            pinned_width_ceiling: parameters.pinned_width_ceiling,
             spread: parameters.spread.map(|value| value.to_f64()),
             spread_proportional: parameters
                 .spread_proportional

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -70,7 +70,7 @@
 //! is pinned by a test. ADR 0001 §8 records the contract.
 
 use crate::domain::Walker;
-use crate::domain::ladder::{PinnedLadder, max_pinned_width};
+use crate::domain::ladder::PinnedLadder;
 use crate::domain::simulator::{DEFAULT_CHAIN_SIZE, DEFAULT_SKEW_SLOPE, DEFAULT_SMILE_CURVE};
 use crate::domain::spread::SpreadModel;
 use crate::session::{SimulationMethod, SimulationParametersV2};
@@ -962,11 +962,11 @@ pub(crate) fn build_chain(
     };
 
     let chain_size = match &pinned {
-        // The ceiling is this simulation's own snapshot budget, not a constant:
-        // a configuration validated for a handful of contracts per snapshot
-        // must not price a thousand strikes per expiration because its spot
-        // drifted.
-        Some(ladder) => ladder.width_from(spot, max_pinned_width(parameters)?)?,
+        // The ceiling was fixed at creation and travels with the parameters,
+        // so it is the same on every instance that ever serves this session:
+        // reading it from the environment here would let the same seed run to
+        // completion on one deployment and refuse at step k on another.
+        Some(ladder) => ladder.width_from(spot, parameters.pinned_width_ceiling)?,
         None => parameters.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE),
     };
     let skew_slope = parameters.skew_slope.unwrap_or(DEFAULT_SKEW_SLOPE);

--- a/src/domain/ladder.rs
+++ b/src/domain/ladder.rs
@@ -43,7 +43,7 @@
 //! provide. Widen the ladder at creation, with `chain_size`, rather than at step
 //! time.
 
-use crate::session::SimulationParametersV2;
+use crate::session::{ExpirationSchedule, SimulationParametersV2};
 use crate::utils::ChainError;
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -171,7 +171,8 @@ impl PinnedLadder {
     /// upstream: the distance in intervals from the spot's at-the-money strike
     /// to whichever pinned strike is furthest from it.
     ///
-    /// `maximum` is the widening [`max_pinned_width`] allows: the smaller of
+    /// `maximum` is the ceiling [`resolve_pinned_ceiling`] fixed at creation
+    /// and the parameters carry: the smaller of
     /// the simulation's own snapshot budget and the absolute ceiling
     /// [`MAX_PINNED_WIDTH`]. A pinned step must not be able to price more
     /// contracts than the configuration was validated for, nor a wider chain
@@ -350,12 +351,12 @@ pub(crate) fn at_the_money(
 /// retroactively break simulations already running, and raising it must not
 /// license the domain to price a wider chain than this.
 ///
-/// It is a ceiling, never the bound on its own; [`max_pinned_width`] takes it
+/// It is a ceiling, never the bound on its own; [`resolve_pinned_ceiling`] takes it
 /// together with the simulation's snapshot budget and keeps whichever is
 /// smaller.
 pub(crate) const MAX_PINNED_WIDTH: usize = 500;
 
-/// The widest chain a pinned step may ask upstream for.
+/// The widest chain a pinned step may ask upstream for, resolved ONCE.
 ///
 /// A pinned step builds wide enough to REACH its ladder and then filters, so
 /// the widening is work the client never asked for and the request caps never
@@ -371,17 +372,20 @@ pub(crate) const MAX_PINNED_WIDTH: usize = 500;
 /// And [`MAX_PINNED_WIDTH`], because that budget is a SERVICE-WIDE cap rather
 /// than a per-simulation one. At its default a single-expiration schedule
 /// divides 200 000 contracts by one, which would license a widening of 99 999
-/// strikes per side; a bound that large is not a bound. The absolute ceiling is
-/// what keeps the widening in the region a client could have asked for
-/// directly.
+/// strikes per side; a bound that large is not a bound.
+///
+/// This is called at CREATION, and the result is stored on the parameters. It
+/// must not be called per step: `max_snapshot_contracts()` is a process-global
+/// read, so a step-time call would make how far a pinned tape gets depend on
+/// the instance serving it, and the same seed could then run to completion on
+/// one deployment and refuse at step k on another (issue #109).
 ///
 /// # Errors
 ///
 /// Returns [`ChainError::Validation`] when the schedule's expiration count
 /// overflows, which the creation path also refuses.
-pub(crate) fn max_pinned_width(parameters: &SimulationParametersV2) -> Result<usize, ChainError> {
-    let expirations = parameters
-        .schedule
+pub(crate) fn resolve_pinned_ceiling(schedule: &ExpirationSchedule) -> Result<usize, ChainError> {
+    let expirations = schedule
         .rules()
         .iter()
         .try_fold(0usize, |total, rule| {
@@ -398,7 +402,7 @@ pub(crate) fn max_pinned_width(parameters: &SimulationParametersV2) -> Result<us
     ))
 }
 
-/// The widening [`max_pinned_width`] allows for a given cap and expiration
+/// The widening [`resolve_pinned_ceiling`] allows for a given cap and expiration
 /// count, split out from the environment so both sides of the minimum can be
 /// exercised: the process-wide cap is resolved once in a `OnceLock`, so a test
 /// that could only call the public entry point would be stuck with whatever
@@ -687,25 +691,58 @@ mod tests {
         assert_eq!(pinned_width_for(200_000, 0), MAX_PINNED_WIDTH);
     }
 
-    /// The parameters entry point agrees with the pure core it delegates to.
+    /// The creation-time resolver agrees with the pure core it delegates to,
+    /// and the parameters carry what it resolved.
     #[test]
-    fn test_the_widening_ceiling_comes_from_the_snapshot_budget() {
+    fn test_the_ceiling_is_resolved_once_and_carried() {
         let parameters = parameters(5000.0, 25.0, 2);
         let cap = crate::infrastructure::max_snapshot_contracts();
 
-        let width = match max_pinned_width(&parameters) {
+        // One expiration in this schedule, so the whole per-snapshot budget is
+        // one chain and the `2n + 1` grid must fit inside it.
+        let resolved = match resolve_pinned_ceiling(&parameters.schedule) {
             Ok(width) => width,
             Err(error) => panic!("the budget must resolve: {error}"),
         };
-
-        // One expiration in this schedule, so the whole per-snapshot budget is
-        // one chain and the `2n + 1` grid must fit inside it.
-        assert_eq!(width, pinned_width_for(cap, 1));
-        assert!(width * 2 < cap, "{width} strikes per side exceeds {cap}");
+        assert_eq!(resolved, pinned_width_for(cap, 1));
         assert!(
-            width <= MAX_PINNED_WIDTH,
-            "{width} strikes per side exceeds the {MAX_PINNED_WIDTH} ceiling"
+            resolved * 2 < cap,
+            "{resolved} strikes per side exceeds {cap}"
         );
+        assert!(
+            resolved <= MAX_PINNED_WIDTH,
+            "{resolved} strikes per side exceeds the {MAX_PINNED_WIDTH} ceiling"
+        );
+
+        // And the request conversion stored exactly that.
+        assert_eq!(parameters.pinned_width_ceiling, resolved);
+    }
+
+    /// The stored ceiling is what a step obeys, whatever this instance would
+    /// resolve now. A session created under a tighter cap keeps refusing the
+    /// widening that cap forbade, on any instance that later serves it.
+    #[test]
+    fn test_a_step_obeys_the_stored_ceiling_not_the_environment() {
+        let mut parameters = parameters(5000.0, 25.0, 2);
+        parameters.strike_ladder = StrikeLadder::Pinned;
+        parameters.pinned_width_ceiling = 3;
+
+        let ladder = match PinnedLadder::resolve(&parameters) {
+            Ok(ladder) => ladder,
+            Err(error) => panic!("the ladder must resolve: {error}"),
+        };
+
+        // Two intervals of drift needs six strikes per side, past the three the
+        // simulation was created under, even though this instance's own budget
+        // would allow far more.
+        match ladder.width_from(pos_or_panic!(5100.0), parameters.pinned_width_ceiling) {
+            Ok(width) => panic!("the stored ceiling must bind, got {width}"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "strike_ladder");
+                assert!(reason.contains("past the 3"), "{reason}");
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
     }
 
     /// A pinned ladder needs an explicit interval, and says so.

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,5 +6,6 @@ pub(crate) mod simulator;
 pub(crate) mod spread;
 mod walker;
 
+pub(crate) use ladder::resolve_pinned_ceiling;
 pub use simulator::Simulator;
 pub(crate) use walker::Walker;

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -26,7 +26,7 @@ use crate::api::rest::validation::{
     time_frame_field,
 };
 use crate::domain::expiry::{CalendarVersion, ExpirationSchedule, tzdb_version};
-use crate::domain::ladder::{StrikeLadder, ensure_ladder_fits};
+use crate::domain::ladder::{MAX_PINNED_WIDTH, StrikeLadder, ensure_ladder_fits};
 use crate::domain::simulator::DEFAULT_CHAIN_SIZE;
 use crate::domain::spread::{MAX_PROPORTIONAL, MAX_TICK, MAX_WIDENING};
 use crate::infrastructure::max_snapshot_contracts;
@@ -403,7 +403,7 @@ impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
             seed: wire.seed,
             pinned_width_ceiling,
         };
-        parameters.validate()?;
+        parameters.validate_stored()?;
         Ok(parameters)
     }
 }
@@ -432,6 +432,37 @@ impl SimulationParametersV2 {
     /// model fails its own invariants, `volatility` disagrees with the walk
     /// model's own volatility, or the schedule is invalid.
     pub fn validate(&self) -> Result<(), ChainError> {
+        self.validate_inner(true)
+    }
+
+    /// The same invariants, for a document coming back from the STORE rather
+    /// than from a request.
+    ///
+    /// One check differs, deliberately. `OCS_MAX_SNAPSHOT_CONTRACTS` is
+    /// admission control: it decides what this instance is willing to accept,
+    /// which is a question about the future. A session that already exists
+    /// answered it when it was created, and re-answering it on load with
+    /// whatever cap the instance happens to run today would mean a simulation
+    /// created under a higher cap fails to DESERIALIZE on a smaller instance,
+    /// taking the tape with it. That is exactly the cross-instance breakage
+    /// issue #109 set out to remove.
+    ///
+    /// So a stored document whose work exceeds this instance's cap loads with
+    /// a warning, the same treatment a `tzdb_version` from another release
+    /// gets, and every deployment-independent invariant still applies —
+    /// including the absolute ceiling on `pinned_width_ceiling`, which is what
+    /// keeps a corrupted document from buying unbounded pricing.
+    ///
+    /// # Errors
+    ///
+    /// As [`SimulationParametersV2::validate`], minus the per-snapshot cap.
+    pub fn validate_stored(&self) -> Result<(), ChainError> {
+        self.validate_inner(false)
+    }
+
+    /// The shared body. `enforce_cap` is what separates a request from a
+    /// document that already exists.
+    fn validate_inner(&self, enforce_cap: bool) -> Result<(), ChainError> {
         if self.steps < 1 {
             return Err(ChainError::Validation {
                 field: "steps".to_string(),
@@ -542,7 +573,20 @@ impl SimulationParametersV2 {
             });
         }
         self.schedule.validate()?;
-        self.validate_snapshot_work()?;
+        self.enforce_snapshot_work(enforce_cap)?;
+
+        // Deployment-independent, so it holds on every path: a stored ceiling
+        // above the absolute maximum would let a corrupted document buy a
+        // widening no request could ever ask for.
+        if self.pinned_width_ceiling > MAX_PINNED_WIDTH {
+            return Err(ChainError::Validation {
+                field: "pinned_width_ceiling".to_string(),
+                reason: format!(
+                    "must not exceed {MAX_PINNED_WIDTH}, got {}",
+                    self.pinned_width_ceiling
+                ),
+            });
+        }
 
         // A simulation has exactly one base volatility. v1 accepts a top-level
         // value and a walk model carrying a different one, and silently prices
@@ -595,7 +639,39 @@ impl SimulationParametersV2 {
     ///
     /// Returns [`ChainError::Validation`] naming `chain_size`, which is the
     /// field a client can lower without changing what the simulation means.
-    fn validate_snapshot_work(&self) -> Result<(), ChainError> {
+    fn enforce_snapshot_work(&self, enforce_cap: bool) -> Result<(), ChainError> {
+        let contracts = self.snapshot_contracts()?;
+        let cap = max_snapshot_contracts();
+
+        if contracts <= cap {
+            return Ok(());
+        }
+        if !enforce_cap {
+            // A session that already exists keeps loading; see
+            // `validate_stored`.
+            warn!(
+                contracts,
+                cap,
+                "a stored simulation prices more contracts per snapshot than this instance would accept"
+            );
+            return Ok(());
+        }
+
+        Err(ChainError::Validation {
+            field: "chain_size".to_string(),
+            reason: format!(
+                "every snapshot would price {contracts} contracts, above the {cap} maximum; \
+                 lower chain_size or the schedules' target_count"
+            ),
+        })
+    }
+
+    /// How many contracts one snapshot of this configuration prices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChainError::Validation`] when the count is not representable.
+    fn snapshot_contracts(&self) -> Result<usize, ChainError> {
         let requested = self.chain_size.unwrap_or(DEFAULT_CHAIN_SIZE);
         let strikes = strikes_per_chain(requested).ok_or_else(|| ChainError::Validation {
             field: "chain_size".to_string(),
@@ -613,7 +689,7 @@ impl SimulationParametersV2 {
                 reason: "the requested expiration counts overflow".to_string(),
             })?;
 
-        let contracts = strikes
+        strikes
             .checked_mul(expirations)
             .ok_or_else(|| ChainError::Validation {
                 field: "chain_size".to_string(),
@@ -621,21 +697,7 @@ impl SimulationParametersV2 {
                     "{strikes} strikes across {expirations} expirations overflows the \
                      contract count"
                 ),
-            })?;
-
-        let cap = max_snapshot_contracts();
-        if contracts > cap {
-            return Err(ChainError::Validation {
-                field: "chain_size".to_string(),
-                reason: format!(
-                    "every snapshot would price {contracts} contracts ({strikes} strikes \
-                     across up to {expirations} expirations), above the {cap} maximum; lower \
-                     chain_size or the schedules' target_count"
-                ),
-            });
-        }
-
-        Ok(())
+            })
     }
 
     /// The simulated instant at `cursor`.
@@ -1693,6 +1755,90 @@ mod tests {
         match serde_json::from_str::<SimulationParametersV2>(&json) {
             Ok(loaded) => assert_eq!(loaded.pinned_width_ceiling, 7),
             Err(error) => panic!("must deserialize: {error}"),
+        }
+    }
+
+    /// A corrupted document cannot buy a widening no request could ask for.
+    ///
+    /// Redis is an outer layer: the stored ceiling is a number the domain then
+    /// obeys, so a hand-edited document raising it past the absolute maximum
+    /// would bypass the guard on how much the service prices per step.
+    #[test]
+    fn test_a_stored_pinned_ceiling_above_the_maximum_is_refused() {
+        let parameters = parameters(reference_request());
+
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                map.insert(
+                    "pinned_width_ceiling".to_string(),
+                    serde_json::json!(MAX_PINNED_WIDTH + 1),
+                );
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => panic!(
+                "a ceiling of {} must be refused, loaded {loaded:?}",
+                MAX_PINNED_WIDTH + 1
+            ),
+            Err(error) => {
+                let rendered = error.to_string();
+                assert!(
+                    rendered.contains("pinned_width_ceiling"),
+                    "the failure must name the field: {rendered}"
+                );
+            }
+        }
+    }
+
+    /// A session created under a higher per-snapshot cap keeps LOADING on an
+    /// instance running a lower one.
+    ///
+    /// The cap is admission control, a decision about what to accept next. A
+    /// session that already exists answered it at creation, and re-answering it
+    /// on load would mean a smaller instance cannot even deserialize a tape a
+    /// bigger one is serving, which is the cross-instance breakage #109 exists
+    /// to remove. The creation path still refuses the same configuration.
+    #[test]
+    fn test_a_stored_simulation_over_the_cap_still_loads_but_is_not_creatable() {
+        let mut parameters = parameters(reference_request());
+
+        // 1 001 strikes across 512 live expirations is half a million
+        // contracts a snapshot, far above any sane cap.
+        parameters.chain_size = Some(*MAX_CHAIN_SIZE);
+        let rules = match (
+            ExpiryRule::new("dailies", ExpiryRuleKind::Daily, 256),
+            ExpiryRule::new("more_dailies", ExpiryRuleKind::Daily, 256),
+        ) {
+            (Ok(first), Ok(second)) => vec![first, second],
+            (first, second) => panic!("the test rules must be valid: {first:?} {second:?}"),
+        };
+        parameters.schedule = match ExpirationSchedule::new(
+            parameters.schedule.calendar(),
+            parameters.schedule.timezone(),
+            parameters.schedule.expiration_time(),
+            rules,
+        ) {
+            Ok(schedule) => schedule,
+            Err(error) => panic!("the test schedule must be valid: {error}"),
+        };
+
+        match parameters.validate() {
+            Ok(()) => panic!("a request for that much work must be refused at creation"),
+            Err(ChainError::Validation { field, reason }) => {
+                assert_eq!(field, "chain_size");
+                assert!(reason.contains("above the"), "{reason}");
+            }
+            Err(error) => panic!("expected a validation failure, got {error:?}"),
+        }
+
+        match parameters.validate_stored() {
+            Ok(()) => {}
+            Err(error) => panic!(
+                "a session that already exists must keep loading on a smaller instance: {error}"
+            ),
         }
     }
 

--- a/src/session/model_v2.rs
+++ b/src/session/model_v2.rs
@@ -299,6 +299,19 @@ pub struct SimulationParametersV2 {
     /// The effective RNG seed. Non-optional: a v2 simulation is always
     /// reproducible, so the seed is resolved at conversion and never `None`.
     pub seed: u64,
+    /// How far a pinned ladder may make a step widen the chain it asks
+    /// upstream for, in strikes per side.
+    ///
+    /// Resolved ONCE, at creation, from the per-snapshot contract cap and this
+    /// simulation's own schedule, exactly as the effective seed is resolved
+    /// once and then carried. The domain reads it from here rather than from
+    /// the environment, so a session keeps the ceiling it was created under for
+    /// its whole life: the same parameters and seed then reach the same step on
+    /// any instance, whatever an operator has since done to
+    /// `OCS_MAX_SNAPSHOT_CONTRACTS`.
+    ///
+    /// A `rolling` simulation carries it too and never consults it.
+    pub pinned_width_ceiling: usize,
 }
 
 /// The deserialization shape of [`SimulationParametersV2`].
@@ -347,12 +360,23 @@ struct SimulationParametersV2Wire {
     #[serde(default)]
     spread_tick: Option<Positive>,
     seed: u64,
+    /// Absent in a document written before the ceiling was stored. Such a
+    /// session is resolved once here, on load, which is the ceiling it would
+    /// have had, and keeps it from then on.
+    #[serde(default)]
+    pinned_width_ceiling: Option<usize>,
 }
 
 impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
     type Error = ChainError;
 
     fn try_from(wire: SimulationParametersV2Wire) -> Result<Self, Self::Error> {
+        // A document written before the ceiling was stored resolves it once,
+        // here, and carries it from then on.
+        let pinned_width_ceiling = match wire.pinned_width_ceiling {
+            Some(ceiling) => ceiling,
+            None => crate::domain::resolve_pinned_ceiling(&wire.schedule)?,
+        };
         let parameters = Self {
             symbol: wire.symbol,
             steps: wire.steps,
@@ -377,6 +401,7 @@ impl TryFrom<SimulationParametersV2Wire> for SimulationParametersV2 {
             spread_tenor_widening: wire.spread_tenor_widening,
             spread_tick: wire.spread_tick,
             seed: wire.seed,
+            pinned_width_ceiling,
         };
         parameters.validate()?;
         Ok(parameters)
@@ -725,6 +750,10 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
             request.schedules,
         )?;
 
+        // The pinned widening ceiling is resolved here, once, from the cap
+        // this instance runs and this simulation's own schedule, and stored.
+        let pinned_width_ceiling = crate::domain::resolve_pinned_ceiling(&schedule)?;
+
         let parameters = Self {
             symbol: request.symbol,
             steps: request.steps,
@@ -756,6 +785,7 @@ impl TryFrom<CreateSimulationRequest> for SimulationParametersV2 {
                 .map(|value| positive_field("spread", value))
                 .transpose()?,
             strike_ladder: request.strike_ladder.unwrap_or_default(),
+            pinned_width_ceiling,
             // The widening coefficients are rates, not prices: zero is the
             // documented default and a negative one would NARROW a quote away
             // from the money, which is not a market anyone trades.
@@ -1620,6 +1650,49 @@ mod tests {
                 "an older document must read as the behaviour it was written under"
             ),
             Err(error) => panic!("an older document must still load: {error}"),
+        }
+    }
+
+    /// A document written before the ceiling was stored still loads, and gets
+    /// the ceiling it would have had, resolved once on the way in.
+    #[test]
+    fn test_stored_parameters_without_a_pinned_ceiling_still_load() {
+        let parameters = parameters(reference_request());
+        let json = match serde_json::to_value(&parameters) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                assert!(
+                    map.remove("pinned_width_ceiling").is_some(),
+                    "the ceiling must be part of the stored shape"
+                );
+                serde_json::Value::Object(map)
+            }
+            other => panic!("the parameters must serialize to an object, got {other:?}"),
+        };
+
+        match serde_json::from_value::<SimulationParametersV2>(json) {
+            Ok(loaded) => assert_eq!(
+                loaded.pinned_width_ceiling, parameters.pinned_width_ceiling,
+                "an older document must read as the ceiling it would have had"
+            ),
+            Err(error) => panic!("an older document must still load: {error}"),
+        }
+    }
+
+    /// A stored ceiling survives the round trip rather than being re-resolved,
+    /// which is the whole point: a session created under a tighter cap keeps
+    /// that ceiling on an instance whose own cap is wider.
+    #[test]
+    fn test_a_stored_pinned_ceiling_survives_the_round_trip() {
+        let mut parameters = parameters(reference_request());
+        parameters.pinned_width_ceiling = 7;
+
+        let json = match serde_json::to_string(&parameters) {
+            Ok(json) => json,
+            Err(error) => panic!("must serialize: {error}"),
+        };
+        match serde_json::from_str::<SimulationParametersV2>(&json) {
+            Ok(loaded) => assert_eq!(loaded.pinned_width_ceiling, 7),
+            Err(error) => panic!("must deserialize: {error}"),
         }
     }
 


### PR DESCRIPTION
Closes #109. Replaces #113, which cannot be reopened because it was merged and then reverted in #128.

## Why this PR exists

#113 carried the right change and was merged with the wrong content: a checkout that failed silently left my working tree on the top of the stack, so the branch was force-pushed with all thirteen levels and the squash landed 5 632 lines on `main`. #128 reverted that. This branch is the real #109 work, rebuilt from the commit the original PR actually had, plus the review fixes it earned.

The diff is 7 files: the ceiling, its plumbing, and the three review fixes. No integration crate, no golden tape, no service images.

## What it does

`max_pinned_width` read `OCS_MAX_SNAPSHOT_CONTRACTS` on every `build_chain`, so the ceiling came from the instance rather than from the session. Tape VALUES were unaffected; how far a tape got was not, and the same seed could refuse at step k on one deployment and run to the end on another. It is resolved once at creation now and stored on `SimulationParametersV2`, next to the effective seed whose pattern it copies.

## The review of #113, addressed here

All three findings, carried over with their fixes:

- the ceiling decides the first step a pinned run refuses at, so it is a **replay input**. `SimulationParametersResponse` echoes it. It stays out of the request, because letting a client raise the bound on what the service builds for it would turn a resource guard into a suggestion
- a stored ceiling was **trusted verbatim**; it is now checked against `MAX_PINNED_WIDTH` on every path, with a test that a hand-edited document one above it is refused
- loading re-ran the **creation-time cap check** against whatever cap the instance runs, so a session created under a higher cap failed to deserialize on a smaller one, which is the same cross-instance breakage this issue exists to remove. `validate_stored` warns where `validate` rejects, as a foreign `tzdb_version` already does, and every deployment-independent invariant still applies

## Checklist

- [x] Reproducibility intact; no walk path touched
- [x] Stored-session shape additive, `#[serde(default)]`, old-document test, corrupted-document test
- [x] REST DTO change is additive: one echoed field
- [x] `make pre-push` clean, zero warnings, 926 tests
- [x] Patch version 0.2.2, one step above the 0.2.1 `main` carries