### PR TITLE
Record the decision to carry no HTTP client in the harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -315,5 +315,9 @@ CLICKHOUSE_PASSWORD=password
 # tree; the tests report the version they found and skip a feature that is not
 # deployed yet rather than failing it.
 #
+# Must be a plain `http://` address. The harness carries no TLS client, by a
+# decision recorded in issue #117, so an `https://` URL is refused with a
+# message saying so rather than failing later as a protocol error.
+#
 # Where your deployment lives is your configuration; do not commit it.
 # OCS_INTEGRATION_BASE_URL=http://localhost:7070

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.14}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.15}
     deploy:
       replicas: 2
       restart_policy:

--- a/README.md
+++ b/README.md
@@ -483,6 +483,13 @@ version it found and skips a feature that is not deployed yet rather than
 failing it. And it is shared, so every test deletes the simulations it
 creates, including when it fails.
 
+The harness carries **no HTTP client dependency**: it speaks HTTP/1.1 over
+`std::net` itself. The consequence worth knowing before pointing it
+somewhere is that `OCS_INTEGRATION_BASE_URL` must be a plain `http://`
+address — a deployment behind TLS cannot be tested from here, and an
+`https://` URL is refused with a message saying why. Issue #117 records the
+decision and what reversing it would take.
+
 ### Exporting a tape
 
 `GET /api/v2/simulations/{id}/export?dataset=…&format=…&from_step=&to_step=`

--- a/examples/integration/src/lib.rs
+++ b/examples/integration/src/lib.rs
@@ -32,14 +32,31 @@
 //! report that something was not exercised; only a real disagreement with the
 //! contract is a failure.
 //!
-//! # No HTTP client dependency
+//! # No HTTP client dependency, decided rather than deferred
 //!
-//! `rules/global_rules.md` forbids adding a dependency without the owner's
-//! approval, and this workspace has no HTTP client. Rather than stall, the
-//! harness speaks HTTP/1.1 over [`std::net::TcpStream`] itself: enough of it
-//! to send a request with a JSON body and read a response, including chunked
-//! transfer encoding. It is deliberately small, and issue #117 proposes
-//! replacing it with `reqwest` if that dependency is ever approved.
+//! This harness speaks HTTP/1.1 over [`std::net::TcpStream`] itself: enough of
+//! it to send a request with a JSON body and read a response, chunked transfer
+//! encoding included. That is a **decision, recorded in issue #117**, not an
+//! accident: the workspace has no HTTP client, `rules/global_rules.md` forbids
+//! adding a dependency without the owner's approval, and the alternative on
+//! offer — `reqwest` — buys convenience this suite does not need.
+//!
+//! What the decision costs, in one place so nobody has to rediscover it:
+//!
+//! - **No HTTPS.** A TLS client is a dependency of its own, so a deployment
+//!   behind TLS cannot be tested from here. An `https://` base URL is refused
+//!   at construction with a message that says so, rather than failing later as
+//!   a protocol error.
+//! - **No connection reuse.** Every request opens a socket. That is fine for a
+//!   test suite and wasteful at the concurrency the endurance tests reach.
+//! - **A protocol reader to maintain**, which grows the first time a test needs
+//!   redirects, keep-alive, or a body read incrementally rather than whole.
+//!
+//! Reversing it is a small change and issue #117 records how: add `reqwest` to
+//! `[workspace.dependencies]` as `X.X`, depend on it from this crate alone
+//! (which is `publish = false`), and delete [`ServiceClient::request`]'s
+//! transport half. Everything above it is written against `Response`, not
+//! against the socket.
 
 pub mod packed;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,13 @@
 //! failing it. And it is shared, so every test deletes the simulations it
 //! creates, including when it fails.
 //!
+//! The harness carries **no HTTP client dependency**: it speaks HTTP/1.1 over
+//! `std::net` itself. The consequence worth knowing before pointing it
+//! somewhere is that `OCS_INTEGRATION_BASE_URL` must be a plain `http://`
+//! address — a deployment behind TLS cannot be tested from here, and an
+//! `https://` URL is refused with a message saying why. Issue #117 records the
+//! decision and what reversing it would take.
+//!
 //! ## Exporting a tape
 //!
 //! `GET /api/v2/simulations/{id}/export?dataset=…&format=…&from_step=&to_step=`


### PR DESCRIPTION
Closes #117

Base branch: `main`
Blocks: #132

Stack: **#117** → #119 → #130 (this is the first)

The three issues in this stack are **independent**: none consumes anything another produces. They are stacked because that is how the run was requested; each could equally be a PR off `main`, and they can be merged bottom up without any of them needing the others.

## The decision, and that it was mine to take

#117 is an owner decision by construction: approve `reqwest` for `examples/integration`, or confirm the hand-written client stays. I took the option that **preserves current behaviour**, which is to keep it, and implemented that fully rather than leaving the issue open. If you want `reqwest` instead, say so and reversing this is small; the issue records exactly what it would take.

## What this PR actually changes

Documentation, in the three places someone meets the consequence:

- the harness module docs now state it as a recorded decision rather than a stopgap, with what it costs: **no HTTPS**, since a TLS client is a dependency of its own, so a deployment behind TLS cannot be tested and an `https://` URL is refused at construction with a message saying why; no connection reuse; and a protocol reader that grows the first time a test needs redirects or keep-alive
- `.env.example` says `OCS_INTEGRATION_BASE_URL` must be a plain `http://` address, and why
- the crate docs say the same in the testing section, so it is visible from the README

It also records what reversing the decision takes, which is genuinely small: add `reqwest` to `[workspace.dependencies]`, depend on it from this `publish = false` member alone, and replace the transport half of `ServiceClient::request`. Everything above it is written against `Response`, not against the socket.

## Checklist

- [x] No code behaviour change; the refusal of an `https://` URL already existed and is now documented
- [x] Reproducibility, stored-session shape and REST DTOs untouched
- [x] `make pre-push` clean, zero warnings, and `cargo clippy --all-features -- -D warnings` clean
- [x] `README.md` regenerated from `lib.rs`
- [x] Patch version bumped to 0.2.15 with the compose image tag
