### PR TITLE
Say that metrics belong to the instance that answers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,17 +175,20 @@ OCS_MAX_SNAPSHOT_CONTRACTS=200000
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Every knob in this file configures ONE process. Session and simulation state
-# is shared through Redis, and every write there is an atomic script, so
-# replicas serve one consistent tape; but the per-process caps and caches are
-# not divided among them:
+# is shared through Redis, and the cursor commit that decides who advanced a
+# session is an atomic compare-and-swap script, so replicas serve one
+# consistent tape; but the per-process caps and caches are not divided among
+# them:
 #
 #   * OCS_MAX_CONCURRENT_PRICING_JOBS bounds one instance, so N replicas allow
 #     N times that many pricing jobs at once (issue #135).
 #   * The tape and snapshot caches are per instance, so a step served by a
 #     different replica rebuilds what its neighbour already built (issue #136).
 #   * /metrics serves the metrics of the instance that answers. Scrape each
-#     replica as its own target and sum across the instance label; scraping a
-#     load-balanced address returns one instance at a time (issue #138).
+#     replica as its own target; counters and histograms aggregate as
+#     sum(rate(..)) across the instance label, gauges such as active_sessions
+#     do not and stay per instance. Scraping a load-balanced address returns
+#     one instance at a time (issue #138).
 
 # Maximum contracts held resident across every cached v2 snapshot. This is the
 # bound that protects memory — OCS_MAX_CACHED_SNAPSHOTS bounds the map, and one

--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,23 @@ OCS_MAX_CACHED_SNAPSHOTS=256
 # Range: 1 .. 10000000.  Default: 200000
 OCS_MAX_SNAPSHOT_CONTRACTS=200000
 
+# ─────────────────────────────────────────────────────────────────────────────
+# A note on running more than one instance
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Every knob in this file configures ONE process. Session and simulation state
+# is shared through Redis, and every write there is an atomic script, so
+# replicas serve one consistent tape; but the per-process caps and caches are
+# not divided among them:
+#
+#   * OCS_MAX_CONCURRENT_PRICING_JOBS bounds one instance, so N replicas allow
+#     N times that many pricing jobs at once (issue #135).
+#   * The tape and snapshot caches are per instance, so a step served by a
+#     different replica rebuilds what its neighbour already built (issue #136).
+#   * /metrics serves the metrics of the instance that answers. Scrape each
+#     replica as its own target and sum across the instance label; scraping a
+#     load-balanced address returns one instance at a time (issue #138).
+
 # Maximum contracts held resident across every cached v2 snapshot. This is the
 # bound that protects memory — OCS_MAX_CACHED_SNAPSHOTS bounds the map, and one
 # entry is a few hundred contracts in the reference configuration and hundreds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,8 +129,18 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.18}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.19}
     deploy:
+      # More than one instance is the intended shape: session and simulation
+      # state lives in Redis and every write there is an atomic Lua script, so
+      # two instances cannot both commit the same step.
+      #
+      # What does NOT aggregate is what each process holds. `/metrics` serves
+      # the metrics of whichever replica answers, so scraping this published
+      # port gives one instance at a time and a counter that appears to reset;
+      # scrape each replica as its own target and sum across the instance
+      # label. The pricing admission cap (#135) and the tape and snapshot
+      # caches (#136) are per instance for the same reason.
       replicas: 2
       restart_policy:
         condition: any

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -132,15 +132,18 @@ services:
     image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.19}
     deploy:
       # More than one instance is the intended shape: session and simulation
-      # state lives in Redis and every write there is an atomic Lua script, so
-      # two instances cannot both commit the same step.
+      # state lives in Redis, and the write that decides who advanced a
+      # session is a compare-and-swap in a Lua script, so two instances cannot
+      # both commit the same step.
       #
       # What does NOT aggregate is what each process holds. `/metrics` serves
       # the metrics of whichever replica answers, so scraping this published
-      # port gives one instance at a time and a counter that appears to reset;
-      # scrape each replica as its own target and sum across the instance
-      # label. The pricing admission cap (#135) and the tape and snapshot
-      # caches (#136) are per instance for the same reason.
+      # port gives one instance at a time and a counter that appears to reset.
+      # Scrape each replica as its own target: counters and histograms then
+      # aggregate as sum(rate(..)) across the instance label, while gauges
+      # such as active_sessions stay per instance and are not a deployment
+      # total under any aggregation. The pricing admission cap (#135) and the
+      # tape and snapshot caches (#136) are per instance for the same reason.
       replicas: 2
       restart_policy:
         condition: any

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ counter reset, so `rate()` over such a series is not wrong so much as
 meaningless. A single scrape endpoint for a whole deployment is an
 aggregator's job, not something this service pretends to do.
 
+What aggregates and what does not depends on the kind of metric. Counters
+and histograms do, as `sum(rate(..))` across the instance label. Gauges do
+not: `active_sessions` is each process's own count, and a session created
+through one replica and deleted through another leaves the first replica's
+gauge untouched, as do reaps and restarts. The live-session total is a
+question for the store, not for a gauge.
+
 The same is true of anything else the process holds: the pricing admission
 semaphore bounds one instance (issue #135), and the tape and snapshot
 caches are per instance too (issue #136). None of that affects what a

--- a/README.md
+++ b/README.md
@@ -222,6 +222,37 @@ down. `Docker/docker-compose.yml` points its backend healthcheck at
 `/ready`, so `docker compose up -d` reports the service healthy only once it
 can actually serve.
 
+#### Metrics are per process
+
+`/metrics` serves the metrics of the INSTANCE that answers. That is what a
+Prometheus exposition is, and it is worth stating because this service is
+meant to run replicated: the numbers there are one instance's share of the
+traffic, never the deployment's total.
+
+So a replicated deployment is scraped **per replica**, each container its
+own target with its own `instance` label, and totals come from summing
+across that label. Scraping one load-balanced address instead returns
+whichever replica answered that scrape, which looks like this:
+
+```
+api_requests_total{endpoint="/metrics",method="GET",status="200"} 4
+api_requests_total{endpoint="/metrics",method="GET",status="200"} 8
+api_requests_total{endpoint="/metrics",method="GET",status="200"} 5
+api_requests_total{endpoint="/metrics",method="GET",status="200"} 9
+```
+
+Two replicas answering in turn. Prometheus reads every apparent drop as a
+counter reset, so `rate()` over such a series is not wrong so much as
+meaningless. A single scrape endpoint for a whole deployment is an
+aggregator's job, not something this service pretends to do.
+
+The same is true of anything else the process holds: the pricing admission
+semaphore bounds one instance (issue #135), and the tape and snapshot
+caches are per instance too (issue #136). None of that affects what a
+client is SERVED — the stores are shared and every write goes through an
+atomic Redis script — only how much work the deployment repeats and how its
+numbers must be read.
+
 **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the
 cursor and then advances it, so a session with `steps = N` serves EXACTLY indices

--- a/src/api/rest/middleware.rs
+++ b/src/api/rest/middleware.rs
@@ -2,11 +2,24 @@ use crate::infrastructure::MetricsCollector;
 use actix_web::{HttpResponse, Responder, web};
 use std::sync::Arc;
 
+/// Serves this INSTANCE's metrics, in the Prometheus text format.
+///
+/// Every counter, gauge and histogram here belongs to the process that
+/// answers, which is normal and correct for a Prometheus exposition and is the
+/// thing to remember when the service runs replicated: the numbers are not a
+/// deployment total, they are one instance's share of it.
+///
+/// A deployment behind one published port therefore has to be scraped **per
+/// replica**, each as its own target with its own instance label. Scraping the
+/// balanced address instead returns whichever instance answered, so a counter
+/// appears to jump up and down between scrapes, Prometheus reads each drop as
+/// a counter reset, and every `rate()` over it is fiction. Summing across the
+/// instance label is what produces a deployment total.
 #[utoipa::path(
     get,
     path = "/metrics",
     responses(
-        (status = 200, description = "Prometheus metrics", content_type = "text/plain")
+        (status = 200, description = "This instance's Prometheus metrics. Counters are PER PROCESS: a replicated deployment must be scraped per replica, each as its own target with an instance label, and totalled by summing across that label. Scraping a load-balanced address returns one instance at a time, which reads as a counter reset.", content_type = "text/plain")
     )
 )]
 pub(crate) async fn metrics_endpoint(

--- a/src/api/rest/middleware.rs
+++ b/src/api/rest/middleware.rs
@@ -13,13 +13,28 @@ use std::sync::Arc;
 /// replica**, each as its own target with its own instance label. Scraping the
 /// balanced address instead returns whichever instance answered, so a counter
 /// appears to jump up and down between scrapes, Prometheus reads each drop as
-/// a counter reset, and every `rate()` over it is fiction. Summing across the
-/// instance label is what produces a deployment total.
+/// a counter reset, and every `rate()` over it is fiction.
+///
+/// How to aggregate depends on what the metric is, and only counters and
+/// histograms aggregate cleanly:
+///
+/// - **counters** (`api_requests_total`, `api_errors_total`,
+///   `session_creations_total`, the cache counters) and **histograms**
+///   (`api_request_duration_seconds`): take the rate per instance and sum, the
+///   usual `sum(rate(...))`. Summing raw counter values across restarts is not
+///   the same thing.
+/// - **gauges** (`active_sessions`, `simulation_cache_size`,
+///   `memory_usage_bytes`): each is that PROCESS's own view. `active_sessions`
+///   in particular is not a deployment total under any aggregation: a create
+///   served by one replica and a delete served by another leave the first
+///   replica's gauge untouched, and neither reaps nor restarts move it. Read
+///   them per instance; the authoritative live-session count is the store's,
+///   not a metric's.
 #[utoipa::path(
     get,
     path = "/metrics",
     responses(
-        (status = 200, description = "This instance's Prometheus metrics. Counters are PER PROCESS: a replicated deployment must be scraped per replica, each as its own target with an instance label, and totalled by summing across that label. Scraping a load-balanced address returns one instance at a time, which reads as a counter reset.", content_type = "text/plain")
+        (status = 200, description = "This instance's Prometheus metrics. Every series is PER PROCESS: a replicated deployment must be scraped per replica, each as its own target with an instance label. Counters and histograms aggregate as sum(rate(..)) across instances; gauges such as active_sessions do NOT, since a create and a delete served by different replicas leave each gauge partial. Scraping a load-balanced address returns one instance at a time, which reads as a counter reset.", content_type = "text/plain")
     )
 )]
 pub(crate) async fn metrics_endpoint(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,13 @@
 //! meaningless. A single scrape endpoint for a whole deployment is an
 //! aggregator's job, not something this service pretends to do.
 //!
+//! What aggregates and what does not depends on the kind of metric. Counters
+//! and histograms do, as `sum(rate(..))` across the instance label. Gauges do
+//! not: `active_sessions` is each process's own count, and a session created
+//! through one replica and deleted through another leaves the first replica's
+//! gauge untouched, as do reaps and restarts. The live-session total is a
+//! question for the store, not for a gauge.
+//!
 //! The same is true of anything else the process holds: the pricing admission
 //! semaphore bounds one instance (issue #135), and the tape and snapshot
 //! caches are per instance too (issue #136). None of that affects what a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,37 @@
 //! `/ready`, so `docker compose up -d` reports the service healthy only once it
 //! can actually serve.
 //!
+//! ### Metrics are per process
+//!
+//! `/metrics` serves the metrics of the INSTANCE that answers. That is what a
+//! Prometheus exposition is, and it is worth stating because this service is
+//! meant to run replicated: the numbers there are one instance's share of the
+//! traffic, never the deployment's total.
+//!
+//! So a replicated deployment is scraped **per replica**, each container its
+//! own target with its own `instance` label, and totals come from summing
+//! across that label. Scraping one load-balanced address instead returns
+//! whichever replica answered that scrape, which looks like this:
+//!
+//! ```text
+//! api_requests_total{endpoint="/metrics",method="GET",status="200"} 4
+//! api_requests_total{endpoint="/metrics",method="GET",status="200"} 8
+//! api_requests_total{endpoint="/metrics",method="GET",status="200"} 5
+//! api_requests_total{endpoint="/metrics",method="GET",status="200"} 9
+//! ```
+//!
+//! Two replicas answering in turn. Prometheus reads every apparent drop as a
+//! counter reset, so `rate()` over such a series is not wrong so much as
+//! meaningless. A single scrape endpoint for a whole deployment is an
+//! aggregator's job, not something this service pretends to do.
+//!
+//! The same is true of anything else the process holds: the pricing admission
+//! semaphore bounds one instance (issue #135), and the tape and snapshot
+//! caches are per instance too (issue #136). None of that affects what a
+//! client is SERVED — the stores are shared and every write goes through an
+//! atomic Redis script — only how much work the deployment repeats and how its
+//! numbers must be read.
+//!
 //! **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 //! of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the
 //! cursor and then advances it, so a session with `steps = N` serves EXACTLY indices


### PR DESCRIPTION
Closes #138

Base branch: `main`
Blocks: #141

Stack: **#138** → #139 → #136 → #135 → #137 (this is the first)

Only one hard dependency exists in this chain, the one #137 declares: the build lock needs the shared cache from #136. **#138, #139 and #135 are independent** of everything else and could each be a PR off `main`.

## Why

Running the suite against the two-replica deployment showed a counter moving by one for three requests. Scraping the published port repeatedly explains it:

```
api_requests_total{endpoint="/metrics",method="GET",status="200"} 4
api_requests_total{endpoint="/metrics",method="GET",status="200"} 8
api_requests_total{endpoint="/metrics",method="GET",status="200"} 5
api_requests_total{endpoint="/metrics",method="GET",status="200"} 9
```

Two replicas answering in turn, each counting its own traffic. Nothing about the metrics is broken; an exposition is per process by definition. What was missing is the instruction that follows: **scrape each replica as its own target and sum across the instance label**. Scraping the balanced address makes Prometheus read every apparent drop as a counter reset, and `rate()` over that is not so much wrong as meaningless.

## Where it now says so

The four places someone meets it: the `/metrics` handler and its OpenAPI description, the crate docs (so it reaches the README), `Docker/docker-compose.yml` right next to `replicas: 2`, and `.env.example`.

The same note names the other two per-process things worth knowing — the pricing admission cap (#135) and the tape and snapshot caches (#136) — and states plainly that **neither changes what a client is served**: session and simulation state lives in Redis and every write there is an atomic Lua script, so two instances cannot both commit the same step. What they cost is duplicated work, not correctness.

## Checklist

- [x] No behaviour change; documentation only
- [x] Reproducibility, stored-session shape and DTOs untouched
- [x] `make pre-push` clean, zero warnings; `README.md` regenerated
- [x] Patch version bumped to 0.2.19 with the compose image tag

