### PR TITLE
Serve the favicon from the binary, and stop assuming one process in the metrics test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all
@@ -40,7 +40,6 @@ csv = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 actix-web = { workspace = true }
-actix-files = { workspace = true }
 redis = { workspace = true }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
@@ -84,7 +83,6 @@ clickhouse = "0.15"
 tokio = { version = "1.53", features = ["full"] }
 async-trait = "0.1"
 actix-web = { version = "4.15", features = ["rustls"] }
-actix-files = "0.7"
 redis = { version = "1.6", features = ["tokio-comp", "connection-manager"] }
 # actix_extras is unavailable: optionstratlib enables utoipa/axum_extras,
 # and utoipa's framework extras are mutually exclusive

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.17}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.18}
     deploy:
       replicas: 2
       restart_policy:

--- a/examples/integration/tests/operational.rs
+++ b/examples/integration/tests/operational.rs
@@ -75,7 +75,8 @@ fn test_metrics_expose_the_documented_counters_and_move() {
     // Three requests that land on exactly that series: a well-formed id that
     // cannot exist is a 404 from the v1 route.
     let absent = "/api/v1/chain?sessionid=00000000-0000-4000-8000-000000000000";
-    for _ in 0..3 {
+    let requests = 3;
+    for _ in 0..requests {
         match client.get(absent) {
             Ok(response) => assert_eq!(
                 response.status,
@@ -93,12 +94,30 @@ fn test_metrics_expose_the_documented_counters_and_move() {
         Ok(response) => sample(&response.text(), series).unwrap_or(0.0),
         Err(error) => panic!("{error}"),
     };
+    let moved = after - before;
 
-    assert_eq!(
-        after - before,
-        3.0,
-        "three requests on {series} must move it by three, it went {before} to {after}"
+    // A counter is per PROCESS, and a deployment may run several behind one
+    // address: this suite found exactly that, two replicas answering in turn,
+    // where three requests and the scrape after them land on whichever
+    // instance the balancer picked. So the assertion is what holds for one
+    // instance or many — the series moved, and by no more than the traffic
+    // this test generated — rather than an exact delta that only holds on a
+    // single-process deployment.
+    assert!(
+        moved >= 1.0,
+        "three requests moved {series} by {moved}; a served request must be counted somewhere"
     );
+    assert!(
+        moved <= f64::from(requests),
+        "{series} moved {moved} for {requests} requests, which is more traffic than this test \
+         produced"
+    );
+    if moved < f64::from(requests) {
+        println!(
+            "INFO: {series} moved {moved} for {requests} requests, so this deployment serves \
+             them from more than one process; a scrape sees one instance at a time"
+        );
+    }
 }
 
 /// One exact series, or `None` when the exposition does not carry it.

--- a/src/api/rest/favicon.rs
+++ b/src/api/rest/favicon.rs
@@ -1,52 +1,92 @@
-use actix_files::NamedFile;
-use std::error::Error;
-use std::path::PathBuf;
+use actix_web::{HttpResponse, Responder, http::header};
 
-/// Asynchronously retrieves the favicon of the application.
+/// The icon itself, compiled into the binary.
 ///
-/// This function attempts to open and return the favicon file located
-/// at the path `static/favicon.ico`. If the file is successfully found,
-/// it is returned wrapped as a `NamedFile`. Otherwise, an error is returned.
+/// It used to be read from `static/favicon.ico` at request time, which made
+/// the route depend on the process's working directory. No container image
+/// ships that directory, so every containerised deployment answered **500**
+/// with `No such file or directory (os error 2)` as the body: a filesystem
+/// error handed to whoever asked for a picture.
 ///
-/// # Returns
-/// * `Ok(NamedFile)` - The favicon file wrapped in a `NamedFile` if found.
-/// * `Err(Box<dyn Error>)` - An error wrapped in a `Box` if the file
-///   could not be opened or does not exist.
+/// Embedding removes the failure rather than handling it. There is no path to
+/// get wrong, no working directory to be in, and nothing for a deployment to
+/// forget to copy.
+const FAVICON: &[u8] = include_bytes!("../../../static/favicon.ico");
+
+/// How long a browser may keep it. The icon changes when the binary does, so
+/// a day is safe and saves a request per visitor per day.
+const CACHE_CONTROL: &str = "public, max-age=86400";
+
+/// Serves the application icon.
 ///
-/// # Errors
-/// This function will return an error if:
-/// - The `static/favicon.ico` path does not exist or is inaccessible.
-/// - Any issues occur during the file opening process.
-///
-pub(crate) async fn get_favicon() -> Result<NamedFile, Box<dyn Error>> {
-    let path: PathBuf = "static/favicon.ico".into();
-    Ok(NamedFile::open(path)?)
+/// Always succeeds: the bytes are part of the binary.
+pub(crate) async fn get_favicon() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("image/x-icon")
+        .insert_header((header::CACHE_CONTROL, CACHE_CONTROL))
+        .body(FAVICON)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::path::PathBuf;
+    use actix_web::body::MessageBody;
+    use actix_web::http::StatusCode;
 
-    /// Test that an error is returned when the favicon file is missing.
-    #[tokio::test]
-    async fn test_get_favicon_not_found() {
-        // Arrange: rename the file out of the way
-        let original = PathBuf::from("static/favicon.ico");
-        let temp = PathBuf::from("static/favicon_temp.ico");
-        fs::rename(&original, &temp).expect("Failed to rename favicon.ico for the test");
+    /// The icon is served, whatever the working directory is.
+    ///
+    /// The previous version of this test renamed a file on disk to prove the
+    /// handler failed without it. That failure is what a deployment actually
+    /// met, so the behaviour it asserted is gone and so is the test.
+    #[actix_web::test]
+    async fn test_the_favicon_is_served_from_the_binary() {
+        let response = get_favicon().await;
+        let response =
+            response.respond_to(&actix_web::test::TestRequest::default().to_http_request());
 
-        // Act
-        let result = get_favicon().await;
-
-        // Assert
-        assert!(
-            result.is_err(),
-            "get_favicon should return an Err when the file is missing"
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("image/x-icon")
         );
 
-        // Cleanup: put the file back
-        fs::rename(&temp, &original).expect("Failed to restore favicon.ico after the test");
+        match response.into_body().try_into_bytes() {
+            Ok(bytes) => {
+                assert!(!bytes.is_empty(), "the icon must carry bytes");
+                assert_eq!(bytes.len(), FAVICON.len());
+            }
+            Err(_) => panic!("the icon body must be readable in one piece"),
+        }
+    }
+
+    /// It does not depend on where the process was started from, which is the
+    /// whole point of the change.
+    #[actix_web::test]
+    async fn test_the_favicon_does_not_depend_on_the_working_directory() {
+        let elsewhere = std::env::temp_dir();
+        let original = match std::env::current_dir() {
+            Ok(original) => original,
+            Err(error) => panic!("the working directory must be readable: {error}"),
+        };
+
+        if std::env::set_current_dir(&elsewhere).is_err() {
+            // A sandbox that refuses the change cannot exercise this; the
+            // assertion above already covers the happy path.
+            return;
+        }
+        let response = get_favicon().await;
+        let response =
+            response.respond_to(&actix_web::test::TestRequest::default().to_http_request());
+        let status = response.status();
+        let _ = std::env::set_current_dir(original);
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the icon must serve from a directory that has no static/ in it"
+        );
     }
 }


### PR DESCRIPTION
Found by running the integration suite against the deployed **0.2.17**, which is exactly what that suite is for.

## 1. `/favicon.ico` answers 500 on every containerised deployment

```
$ curl -i http://<deployment>/favicon.ico
HTTP/1.1 500 Internal Server Error

No such file or directory (os error 2)
```

The handler opened `static/favicon.ico` **relative to the process's working directory**, and no container image ships `static/`. So it is not "the icon is missing on that host": it fails the same way on every containerised deployment, and hands a filesystem error string to whoever asked for a picture.

The icon is compiled into the binary now. That removes the failure rather than handling it: no path to get wrong, no working directory to be in, nothing for a deployment to forget to copy. `actix-files` was in the dependency list for this handler alone and goes with it.

The old unit test renamed a file on disk to assert the handler failed without it; that failure is what the deployment met, so the behaviour and the test are gone. Two tests replace it: the icon is served, and it is served from a working directory that has no `static/` in it.

## 2. The metrics test assumed one process; the deployment runs two

The counter assertion required an exact delta of three for three requests. Scraping the deployment repeatedly shows why that cannot hold:

```
api_requests_total{endpoint="/metrics",...} 4
api_requests_total{endpoint="/metrics",...} 8
api_requests_total{endpoint="/metrics",...} 5
api_requests_total{endpoint="/metrics",...} 9
```

Two replicas answering in turn, each counting its own traffic. The assertion is now what holds for one instance or many — the series moved, and by no more than the traffic this test produced — and it prints a line when it sees fewer, which is how a replicated deployment announces itself to whoever reads the output.

That `/metrics` behind a load-balanced pair returns alternating half-truths is a real operational problem for anything scraping it, and it is filed separately rather than papered over here.

## Checklist

- [x] Reproducibility, stored-session shape and REST DTOs untouched
- [x] One dependency removed, none added
- [x] `make pre-push` clean, zero warnings, 929 tests
- [x] Verified against the deployment: the metrics test now passes there and reports the replication; the favicon test stays red until this ships, which is correct
- [x] Patch version bumped to 0.2.18 with the compose image tag
