### PR TITLE
Document the v1 rejection shapes rather than align them with v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -127,7 +127,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.15}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.16}
     deploy:
       replicas: 2
       restart_policy:

--- a/README.md
+++ b/README.md
@@ -464,6 +464,25 @@ from the effective parameters, so it costs latency and nothing else. The
 sweep publishes `v2_simulations_expired_total`, and the caches publish
 `v2_tape_cache_size` and `v2_snapshot_cache_size`.
 
+### The rejection shapes, and where v1 and v2 differ
+
+Every 400 this service answers carries `error`. Most also carry `field`,
+naming the request field at fault, and that pair is what a generated client
+should expect. Two v1 cases do not, and they are documented rather than
+aligned because `/api/v1/chain` is frozen on RENDERED values, so changing an
+error body changes what an existing client parses (issue #119):
+
+| Case | v1 answers | v2 answers |
+|---|---|---|
+| a `sessionid` / `id` that is not a UUID | `{error}`, message prefixed `Invalid State`, **no `field` key** | `{error, field}` with `field` = `id` |
+| the id parameter missing entirely | `{error, field}` with `field` **empty** | `{error, field}` with `field` empty |
+| a body or query parameter out of range | `{error, field}` naming the field | `{error, field}` naming the field |
+| a resource that does not exist | `{error}`, 404 | `{error}`, 404 |
+
+The v2 surface is the one to write new clients against. A v1 client that
+matches on the `Invalid State` prefix is relying on a rendered value, which
+is exactly what v1 promises not to change.
+
 ### Testing against a deployment
 
 The default suite is hermetic: `LOGLEVEL=WARN cargo test --workspace`

--- a/examples/integration/tests/rejections.rs
+++ b/examples/integration/tests/rejections.rs
@@ -396,12 +396,15 @@ fn test_the_v1_rejection_contract_is_a_400_that_explains_itself() {
         return;
     };
 
-    // What a live service answers TODAY, asserted exactly, so a change in
-    // either direction is visible rather than silently tolerated: the
-    // malformed case carries no `field` key at all and renders with an
-    // `Invalid State` prefix, and the missing one carries an empty field.
-    // Both are what issue #119 decides; when it is decided these expectations
-    // change with it, deliberately.
+    // What a live service answers, asserted exactly, so a change in either
+    // direction is visible rather than silently tolerated: the malformed case
+    // carries no `field` key at all and renders with an `Invalid State`
+    // prefix, and the missing one carries an empty field.
+    //
+    // Issue #119 DECIDED this rather than left it open: v1 is frozen on
+    // rendered values, so the shapes stay and are documented in the OpenAPI
+    // document and the crate docs instead. These assertions are therefore the
+    // contract now, not a snapshot of an accident.
     for (case, path, expects_field, prefix) in [
         (
             "a malformed session id",

--- a/src/api/rest/handlers.rs
+++ b/src/api/rest/handlers.rs
@@ -289,7 +289,7 @@ fn json_body(bytes: Vec<u8>) -> HttpResponse {
     ),
     responses(
         (status = 201, description = "Session created successfully", body = SessionResponse),
-        (status = 400, description = "Validation failed: a parameter was non-finite, out of range (e.g. negative price/volatility), or steps/chain_size exceeded the configured limits.", body = ValidationErrorResponse),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range (e.g. negative price/volatility), or steps/chain_size exceeded the configured limits. The body is the typed `{error, field}` naming the offending field.", body = ValidationErrorResponse),
         (status = 409, description = "Session id already exists", body = ErrorResponse),
         (status = 500, description = "Internal server error")
     )
@@ -420,7 +420,7 @@ pub(crate) struct ChainQuery {
     ),
     responses(
         (status = 200, description = "Advanced one step; served snapshot returned", body = ChainResponse),
-        (status = 400, description = "Malformed session id, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` of ValidationErrorResponse with `field` = `greeks`; a malformed id carries `error` alone."),
+        (status = 400, description = "Malformed or missing `sessionid`, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` with `field` = `greeks`. A malformed `sessionid` carries `error` ALONE, with no `field` key, and its message is prefixed `Invalid State`; a missing `sessionid` carries `{error, field}` with `field` empty. Neither is a ValidationErrorResponse: v1 is frozen on rendered values, so these shapes differ from v2, which names `id`. See issue #119."),
         (status = 404, description = "Session not found"),
         (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 410, description = "Simulation completed. No more steps available"),
@@ -543,7 +543,7 @@ pub(crate) async fn advance_step(
     ),
     responses(
         (status = 200, description = "Current snapshot returned (read-only; repeatable)", body = ChainResponse),
-        (status = 400, description = "Malformed session id, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` of ValidationErrorResponse with `field` = `greeks`; a malformed id carries `error` alone."),
+        (status = 400, description = "Malformed or missing `sessionid`, or an unknown `greeks` level. The unknown-level body is the typed `{error, field}` with `field` = `greeks`. A malformed `sessionid` carries `error` ALONE, with no `field` key, and its message is prefixed `Invalid State`; a missing `sessionid` carries `{error, field}` with `field` empty. Neither is a ValidationErrorResponse: v1 is frozen on rendered values, so these shapes differ from v2, which names `id`. See issue #119."),
         (status = 404, description = "Session not found"),
         (status = 410, description = "Session completed; no current step available"),
         (status = 500, description = "Internal server error")
@@ -612,7 +612,7 @@ pub(crate) async fn get_current_step(
     ),
     responses(
         (status = 200, description = "Session replaced", body = SessionResponse),
-        (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
+        (status = 400, description = "Validation failed: a parameter was non-finite, out of range, or exceeded the configured limits, OR the `sessionid` could not be read. A parameter failure carries the typed `{error, field}`. A malformed `sessionid` carries `error` ALONE, with no `field` key, and its message is prefixed `Invalid State`; a missing `sessionid` carries `{error, field}` with `field` empty. Neither is a ValidationErrorResponse: v1 is frozen on rendered values, so these shapes differ from v2, which names `id`. See issue #119.", body = ValidationErrorResponse),
         (status = 404, description = "Session not found"),
         (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 500, description = "Internal server error")
@@ -726,7 +726,7 @@ pub(crate) async fn replace_session(
     responses(
         (status = 200, description = "Session updated", body = SessionResponse),
         (status = 404, description = "Session not found"),
-        (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits.", body = ValidationErrorResponse),
+        (status = 400, description = "Validation failed: a supplied parameter was non-finite, out of range, or exceeded the configured limits, OR the `sessionid` could not be read. A parameter failure carries the typed `{error, field}`. A malformed `sessionid` carries `error` ALONE, with no `field` key, and its message is prefixed `Invalid State`; a missing `sessionid` carries `{error, field}` with `field` empty. Neither is a ValidationErrorResponse: v1 is frozen on rendered values, so these shapes differ from v2, which names `id`. See issue #119.", body = ValidationErrorResponse),
         (status = 409, description = "Concurrent modification: another request advanced or modified the session; retry"),
         (status = 500, description = "Internal server error")
     )
@@ -838,6 +838,7 @@ pub(crate) async fn update_session(
     ),
     responses(
         (status = 200, description = "Session deleted", body = String),
+        (status = 400, description = "The `sessionid` could not be read. A malformed `sessionid` carries `error` ALONE, with no `field` key, and its message is prefixed `Invalid State`; a missing `sessionid` carries `{error, field}` with `field` empty. Neither is a ValidationErrorResponse: v1 is frozen on rendered values, so these shapes differ from v2, which names `id`. See issue #119.", body = ErrorResponse),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     )

--- a/src/api/rest/responses.rs
+++ b/src/api/rest/responses.rs
@@ -139,6 +139,14 @@ pub struct ErrorResponse {
 /// Error body returned for request-validation failures (HTTP 400): the
 /// human-readable message plus the exact request field that failed, so
 /// generated clients match the actual wire shape.
+///
+/// **Not every v1 400 uses this shape.** A `sessionid` that cannot be parsed
+/// answers [`ErrorResponse`] instead — `error` alone, no `field`, with the
+/// message prefixed `Invalid State` — while a missing one answers this shape
+/// with `field` empty. v2 names `id` for the same mistake. `/api/v1/chain` is
+/// frozen on rendered values, so aligning the two would change what an
+/// existing client parses; issue #119 records the decision to document the
+/// difference rather than remove it.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
 pub struct ValidationErrorResponse {
     /// Human-readable description of the validation failure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,6 +447,25 @@
 //! sweep publishes `v2_simulations_expired_total`, and the caches publish
 //! `v2_tape_cache_size` and `v2_snapshot_cache_size`.
 //!
+//! ## The rejection shapes, and where v1 and v2 differ
+//!
+//! Every 400 this service answers carries `error`. Most also carry `field`,
+//! naming the request field at fault, and that pair is what a generated client
+//! should expect. Two v1 cases do not, and they are documented rather than
+//! aligned because `/api/v1/chain` is frozen on RENDERED values, so changing an
+//! error body changes what an existing client parses (issue #119):
+//!
+//! | Case | v1 answers | v2 answers |
+//! |---|---|---|
+//! | a `sessionid` / `id` that is not a UUID | `{error}`, message prefixed `Invalid State`, **no `field` key** | `{error, field}` with `field` = `id` |
+//! | the id parameter missing entirely | `{error, field}` with `field` **empty** | `{error, field}` with `field` empty |
+//! | a body or query parameter out of range | `{error, field}` naming the field | `{error, field}` naming the field |
+//! | a resource that does not exist | `{error}`, 404 | `{error}`, 404 |
+//!
+//! The v2 surface is the one to write new clients against. A v1 client that
+//! matches on the `Invalid State` prefix is relying on a rendered value, which
+//! is exactly what v1 promises not to change.
+//!
 //! ## Testing against a deployment
 //!
 //! The default suite is hermetic: `LOGLEVEL=WARN cargo test --workspace`


### PR DESCRIPTION
Closes #119

Base branch: `stack/1-117-http-client-decision`
Stacked on: #131
Blocks: #133

Stack: #117 → **#119** → #130

The three issues are independent; the diff is cumulative until #131 merges, so read it against the base branch rather than against `main`.

## The decision, and that it was mine to take

#119 offered two options: make v1 carry `field` and correct the `Invalid State` prefix, or record that v1 rejections are what they are and document the difference. I took the second, because it **preserves current behaviour**: `/api/v1/chain` is frozen on rendered values, IronCondor consumes it, and adding a key or rewording a message changes what an existing client parses. If you would rather change the wire, this is the PR to say so on, and the work is small.

## What a live service actually answers, now documented

| Case | v1 | v2 |
|---|---|---|
| id that is not a UUID | `{error}`, prefixed `Invalid State`, **no `field` key** | `{error, field}` with `field` = `id` |
| id missing entirely | `{error, field}` with `field` **empty** | same |
| parameter out of range | `{error, field}` naming the field | same |

- every v1 endpoint's 400 now states which of those shapes it can answer. **DELETE documented no 400 at all** while answering one; it does now
- the crate docs carry the table above, so a client author meets the difference before their parser does
- `ValidationErrorResponse` says plainly that not every v1 400 uses it, and why

## Tests

Unchanged, deliberately: the #104 integration test already asserts exactly these shapes against a live service. Its comment now says this is the decided contract rather than a snapshot of an accident waiting on this issue. I re-read the published OpenAPI document from a running build to confirm every description landed.

## Checklist

- [x] No behaviour change; documentation and OpenAPI only
- [x] Reproducibility, stored-session shape and DTO shapes untouched
- [x] `make pre-push` clean, zero warnings; `README.md` regenerated
- [x] Patch version bumped to 0.2.16 with the compose image tag

