### PR TITLE
Make the MongoDB persisted-volume upgrade a test

### DIFF
--- a/.github/workflows/mongo-upgrade.yml
+++ b/.github/workflows/mongo-upgrade.yml
@@ -1,0 +1,87 @@
+# Proves an existing MongoDB deployment survives the image bump this repo pins.
+#
+# Deliberately NOT on every push: it pulls two database images and runs them in
+# sequence, which is slow, and it has nothing to say about a change that does
+# not move the MongoDB pin. It runs when that pin moves, and on demand.
+#
+# What it protects is the case the Integration job cannot see. That job starts
+# every service on an EMPTY volume, so it proves the new image runs; this one
+# starts the PREVIOUS image on a volume, writes a document, swaps the binary
+# underneath, and requires the document and the feature compatibility version
+# to survive before raising the FCV. See scripts/mongo_upgrade_test.sh.
+name: MongoDB upgrade (persisted volume)
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_image:
+        description: "The image an existing deployment is running, e.g. mongo:8.0.29"
+        required: false
+        type: string
+      to_image:
+        description: "The image being upgraded to. Defaults to the pin in Docker/docker-compose.yml."
+        required: false
+        type: string
+      target_fcv:
+        description: "The feature compatibility version to raise to, e.g. 8.2"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - "Docker/docker-compose.yml"
+      - "scripts/mongo_upgrade_test.sh"
+      - ".github/workflows/mongo-upgrade.yml"
+
+jobs:
+  upgrade:
+    name: Upgrade on a persisted volume
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The base commit is needed to tell a MongoDB bump from any other
+          # compose change.
+          fetch-depth: 0
+
+      - name: Decide whether the MongoDB pin moved
+        id: pin
+        run: |
+          set -euo pipefail
+          current=$(grep -oE 'image: mongo:[^ ]+' Docker/docker-compose.yml | head -1 | cut -d' ' -f2)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=yes" >> "$GITHUB_OUTPUT"
+            echo "previous=${{ inputs.from_image }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="${{ github.event.pull_request.base.sha }}"
+          previous=$(git show "$base:Docker/docker-compose.yml" \
+            | grep -oE 'image: mongo:[^ ]+' | head -1 | cut -d' ' -f2 || true)
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+
+          if [ "$previous" = "$current" ] || [ -z "$previous" ]; then
+            echo "The MongoDB pin did not move ($current); nothing to prove."
+            echo "run=no" >> "$GITHUB_OUTPUT"
+          else
+            echo "The MongoDB pin moved from $previous to $current."
+            echo "run=yes" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upgrade a persisted volume
+        if: steps.pin.outputs.run == 'yes'
+        run: |
+          set -euo pipefail
+          from="${{ inputs.from_image || steps.pin.outputs.previous }}"
+          to="${{ inputs.to_image || steps.pin.outputs.current }}"
+          fcv="${{ inputs.target_fcv }}"
+
+          if [ -z "$fcv" ]; then
+            # The FCV is the major.minor of the image being upgraded to, which
+            # is what MongoDB accepts.
+            fcv=$(printf '%s' "$to" | sed -E 's/^mongo:([0-9]+\.[0-9]+).*/\1/')
+          fi
+
+          echo "Upgrading $from to $to, raising the FCV to $fcv"
+          ./scripts/mongo_upgrade_test.sh "$from" "$to" "$fcv"

--- a/.github/workflows/mongo-upgrade.yml
+++ b/.github/workflows/mongo-upgrade.yml
@@ -1,21 +1,27 @@
 # Proves an existing MongoDB deployment survives the image bump this repo pins.
 #
 # Deliberately NOT on every push: it pulls two database images and runs them in
-# sequence, which is slow, and it has nothing to say about a change that does
-# not move the MongoDB pin. It runs when that pin moves, and on demand.
+# sequence, and it has nothing to say about a change that does not move the
+# MongoDB pin or touch the test itself.
 #
 # What it protects is the case the Integration job cannot see. That job starts
 # every service on an EMPTY volume, so it proves the new image runs; this one
 # starts the PREVIOUS image on a volume, writes a document, swaps the binary
-# underneath, and requires the document and the feature compatibility version
-# to survive before raising the FCV. See scripts/mongo_upgrade_test.sh.
+# underneath, rolls back to the old image on the touched directory, and only
+# then raises the feature compatibility version. See
+# scripts/mongo_upgrade_test.sh.
+#
+# Every value that comes from a GitHub context reaches the shell through `env`
+# and is read as a quoted variable. Interpolating one into the script body
+# would let a dispatch input carrying a newline or a command substitution run
+# as code rather than be read as an image reference.
 name: MongoDB upgrade (persisted volume)
 
 on:
   workflow_dispatch:
     inputs:
       from_image:
-        description: "The image an existing deployment is running, e.g. mongo:8.0.29"
+        description: "The image an existing deployment is running, e.g. mongo:8.0.29@sha256:..."
         required: false
         type: string
       to_image:
@@ -43,39 +49,101 @@ jobs:
           # compose change.
           fetch-depth: 0
 
-      - name: Decide whether the MongoDB pin moved
-        id: pin
+      - name: Decide what to upgrade
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          INPUT_FROM: ${{ inputs.from_image }}
         run: |
           set -euo pipefail
-          current=$(grep -oE 'image: mongo:[^ ]+' Docker/docker-compose.yml | head -1 | cut -d' ' -f2)
-          echo "current=$current" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "run=yes" >> "$GITHUB_OUTPUT"
-            echo "previous=${{ inputs.from_image }}" >> "$GITHUB_OUTPUT"
+          # A value reaching GITHUB_OUTPUT with a newline in it could forge a
+          # second output line, so every image reference is checked against the
+          # shape a reference actually has before it goes anywhere.
+          check_reference() {
+            case "$2" in
+              "") return 0 ;;
+              *) ;;
+            esac
+            if ! printf '%s' "$2" | grep -qE '^mongo:[A-Za-z0-9._-]+(@sha256:[a-f0-9]{64})?$'; then
+              echo "$1 is not a mongo image reference: $2" >&2
+              exit 1
+            fi
+          }
+
+          check_reference "the from_image input" "$INPUT_FROM"
+
+          current=$(grep -oE 'image: mongo:[^ ]+' Docker/docker-compose.yml | head -1 | cut -d' ' -f2 || true)
+          if [ -z "$current" ]; then
+            echo "Could not read the MongoDB pin from Docker/docker-compose.yml." >&2
+            echo "This gate cannot be skipped on a lookup failure: fix the parser or the file." >&2
+            exit 1
+          fi
+          check_reference "the pin in Docker/docker-compose.yml" "$current"
+          printf 'current=%s\n' "$current" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            printf 'run=yes\n' >> "$GITHUB_OUTPUT"
+            printf 'previous=%s\n' "$INPUT_FROM" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          base="${{ github.event.pull_request.base.sha }}"
-          previous=$(git show "$base:Docker/docker-compose.yml" \
+          if [ -z "$BASE_SHA" ]; then
+            echo "No base commit to compare against; refusing to skip silently." >&2
+            exit 1
+          fi
+          previous=$(git show "$BASE_SHA:Docker/docker-compose.yml" \
             | grep -oE 'image: mongo:[^ ]+' | head -1 | cut -d' ' -f2 || true)
-          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          if [ -z "$previous" ]; then
+            echo "Could not read the MongoDB pin from the base commit $BASE_SHA." >&2
+            echo "An undiscoverable pin is a failure, not a skip: it would silently remove this gate." >&2
+            exit 1
+          fi
+          check_reference "the pin in the base commit" "$previous"
+          printf 'previous=%s\n' "$previous" >> "$GITHUB_OUTPUT"
 
-          if [ "$previous" = "$current" ] || [ -z "$previous" ]; then
-            echo "The MongoDB pin did not move ($current); nothing to prove."
-            echo "run=no" >> "$GITHUB_OUTPUT"
+          # The test itself changing is also a reason to run it: the pin has
+          # not moved, so the script's own defaults are what gets exercised.
+          if git diff --name-only "$BASE_SHA" HEAD \
+            | grep -qE '^(scripts/mongo_upgrade_test\.sh|\.github/workflows/mongo-upgrade\.yml)$'; then
+            echo "The upgrade test itself changed; running it against its documented default pair."
+            printf 'run=yes\n' >> "$GITHUB_OUTPUT"
+            printf 'use_defaults=yes\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$previous" = "$current" ]; then
+            echo "The MongoDB pin did not move ($current) and the test did not change."
+            printf 'run=no\n' >> "$GITHUB_OUTPUT"
           else
             echo "The MongoDB pin moved from $previous to $current."
-            echo "run=yes" >> "$GITHUB_OUTPUT"
+            printf 'run=yes\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upgrade a persisted volume
-        if: steps.pin.outputs.run == 'yes'
+        if: steps.plan.outputs.run == 'yes'
+        env:
+          INPUT_FROM: ${{ inputs.from_image }}
+          INPUT_TO: ${{ inputs.to_image }}
+          INPUT_FCV: ${{ inputs.target_fcv }}
+          PLAN_PREVIOUS: ${{ steps.plan.outputs.previous }}
+          PLAN_CURRENT: ${{ steps.plan.outputs.current }}
+          USE_DEFAULTS: ${{ steps.plan.outputs.use_defaults }}
         run: |
           set -euo pipefail
-          from="${{ inputs.from_image || steps.pin.outputs.previous }}"
-          to="${{ inputs.to_image || steps.pin.outputs.current }}"
-          fcv="${{ inputs.target_fcv }}"
+
+          if [ "${USE_DEFAULTS:-}" = "yes" ]; then
+            # The script's own defaults are the documented pair, and they are
+            # what a change to the test has to be exercised against.
+            echo "Running the script with its documented defaults"
+            ./scripts/mongo_upgrade_test.sh
+            exit 0
+          fi
+
+          from="${INPUT_FROM:-$PLAN_PREVIOUS}"
+          to="${INPUT_TO:-$PLAN_CURRENT}"
+          fcv="${INPUT_FCV:-}"
 
           if [ -z "$fcv" ]; then
             # The FCV is the major.minor of the image being upgraded to, which
@@ -83,5 +151,5 @@ jobs:
             fcv=$(printf '%s' "$to" | sed -E 's/^mongo:([0-9]+\.[0-9]+).*/\1/')
           fi
 
-          echo "Upgrading $from to $to, raising the FCV to $fcv"
+          printf 'Upgrading %s to %s, raising the FCV to %s\n' "$from" "$to" "$fcv"
           ./scripts/mongo_upgrade_test.sh "$from" "$to" "$fcv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -83,9 +83,11 @@ services:
     #      easy return
     #      db.adminCommand({setFeatureCompatibilityVersion: "8.2", confirm: true})
     #
-    # Verified on this exact digest against a persisted volume: 8.0.29 with
-    # FCV 8.0, binary swapped, 8.2.12 started, documents intact, FCV still 8.0,
-    # then raised to 8.2. A fresh volume needs none of this.
+    # That sequence is a test, not a paragraph: `make test-mongo-upgrade` runs
+    # it (scripts/mongo_upgrade_test.sh), and CI runs it automatically when
+    # this pin moves. Verified on this exact digest: 8.0.29 with FCV 8.0,
+    # binary swapped, 8.2.12 started, documents intact, FCV still 8.0, then
+    # raised to 8.2. A fresh volume needs none of this.
     image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
     volumes:
       - mongodb-data:/data/db
@@ -127,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.16}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.17}
     deploy:
       replicas: 2
       restart_policy:

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,16 @@ test-integration:
 		echo "OCS_INTEGRATION_BASE_URL is unset: every integration test will skip"
 	LOGLEVEL=WARN cargo test -p examples_integration --all-features -- --nocapture
 
+# Prove an existing MongoDB deployment survives the image this repo pins.
+#
+# Starts the previous image on a volume, writes a document, swaps the binary
+# underneath, and requires the document and the FCV to survive before raising
+# it. Needs docker and pulls two database images, so it is not part of
+# `pre-push`; CI runs it when the MongoDB pin moves.
+.PHONY: test-mongo-upgrade
+test-mongo-upgrade:
+	./scripts/mongo_upgrade_test.sh
+
 # Format the code
 .PHONY: fmt
 fmt:

--- a/scripts/mongo_upgrade_test.sh
+++ b/scripts/mongo_upgrade_test.sh
@@ -14,9 +14,13 @@
 #   1. start the PREVIOUS image on a named volume, write a document, record the
 #      FCV;
 #   2. stop it, start the NEW image on the SAME volume, and require the
-#      document to still be there with the FCV unchanged — this is the
-#      reversible point, both binaries serve that directory;
-#   3. raise the FCV, and require it to take.
+#      document to still be there with the FCV unchanged;
+#   3. PROVE the rollback: stop the new image and start the OLD one again on
+#      the same, now-touched directory, requiring it to become ready with the
+#      data and the FCV intact. An unchanged FCV is not by itself proof that
+#      the old binary can still open a directory the new one has written to;
+#   4. return to the new image and raise the FCV, which is the step that stops
+#      being reversible.
 #
 # ClickHouse is deliberately NOT covered here. Its data directory carries its
 # own expectations, but it has no equivalent of the FCV handshake: the server
@@ -32,7 +36,10 @@
 
 set -euo pipefail
 
-FROM_IMAGE="${1:-mongo:8.0.29}"
+# Pinned by digest, like everything else in this repository: a mutable tag can
+# be republished, and then the test proves an upgrade path from bytes nobody
+# ships. This is the digest the compose file carried before the bump.
+FROM_IMAGE="${1:-mongo:8.0.29@sha256:de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06}"
 TO_IMAGE="${2:-mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3}"
 TARGET_FCV="${3:-8.2}"
 
@@ -111,10 +118,36 @@ SURVIVED=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()")
 
 FCV_AFTER_SWAP=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
 [ "$FCV_AFTER_SWAP" = "$FCV_BEFORE" ] || \
-    fail "the swap moved the FCV from $FCV_BEFORE to $FCV_AFTER_SWAP; it must stay put, that is what makes this step reversible"
-echo "   document intact, FCV still $FCV_AFTER_SWAP, so the old image could still take over"
+    fail "the swap moved the FCV from $FCV_BEFORE to $FCV_AFTER_SWAP; it must stay put, or the rollback below cannot work"
+echo "   document intact, FCV still $FCV_AFTER_SWAP"
 
-echo "== 3. raising the feature compatibility version"
+echo "== 3. rolling back to $FROM_IMAGE on the touched volume"
+# The claim being tested is that step 2 is reversible. An unchanged FCV does
+# not establish that: the new binary has opened the directory and may have
+# written to it. The only proof is putting the old image back.
+docker stop "$CONTAINER" >/dev/null
+sleep 2
+start_on_volume "$FROM_IMAGE"
+wait_for_mongo "$FROM_IMAGE (rollback)"
+
+ROLLBACK_VERSION=$(mongosh_eval 'db.version()')
+[ "$ROLLBACK_VERSION" = "$FROM_VERSION" ] || \
+    fail "the rollback is running $ROLLBACK_VERSION rather than $FROM_VERSION"
+
+ROLLED_BACK=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()")
+[ "$ROLLED_BACK" = "1" ] || fail "the document did not survive the rollback, count was $ROLLED_BACK"
+
+FCV_ROLLBACK=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
+[ "$FCV_ROLLBACK" = "$FCV_BEFORE" ] || \
+    fail "the rollback reports FCV $FCV_ROLLBACK rather than $FCV_BEFORE"
+echo "   $ROLLBACK_VERSION came back up on the touched directory, document intact, FCV $FCV_ROLLBACK"
+
+echo "== 4. returning to $TO_IMAGE and raising the feature compatibility version"
+docker stop "$CONTAINER" >/dev/null
+sleep 2
+start_on_volume "$TO_IMAGE"
+wait_for_mongo "$TO_IMAGE (second time)"
+
 mongosh_eval "db.adminCommand({setFeatureCompatibilityVersion: '$TARGET_FCV', confirm: true})" >/dev/null
 FCV_FINAL=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
 [ "$FCV_FINAL" = "$TARGET_FCV" ] || fail "the FCV is $FCV_FINAL after asking for $TARGET_FCV"
@@ -124,4 +157,4 @@ STILL_THERE=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()
 
 echo "   FCV $FCV_FINAL, document intact"
 echo
-echo "PASS: $FROM_VERSION to $TO_VERSION on a persisted volume, FCV $FCV_BEFORE to $FCV_FINAL"
+echo "PASS: $FROM_VERSION to $TO_VERSION on a persisted volume, rollback to $FROM_VERSION proven, FCV $FCV_BEFORE to $FCV_FINAL"

--- a/scripts/mongo_upgrade_test.sh
+++ b/scripts/mongo_upgrade_test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Proves that an EXISTING MongoDB deployment survives the upgrade the compose
+# file pins.
+#
+# The Integration job starts every service container on an empty volume, so it
+# proves the new image runs and says nothing about a data directory that
+# already exists. That is where MongoDB upgrades actually fail: the directory
+# carries a feature compatibility version, a binary refuses one above its own,
+# and raising it is the step that stops being reversible.
+#
+# The sequence, which is the documented procedure executed rather than read:
+#
+#   1. start the PREVIOUS image on a named volume, write a document, record the
+#      FCV;
+#   2. stop it, start the NEW image on the SAME volume, and require the
+#      document to still be there with the FCV unchanged — this is the
+#      reversible point, both binaries serve that directory;
+#   3. raise the FCV, and require it to take.
+#
+# ClickHouse is deliberately NOT covered here. Its data directory carries its
+# own expectations, but it has no equivalent of the FCV handshake: the server
+# migrates its metadata on start and refuses to start on a directory written by
+# a newer build, which is a failure an operator sees immediately rather than a
+# silent one weeks later. If that changes, this script is the shape to copy.
+#
+# Usage:
+#   scripts/mongo_upgrade_test.sh [FROM_IMAGE] [TO_IMAGE] [TARGET_FCV]
+#
+# The defaults are the previous and current pins. Pass them explicitly when
+# bumping so the test runs against the two images the bump moves between.
+
+set -euo pipefail
+
+FROM_IMAGE="${1:-mongo:8.0.29}"
+TO_IMAGE="${2:-mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3}"
+TARGET_FCV="${3:-8.2}"
+
+VOLUME="ocs-mongo-upgrade-$$"
+CONTAINER="ocs-mongo-upgrade-$$"
+USER_NAME="admin"
+PASSWORD="password"
+PROBE_DB="ocs_upgrade_probe"
+
+cleanup() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker volume rm -f "$VOLUME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Runs one mongosh expression and prints its last line.
+mongosh_eval() {
+    docker exec "$CONTAINER" mongosh -u "$USER_NAME" -p "$PASSWORD" --quiet --eval "$1" 2>/dev/null | tail -1
+}
+
+# Waits for the container to answer, or gives up with the log.
+wait_for_mongo() {
+    local label="$1"
+    for _ in $(seq 1 60); do
+        if docker exec "$CONTAINER" mongosh -u "$USER_NAME" -p "$PASSWORD" --quiet --eval 'db.version()' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "FAIL: $label never became ready" >&2
+    docker logs "$CONTAINER" 2>&1 | tail -30 >&2
+    exit 1
+}
+
+start_on_volume() {
+    local image="$1"
+    docker run -d --rm \
+        --name "$CONTAINER" \
+        -v "$VOLUME:/data/db" \
+        -e MONGO_INITDB_ROOT_USERNAME="$USER_NAME" \
+        -e MONGO_INITDB_ROOT_PASSWORD="$PASSWORD" \
+        "$image" >/dev/null
+}
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+echo "== 1. seeding $FROM_IMAGE on a fresh volume"
+docker volume create "$VOLUME" >/dev/null
+start_on_volume "$FROM_IMAGE"
+wait_for_mongo "$FROM_IMAGE"
+
+FROM_VERSION=$(mongosh_eval 'db.version()')
+echo "   running $FROM_VERSION"
+
+mongosh_eval "db.getSiblingDB('$PROBE_DB').events.insertOne({probe: 'upgrade', at: new Date()})" >/dev/null
+SEEDED=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()")
+[ "$SEEDED" = "1" ] || fail "the probe document was not written, count was $SEEDED"
+
+FCV_BEFORE=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
+echo "   seeded one document, FCV $FCV_BEFORE"
+
+echo "== 2. swapping the binary under the same volume"
+docker stop "$CONTAINER" >/dev/null
+sleep 2
+start_on_volume "$TO_IMAGE"
+wait_for_mongo "$TO_IMAGE"
+
+TO_VERSION=$(mongosh_eval 'db.version()')
+echo "   running $TO_VERSION"
+
+SURVIVED=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()")
+[ "$SURVIVED" = "1" ] || fail "the document did not survive the swap, count was $SURVIVED"
+
+FCV_AFTER_SWAP=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
+[ "$FCV_AFTER_SWAP" = "$FCV_BEFORE" ] || \
+    fail "the swap moved the FCV from $FCV_BEFORE to $FCV_AFTER_SWAP; it must stay put, that is what makes this step reversible"
+echo "   document intact, FCV still $FCV_AFTER_SWAP, so the old image could still take over"
+
+echo "== 3. raising the feature compatibility version"
+mongosh_eval "db.adminCommand({setFeatureCompatibilityVersion: '$TARGET_FCV', confirm: true})" >/dev/null
+FCV_FINAL=$(mongosh_eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version')
+[ "$FCV_FINAL" = "$TARGET_FCV" ] || fail "the FCV is $FCV_FINAL after asking for $TARGET_FCV"
+
+STILL_THERE=$(mongosh_eval "db.getSiblingDB('$PROBE_DB').events.countDocuments()")
+[ "$STILL_THERE" = "1" ] || fail "the document was lost raising the FCV, count was $STILL_THERE"
+
+echo "   FCV $FCV_FINAL, document intact"
+echo
+echo "PASS: $FROM_VERSION to $TO_VERSION on a persisted volume, FCV $FCV_BEFORE to $FCV_FINAL"


### PR DESCRIPTION
Closes #130

Base branch: `stack/2-119-v1-rejection-shape`
Stacked on: #132
Stack: #117 → #119 → **#130** (last)

The three issues are independent; the diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## Why

The Integration job starts every service container on an **empty volume**. That proves the new image runs and says nothing about upgrading a deployment that already holds data, which is exactly where MongoDB upgrades fail: the data directory carries a feature compatibility version, a binary refuses a directory whose FCV is above it, and raising the FCV is the step that stops being reversible.

For #116 I ran that procedure by hand. This makes it a test, so the next bump cannot skip it.

## What it does

`scripts/mongo_upgrade_test.sh`, in three steps that each fail loudly with the container log rather than hanging:

1. seed the **previous** image on a named volume with a document, record the FCV
2. stop it, start the **new** image on the same volume, and require the document to still be there **and the FCV to be unchanged** — this is the reversible point, both binaries serve that directory
3. raise the FCV and require it to take, with the document still intact

`make test-mongo-upgrade` runs it locally. The workflow runs it when the MongoDB pin in `Docker/docker-compose.yml` actually moves, which it detects by comparing the pin against the pull request's base, and on demand with explicit images. Not on every push: it pulls two database images and has nothing to say about a change that leaves the pin alone.

## A decision I took

ClickHouse is **not** covered, and the reason is written into the script rather than left implicit: it has no FCV handshake. A data directory written by a newer build makes the server refuse to start, which an operator sees immediately rather than discovering weeks later. If that ever changes, the script is the shape to copy.

## Verified

Run locally against the exact pins this repo carries:

```
PASS: 8.0.29 to 8.2.12 on a persisted volume, FCV 8.0 to 8.2
```

## Checklist

- [x] Runs the previous pinned image, swaps to the new one on the same volume, asserts the document, the FCV before the raise, and the raise
- [x] Runs on a MongoDB pin bump rather than every push, plus `workflow_dispatch`
- [x] ClickHouse considered, with the reason for leaving it out recorded
- [x] No library change; `make pre-push` clean, zero warnings
- [x] Patch version bumped to 0.2.17 with the compose image tag
