### PR TITLE
Cover what a client sees when replicas answer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,3 +341,12 @@ CLICKHOUSE_PASSWORD=password
 #
 # Where your deployment lives is your configuration; do not commit it.
 # OCS_INTEGRATION_BASE_URL=http://localhost:7070
+
+# The replicas' own addresses, comma-separated, bypassing the balancer.
+#
+# Some contracts cannot be checked through a balanced address at all: "this
+# replica answers readiness for itself" needs a way to reach that replica, and
+# a single-instance baseline tape cannot be walked through a balancer. The
+# tests that need it skip and say so when this is unset; the rest run either
+# way.
+# OCS_INTEGRATION_INSTANCE_URLS=http://localhost:7071,http://localhost:7072

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.19}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.20}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a

--- a/README.md
+++ b/README.md
@@ -540,6 +540,12 @@ version it found and skips a feature that is not deployed yet rather than
 failing it. And it is shared, so every test deletes the simulations it
 creates, including when it fails.
 
+Every response carries `x-ocs-instance`, an opaque identity fixed for the
+life of the process, so an operator can tell which replica served a request
+and the suite can prove it exercised more than one rather than assuming it.
+`OCS_INTEGRATION_INSTANCE_URLS` names the replicas' own addresses for the
+checks that need a known one.
+
 The harness carries **no HTTP client dependency**: it speaks HTTP/1.1 over
 `std::net` itself. The consequence worth knowing before pointing it
 somewhere is that `OCS_INTEGRATION_BASE_URL` must be a plain `http://`

--- a/examples/integration/src/lib.rs
+++ b/examples/integration/src/lib.rs
@@ -616,59 +616,70 @@ pub fn report_cleanup(client: &ServiceClient, path: &str, what: &str) {
     }
 }
 
-/// How many distinct processes answered `scrapes` scrapes of `/metrics`.
-///
-/// A counter is per process and only ever grows, so one instance produces a
-/// non-decreasing sequence of scrapes. N instances taking turns produce N such
-/// sequences INTERLEAVED, which reads as a series that keeps stepping
-/// backwards. The instance count is therefore the smallest number of
-/// non-decreasing sequences the observations can be split into, which is what
-/// the greedy pass below computes.
-///
-/// It is a lower bound: two instances that happen to hold the same value are
-/// indistinguishable from one. It never overcounts, which is what matters for
-/// a number this suite only reports.
-pub fn instances_behind(client: &ServiceClient, scrapes: usize) -> usize {
-    let series = "api_requests_total{endpoint=\"/metrics\",method=\"GET\",status=\"200\"}";
-    let mut observed = Vec::new();
+/// The header every response of this service carries, naming the process that
+/// produced it.
+pub const INSTANCE_HEADER: &str = "x-ocs-instance";
 
-    for _ in 0..scrapes {
-        let body = match client.get("/metrics") {
-            Ok(response) => {
-                assert_eq!(response.status, 200, "/metrics must answer 200");
-                response.text()
-            }
+/// The variable naming the individual replicas, when an operator has them.
+///
+/// Comma-separated base URLs, one per instance, bypassing the balancer. Some
+/// contracts cannot be checked through a balanced address at all — "this
+/// replica answers for itself" needs a way to reach that replica — and this is
+/// how a test gets one. Unset, those tests skip and say why.
+pub const INSTANCE_URLS_VARIABLE: &str = "OCS_INTEGRATION_INSTANCE_URLS";
+
+/// The instance that produced a response, if it said.
+///
+/// A deployment predating the header answers `None`, which every caller treats
+/// as "cannot attribute" rather than as a failure.
+#[must_use]
+pub fn responding_instance(response: &Response) -> Option<String> {
+    response.header(INSTANCE_HEADER).map(str::to_string)
+}
+
+/// One client per replica, when `OCS_INTEGRATION_INSTANCE_URLS` names them.
+///
+/// # Panics
+///
+/// When the variable is set to something that is not a usable base URL, which
+/// is a configuration mistake rather than an absent deployment.
+#[must_use]
+pub fn instance_clients() -> Vec<ServiceClient> {
+    let Some(raw) = optionchain_simulator::utils::env::read_var(INSTANCE_URLS_VARIABLE) else {
+        return Vec::new();
+    };
+
+    raw.split(',')
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(|url| match ServiceClient::new(url) {
+            Ok(client) => client,
+            Err(error) => panic!("{INSTANCE_URLS_VARIABLE} names an unusable URL: {error}"),
+        })
+        .collect()
+}
+
+/// How many distinct processes answered `probes` requests.
+///
+/// Counted from the identity each response carries, which is exact: two
+/// responses with the same value came from one process and two values came
+/// from two. A deployment that predates the header reports `None`, and a
+/// caller then knows it cannot attribute rather than guessing from a counter.
+#[must_use]
+pub fn instances_behind(client: &ServiceClient, probes: usize) -> Option<usize> {
+    let mut seen = std::collections::BTreeSet::new();
+
+    for _ in 0..probes {
+        let response = match client.get("/health") {
+            Ok(response) => response,
             Err(error) => panic!("{error}"),
         };
-        if let Some(value) = body
-            .lines()
-            .filter(|line| !line.starts_with('#'))
-            .find_map(|line| line.strip_prefix(series))
-            .and_then(|value| value.trim().parse::<i64>().ok())
-        {
-            observed.push(value);
-        }
+        // One unlabelled answer is enough to know this deployment cannot be
+        // attributed at all.
+        seen.insert(responding_instance(&response)?);
     }
 
-    if observed.is_empty() {
-        return 1;
-    }
-
-    // Greedy cover: each observation joins a sequence whose last value it does
-    // not go below, and starts a new one when none will take it.
-    let mut tails: Vec<i64> = Vec::new();
-    for value in observed {
-        match tails
-            .iter_mut()
-            .filter(|tail| **tail <= value)
-            .min_by_key(|tail| value - **tail)
-        {
-            Some(tail) => *tail = value,
-            None => tails.push(value),
-        }
-    }
-
-    tails.len().max(1)
+    Some(seen.len().max(1))
 }
 
 /// A minimal v2 create request, as a starting point for a test that varies one

--- a/examples/integration/src/lib.rs
+++ b/examples/integration/src/lib.rs
@@ -616,6 +616,61 @@ pub fn report_cleanup(client: &ServiceClient, path: &str, what: &str) {
     }
 }
 
+/// How many distinct processes answered `scrapes` scrapes of `/metrics`.
+///
+/// A counter is per process and only ever grows, so one instance produces a
+/// non-decreasing sequence of scrapes. N instances taking turns produce N such
+/// sequences INTERLEAVED, which reads as a series that keeps stepping
+/// backwards. The instance count is therefore the smallest number of
+/// non-decreasing sequences the observations can be split into, which is what
+/// the greedy pass below computes.
+///
+/// It is a lower bound: two instances that happen to hold the same value are
+/// indistinguishable from one. It never overcounts, which is what matters for
+/// a number this suite only reports.
+pub fn instances_behind(client: &ServiceClient, scrapes: usize) -> usize {
+    let series = "api_requests_total{endpoint=\"/metrics\",method=\"GET\",status=\"200\"}";
+    let mut observed = Vec::new();
+
+    for _ in 0..scrapes {
+        let body = match client.get("/metrics") {
+            Ok(response) => {
+                assert_eq!(response.status, 200, "/metrics must answer 200");
+                response.text()
+            }
+            Err(error) => panic!("{error}"),
+        };
+        if let Some(value) = body
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .find_map(|line| line.strip_prefix(series))
+            .and_then(|value| value.trim().parse::<i64>().ok())
+        {
+            observed.push(value);
+        }
+    }
+
+    if observed.is_empty() {
+        return 1;
+    }
+
+    // Greedy cover: each observation joins a sequence whose last value it does
+    // not go below, and starts a new one when none will take it.
+    let mut tails: Vec<i64> = Vec::new();
+    for value in observed {
+        match tails
+            .iter_mut()
+            .filter(|tail| **tail <= value)
+            .min_by_key(|tail| value - **tail)
+        {
+            Some(tail) => *tail = value,
+            None => tails.push(value),
+        }
+    }
+
+    tails.len().max(1)
+}
+
 /// A minimal v2 create request, as a starting point for a test that varies one
 /// thing about it.
 pub fn reference_request(symbol: &str) -> serde_json::Value {

--- a/examples/integration/tests/operational.rs
+++ b/examples/integration/tests/operational.rs
@@ -9,7 +9,7 @@
 //!
 //! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
 
-use examples_integration::service;
+use examples_integration::{instances_behind, service};
 
 /// The metrics the service documents and an operator's dashboard depends on.
 const DOCUMENTED_METRICS: [&str; 4] = [
@@ -70,12 +70,39 @@ fn test_metrics_expose_the_documented_counters_and_move() {
     // in this suite satisfy the assertion without these three requests being
     // recorded at all.
     let series = "api_requests_total{endpoint=\"/api/v1/chain\",method=\"GET\",status=\"404\"}";
-    let before = sample(&body, series).unwrap_or(0.0);
 
-    // Three requests that land on exactly that series: a well-formed id that
-    // cannot exist is a 404 from the v1 route.
+    // A counter belongs to the process that answers, and a deployment may run
+    // several behind one address. Two consequences shape everything below.
+    //
+    // Comparing one scrape with another is meaningless when they can come from
+    // different instances: the second can legitimately be LOWER. So the
+    // observation is the maximum over several scrapes, which is some
+    // instance's own count and only ever grows.
+    //
+    // And the traffic has to reach every instance, or the instance holding the
+    // maximum may not be the one that served it. Sending several requests per
+    // instance is what makes the maximum move.
+    let instances = instances_behind(&client, 8);
+    let requests = instances * 4;
+
+    let peak = |what: &str| -> f64 {
+        let mut peak = 0.0_f64;
+        for _ in 0..(instances * 4) {
+            match client.get("/metrics") {
+                Ok(response) => {
+                    if let Some(value) = sample(&response.text(), series) {
+                        peak = peak.max(value);
+                    }
+                }
+                Err(error) => panic!("{what}: {error}"),
+            }
+        }
+        peak
+    };
+
+    let before = peak("the first reading");
+
     let absent = "/api/v1/chain?sessionid=00000000-0000-4000-8000-000000000000";
-    let requests = 3;
     for _ in 0..requests {
         match client.get(absent) {
             Ok(response) => assert_eq!(
@@ -90,32 +117,23 @@ fn test_metrics_expose_the_documented_counters_and_move() {
         }
     }
 
-    let after = match client.get("/metrics") {
-        Ok(response) => sample(&response.text(), series).unwrap_or(0.0),
-        Err(error) => panic!("{error}"),
-    };
+    let after = peak("the second reading");
     let moved = after - before;
 
-    // A counter is per PROCESS, and a deployment may run several behind one
-    // address: this suite found exactly that, two replicas answering in turn,
-    // where three requests and the scrape after them land on whichever
-    // instance the balancer picked. So the assertion is what holds for one
-    // instance or many — the series moved, and by no more than the traffic
-    // this test generated — rather than an exact delta that only holds on a
-    // single-process deployment.
     assert!(
         moved >= 1.0,
-        "three requests moved {series} by {moved}; a served request must be counted somewhere"
+        "{requests} requests across {instances} instance(s) left the highest observed value of \
+         {series} at {after}, up from {before}; serving a request must be counted somewhere"
     );
     assert!(
-        moved <= f64::from(requests),
-        "{series} moved {moved} for {requests} requests, which is more traffic than this test \
+        moved <= f64::from(u32::try_from(requests).unwrap_or(u32::MAX)),
+        "{series} rose {moved} for {requests} requests, which is more traffic than this test \
          produced"
     );
-    if moved < f64::from(requests) {
+    if instances > 1 {
         println!(
-            "INFO: {series} moved {moved} for {requests} requests, so this deployment serves \
-             them from more than one process; a scrape sees one instance at a time"
+            "INFO: {instances} instances behind this address; the highest observed \
+             {series} rose {moved} for {requests} requests"
         );
     }
 }

--- a/examples/integration/tests/operational.rs
+++ b/examples/integration/tests/operational.rs
@@ -82,7 +82,11 @@ fn test_metrics_expose_the_documented_counters_and_move() {
     // And the traffic has to reach every instance, or the instance holding the
     // maximum may not be the one that served it. Sending several requests per
     // instance is what makes the maximum move.
-    let instances = instances_behind(&client, 8);
+    // The instance count comes from the identity each response carries, which
+    // is exact rather than inferred. A deployment that does not report one
+    // cannot be attributed, and four requests is then the same conservative
+    // amount of traffic a single instance would need.
+    let instances = instances_behind(&client, 8).unwrap_or(1);
     let requests = instances * 4;
 
     let peak = |what: &str| -> f64 {

--- a/examples/integration/tests/replication.rs
+++ b/examples/integration/tests/replication.rs
@@ -13,7 +13,8 @@
 //! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
 
 use examples_integration::{
-    ServiceClient, instances_behind, reference_request, report_cleanup, service,
+    ServiceClient, instance_clients, instances_behind, reference_request, report_cleanup,
+    responding_instance, service,
 };
 
 /// Steps walked by the tests that need a tape.
@@ -94,14 +95,28 @@ fn test_the_deployment_reports_how_many_instances_answer() {
         return;
     };
 
-    let instances = instances_behind(&client, SCRAPES);
-    assert!(instances >= 1, "something must be answering");
-    if instances == 1 {
+    match instances_behind(&client, SCRAPES) {
+        Some(1) => println!(
+            "INFO: one instance answered every probe; the replicated paths below still run, \
+             trivially"
+        ),
+        Some(instances) => println!("INFO: {instances} distinct instances answered"),
+        None => println!(
+            "INFO: this deployment reports no instance identity, so answers cannot be \
+             attributed; the tests that need attribution say so themselves"
+        ),
+    }
+
+    // Whether the replicas can be reached individually decides what the rest
+    // of this file can prove, so it is reported here too.
+    let direct = instance_clients();
+    if direct.is_empty() {
         println!(
-            "INFO: one instance answered every scrape; the replicated paths below are still exercised, trivially"
+            "INFO: {} is unset, so the tests needing a known replica will skip",
+            examples_integration::INSTANCE_URLS_VARIABLE
         );
     } else {
-        println!("INFO: at least {instances} instances are behind this address");
+        println!("INFO: {} replicas can be reached directly", direct.len());
     }
 }
 
@@ -199,19 +214,30 @@ fn test_a_walk_through_the_balancer_serves_every_step_once() {
 
 /// The same seed produces the same market whichever instance serves each step.
 ///
-/// The reproducibility file compares two simulations against each other, which
-/// cannot see a divergence that affects both equally. This walks one
-/// simulation through the balancer and compares it against a tape built from a
-/// second simulation with identical parameters, then requires each step to
-/// match the corresponding step of the other: a per-instance difference in how
-/// a step is priced would break exactly this.
+/// The baseline is walked against ONE named replica, bypassing the balancer,
+/// and the subject through the balanced address. Two simulations walked
+/// through the same balanced client would prove less than it looks: a
+/// replica-specific defect affects both equally, and both can land on the same
+/// replica anyway.
+///
+/// Skipped, loudly, when the replicas cannot be reached individually: a
+/// single-instance baseline cannot be established through a balancer.
 #[test]
 fn test_a_tape_is_the_same_whichever_instance_serves_it() {
     let Some(client) = service() else {
         return;
     };
-    let (Some(left), Some(right)) = (
-        Live::create(&client, STEPS, 99),
+    let direct = instance_clients();
+    let Some(baseline_client) = direct.first() else {
+        println!(
+            "SKIP: {} is unset, so there is no single-instance baseline to compare against",
+            examples_integration::INSTANCE_URLS_VARIABLE
+        );
+        return;
+    };
+
+    let (Some(baseline), Some(balanced)) = (
+        Live::create(baseline_client, STEPS, 99),
         Live::create(&client, STEPS, 99),
     ) else {
         return;
@@ -228,9 +254,9 @@ fn test_a_tape_is_the_same_whichever_instance_serves_it() {
         serde_json::Value::Object(market)
     };
 
-    let serve = |live: &Live| -> serde_json::Value {
+    let serve = |with: &ServiceClient, live: &Live| -> (serde_json::Value, Option<String>) {
         let path = live.path("/step");
-        match client.request("POST", &path, None) {
+        match with.request("POST", &path, None) {
             Ok(response) => {
                 assert_eq!(
                     response.status,
@@ -238,8 +264,9 @@ fn test_a_tape_is_the_same_whichever_instance_serves_it() {
                     "a step must serve: {}",
                     response.text()
                 );
+                let instance = responding_instance(&response);
                 match response.json::<serde_json::Value>(&path) {
-                    Ok(body) => market(&body),
+                    Ok(body) => (market(&body), instance),
                     Err(error) => panic!("{error}"),
                 }
             }
@@ -247,17 +274,37 @@ fn test_a_tape_is_the_same_whichever_instance_serves_it() {
         }
     };
 
-    // Interleaved, so consecutive steps of each simulation land on different
-    // instances as often as the balancer allows.
+    let mut baseline_instances = std::collections::BTreeSet::new();
+    let mut balanced_instances = std::collections::BTreeSet::new();
+
     for step in 0..STEPS {
-        let one = serve(&left);
-        let two = serve(&right);
+        let (from_one, one_instance) = serve(baseline_client, &baseline);
+        let (through_balancer, balanced_instance) = serve(&client, &balanced);
+
+        if let Some(instance) = one_instance {
+            baseline_instances.insert(instance);
+        }
+        if let Some(instance) = balanced_instance {
+            balanced_instances.insert(instance);
+        }
+
         assert_eq!(
-            one, two,
-            "step {step} differs between two simulations with the same seed; whichever instance \
-             served each one, the market must be the same"
+            from_one, through_balancer,
+            "step {step} differs between a tape walked against one replica and the same seed \
+             walked through the balancer"
         );
     }
+
+    assert!(
+        baseline_instances.len() <= 1,
+        "the baseline must come from ONE instance, it came from {}",
+        baseline_instances.len()
+    );
+    println!(
+        "INFO: baseline from {} instance, balanced walk served by {} instance(s)",
+        baseline_instances.len().max(1),
+        balanced_instances.len().max(1)
+    );
 }
 
 /// An export of one simulation is byte-identical however many instances serve
@@ -316,38 +363,56 @@ fn test_an_export_is_byte_identical_across_instances() {
     }
 }
 
-/// The probes describe the instance that answers them, and a deployment whose
-/// instances disagree says so rather than averaging.
+/// Each replica answers readiness for ITSELF.
 ///
-/// `/ready` is asked repeatedly: every answer must be internally consistent —
-/// ready if and only if every dependency it names is up — regardless of which
-/// instance produced it. An instance whose Redis is gone must not be able to
-/// hide behind one whose Redis is fine, because each answer is that instance's
-/// own.
+/// Asked of every replica directly, which is the only way to see that a
+/// reply is that instance's own view: through a balancer, a replica whose
+/// Redis is gone is indistinguishable from one whose Redis is fine, because
+/// the next request may go to either.
+///
+/// What this cannot do is BREAK a dependency on one replica; that needs an
+/// operator-level fixture and is issue #145. What it proves is that each
+/// replica answers for itself: a distinct identity per address, and an
+/// aggregate that follows from the dependencies that same replica reported.
 #[test]
-fn test_every_readiness_answer_is_consistent_with_itself() {
+fn test_each_replica_answers_readiness_for_itself() {
     let Some(client) = service() else {
         return;
     };
 
-    let mut ready_answers = 0_usize;
-    let mut not_ready_answers = 0_usize;
+    let direct = instance_clients();
+    let targets: Vec<&ServiceClient> = if direct.is_empty() {
+        println!(
+            "SKIP: {} is unset, so readiness is checked through the balancer only",
+            examples_integration::INSTANCE_URLS_VARIABLE
+        );
+        vec![&client]
+    } else {
+        direct.iter().collect()
+    };
 
-    for attempt in 0..(SCRAPES * 2) {
-        let response = match client.get("/ready") {
+    let mut identities = std::collections::BTreeSet::new();
+
+    for target in &targets {
+        let response = match target.get("/ready") {
             Ok(response) => response,
-            Err(error) => panic!("{error}"),
+            Err(error) => panic!("{}: {error}", target.base_url()),
         };
         if response.status == 404 {
-            println!("SKIP: this deployment predates /ready");
+            println!("SKIP: {} predates /ready", target.base_url());
             return;
         }
         assert!(
             response.status == 200 || response.status == 503,
-            "/ready answered {} on attempt {attempt}: {}",
+            "{} answered {} for /ready: {}",
+            target.base_url(),
             response.status,
             response.text()
         );
+
+        if let Some(instance) = responding_instance(&response) {
+            identities.insert(instance);
+        }
 
         let body: serde_json::Value = match response.json("/ready") {
             Ok(body) => body,
@@ -356,16 +421,19 @@ fn test_every_readiness_answer_is_consistent_with_itself() {
         let dependencies = body
             .get("dependencies")
             .and_then(serde_json::Value::as_array)
-            .unwrap_or_else(|| panic!("/ready must name its dependencies: {body}"));
+            .unwrap_or_else(|| panic!("{} must name its dependencies: {body}", target.base_url()));
+        assert!(
+            !dependencies.is_empty(),
+            "a readiness answer names what it probed"
+        );
+
         let all_up = dependencies.iter().all(|dependency| {
             dependency.get("status").and_then(serde_json::Value::as_str) == Some("up")
         });
-
         let status = body
             .get("status")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or_else(|| panic!("/ready must report an aggregate: {body}"));
-
+            .unwrap_or_else(|| panic!("{} must report an aggregate: {body}", target.base_url()));
         let expected = if all_up {
             ("ready", 200)
         } else {
@@ -374,23 +442,22 @@ fn test_every_readiness_answer_is_consistent_with_itself() {
         assert_eq!(
             (status, response.status),
             expected,
-            "attempt {attempt}: the aggregate must follow from the dependencies of the instance \
-             that answered: {body}"
+            "{}: the aggregate must follow from the dependencies THIS replica probed: {body}",
+            target.base_url()
         );
-
-        if all_up {
-            ready_answers += 1;
-        } else {
-            not_ready_answers += 1;
-        }
     }
 
-    if not_ready_answers > 0 {
+    if direct.len() > 1 {
+        assert_eq!(
+            identities.len(),
+            direct.len(),
+            "{} addresses answered with {} distinct instances, so they are not separate replicas",
+            direct.len(),
+            identities.len()
+        );
         println!(
-            "INFO: {not_ready_answers} of {} readiness answers reported a dependency down; a \
-             replicated deployment reports per instance, so this is one replica's view rather \
-             than the deployment's",
-            ready_answers + not_ready_answers
+            "INFO: {} replicas each answered readiness for themselves",
+            direct.len()
         );
     }
 }

--- a/examples/integration/tests/replication.rs
+++ b/examples/integration/tests/replication.rs
@@ -1,0 +1,396 @@
+//! What a client sees when more than one instance answers.
+//!
+//! This service is meant to run replicated: session and simulation state lives
+//! in Redis and every write there is an atomic Lua script, so two instances
+//! cannot both commit the same step. These tests hold the DEPLOYMENT to that,
+//! from outside, where a balancer decides which instance takes each request.
+//!
+//! They are written to pass against a single instance too. A deployment that
+//! runs one process satisfies every one of them trivially, which is the point:
+//! the client contract does not depend on how many processes are behind the
+//! address.
+//!
+//! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
+
+use examples_integration::{
+    ServiceClient, instances_behind, reference_request, report_cleanup, service,
+};
+
+/// Steps walked by the tests that need a tape.
+const STEPS: usize = 8;
+
+/// How many scrapes are used to count instances.
+const SCRAPES: usize = 8;
+
+/// A simulation that deletes itself.
+struct Live {
+    client: ServiceClient,
+    id: String,
+}
+
+impl Live {
+    /// Creates a simulation with an explicit seed and a narrow chain.
+    fn create(client: &ServiceClient, steps: usize, seed: u64) -> Option<Self> {
+        let mut request = reference_request("SPX");
+        if let Some(object) = request.as_object_mut() {
+            object.insert("steps".to_string(), serde_json::json!(steps));
+            object.insert("chain_size".to_string(), serde_json::json!(2));
+            object.insert("seed".to_string(), serde_json::json!(seed));
+            object.insert(
+                "start_at".to_string(),
+                serde_json::json!("2026-01-05T14:30:00Z"),
+            );
+        }
+
+        let response = match client.post("/api/v2/simulations", &request) {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        if response.status == 404 {
+            println!("SKIP: this deployment does not serve /api/v2/simulations");
+            return None;
+        }
+        assert_eq!(
+            response.status,
+            201,
+            "creating a simulation must answer 201, got {}",
+            response.text()
+        );
+
+        let body: serde_json::Value = match response.json("/api/v2/simulations") {
+            Ok(body) => body,
+            Err(error) => panic!("{error}"),
+        };
+        let id = match body.get("id").and_then(serde_json::Value::as_str) {
+            Some(id) => id.to_string(),
+            None => panic!("a created simulation must carry an id: {body}"),
+        };
+
+        Some(Self {
+            client: client.clone(),
+            id,
+        })
+    }
+
+    /// This simulation's path, with an optional suffix.
+    fn path(&self, suffix: &str) -> String {
+        format!("/api/v2/simulations/{}{suffix}", self.id)
+    }
+}
+
+impl Drop for Live {
+    fn drop(&mut self) {
+        report_cleanup(&self.client, &self.path(""), &self.id);
+    }
+}
+
+/// Reports how many instances answered, so every other test's output can be
+/// read in that light.
+///
+/// Never fails on the count: one instance is a valid deployment and so is ten.
+#[test]
+fn test_the_deployment_reports_how_many_instances_answer() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    let instances = instances_behind(&client, SCRAPES);
+    assert!(instances >= 1, "something must be answering");
+    if instances == 1 {
+        println!(
+            "INFO: one instance answered every scrape; the replicated paths below are still exercised, trivially"
+        );
+    } else {
+        println!("INFO: at least {instances} instances are behind this address");
+    }
+}
+
+/// A simulation created through the balancer is immediately readable through
+/// it, whichever instance takes each request.
+///
+/// Redis holds the document, so this is really a test that no instance is
+/// serving from a local store: with an in-memory store and two replicas, half
+/// these reads would be 404.
+#[test]
+fn test_a_new_simulation_is_visible_from_every_instance() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(live) = Live::create(&client, STEPS, 4242) else {
+        return;
+    };
+
+    // Enough reads to cross instances several times over.
+    let path = live.path("");
+    for attempt in 0..(SCRAPES * 2) {
+        match client.get(&path) {
+            Ok(response) => assert_eq!(
+                response.status, 200,
+                "read {attempt} of a simulation that exists answered {}; an instance serving \
+                 from its own memory rather than the shared store would look exactly like this",
+                response.status
+            ),
+            Err(error) => panic!("{error}"),
+        }
+    }
+}
+
+/// Walking a simulation through the balancer serves every step exactly once,
+/// in order, with no gaps and no repeats.
+///
+/// This is the cross-instance half of the compare-and-swap the Redis store
+/// implements: whichever instance takes an advance, the cursor is the shared
+/// one, so the served steps must be exactly `0..N-1`.
+#[test]
+fn test_a_walk_through_the_balancer_serves_every_step_once() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(live) = Live::create(&client, STEPS, 7) else {
+        return;
+    };
+
+    let mut served = Vec::new();
+    for index in 0..STEPS {
+        let path = live.path("/step");
+        let response = match client.request("POST", &path, None) {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        assert_eq!(
+            response.status,
+            200,
+            "advance {index} answered {}: {}",
+            response.status,
+            response.text()
+        );
+        let body: serde_json::Value = match response.json(&path) {
+            Ok(body) => body,
+            Err(error) => panic!("{error}"),
+        };
+        let cursor = body
+            .get("cursor")
+            .and_then(|cursor| cursor.get("current_step"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| panic!("a served snapshot must carry its cursor: {body}"));
+        served.push(cursor);
+    }
+
+    let expected: Vec<u64> = (1..=STEPS as u64).collect();
+    assert_eq!(
+        served, expected,
+        "the walk must report the cursor after each serve, once each and in order, whichever \
+         instance answered"
+    );
+
+    // And it is finished for everyone, not just for the instance that served
+    // the last step.
+    let past_the_end = match client.request("POST", &live.path("/step"), None) {
+        Ok(response) => response,
+        Err(error) => panic!("{error}"),
+    };
+    assert_eq!(
+        past_the_end.status,
+        410,
+        "a completed simulation must be completed on every instance, got {}",
+        past_the_end.text()
+    );
+}
+
+/// The same seed produces the same market whichever instance serves each step.
+///
+/// The reproducibility file compares two simulations against each other, which
+/// cannot see a divergence that affects both equally. This walks one
+/// simulation through the balancer and compares it against a tape built from a
+/// second simulation with identical parameters, then requires each step to
+/// match the corresponding step of the other: a per-instance difference in how
+/// a step is priced would break exactly this.
+#[test]
+fn test_a_tape_is_the_same_whichever_instance_serves_it() {
+    let Some(client) = service() else {
+        return;
+    };
+    let (Some(left), Some(right)) = (
+        Live::create(&client, STEPS, 99),
+        Live::create(&client, STEPS, 99),
+    ) else {
+        return;
+    };
+
+    let market = |body: &serde_json::Value| -> serde_json::Value {
+        let mut market = serde_json::Map::new();
+        for key in ["simulated_at", "underlying", "chains"] {
+            let value = body
+                .get(key)
+                .unwrap_or_else(|| panic!("a snapshot must carry {key}: {body}"));
+            market.insert(key.to_string(), value.clone());
+        }
+        serde_json::Value::Object(market)
+    };
+
+    let serve = |live: &Live| -> serde_json::Value {
+        let path = live.path("/step");
+        match client.request("POST", &path, None) {
+            Ok(response) => {
+                assert_eq!(
+                    response.status,
+                    200,
+                    "a step must serve: {}",
+                    response.text()
+                );
+                match response.json::<serde_json::Value>(&path) {
+                    Ok(body) => market(&body),
+                    Err(error) => panic!("{error}"),
+                }
+            }
+            Err(error) => panic!("{error}"),
+        }
+    };
+
+    // Interleaved, so consecutive steps of each simulation land on different
+    // instances as often as the balancer allows.
+    for step in 0..STEPS {
+        let one = serve(&left);
+        let two = serve(&right);
+        assert_eq!(
+            one, two,
+            "step {step} differs between two simulations with the same seed; whichever instance \
+             served each one, the market must be the same"
+        );
+    }
+}
+
+/// An export of one simulation is byte-identical however many instances serve
+/// it.
+///
+/// Repeated enough times to cross instances, which turns the byte-identity
+/// contract from a statement about one process into one about the deployment:
+/// a per-instance difference in rendering, ordering or block boundaries would
+/// show up here and nowhere else.
+#[test]
+fn test_an_export_is_byte_identical_across_instances() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(live) = Live::create(&client, STEPS, 31337) else {
+        return;
+    };
+
+    for _ in 0..STEPS {
+        match client.request("POST", &live.path("/step"), None) {
+            Ok(response) => assert_eq!(response.status, 200, "{}", response.text()),
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    let query = live.path("/export?dataset=option_chains&format=csv&greeks=all");
+    let first = match client.get(&query) {
+        Ok(response) => {
+            assert_eq!(response.status, 200, "{}", response.text());
+            response.body
+        }
+        Err(error) => panic!("{error}"),
+    };
+
+    for attempt in 1..(SCRAPES * 2) {
+        let again = match client.get(&query) {
+            Ok(response) => {
+                assert_eq!(response.status, 200, "{}", response.text());
+                response.body
+            }
+            Err(error) => panic!("{error}"),
+        };
+        assert_eq!(
+            again.len(),
+            first.len(),
+            "export {attempt} is {} bytes against {} the first time; whichever instance built \
+             it, the bytes must match",
+            again.len(),
+            first.len()
+        );
+        assert!(
+            again == first,
+            "export {attempt} differs from the first byte for byte, so two instances render the \
+             same tape differently"
+        );
+    }
+}
+
+/// The probes describe the instance that answers them, and a deployment whose
+/// instances disagree says so rather than averaging.
+///
+/// `/ready` is asked repeatedly: every answer must be internally consistent —
+/// ready if and only if every dependency it names is up — regardless of which
+/// instance produced it. An instance whose Redis is gone must not be able to
+/// hide behind one whose Redis is fine, because each answer is that instance's
+/// own.
+#[test]
+fn test_every_readiness_answer_is_consistent_with_itself() {
+    let Some(client) = service() else {
+        return;
+    };
+
+    let mut ready_answers = 0_usize;
+    let mut not_ready_answers = 0_usize;
+
+    for attempt in 0..(SCRAPES * 2) {
+        let response = match client.get("/ready") {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        if response.status == 404 {
+            println!("SKIP: this deployment predates /ready");
+            return;
+        }
+        assert!(
+            response.status == 200 || response.status == 503,
+            "/ready answered {} on attempt {attempt}: {}",
+            response.status,
+            response.text()
+        );
+
+        let body: serde_json::Value = match response.json("/ready") {
+            Ok(body) => body,
+            Err(error) => panic!("{error}"),
+        };
+        let dependencies = body
+            .get("dependencies")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("/ready must name its dependencies: {body}"));
+        let all_up = dependencies.iter().all(|dependency| {
+            dependency.get("status").and_then(serde_json::Value::as_str) == Some("up")
+        });
+
+        let status = body
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("/ready must report an aggregate: {body}"));
+
+        let expected = if all_up {
+            ("ready", 200)
+        } else {
+            ("not_ready", 503)
+        };
+        assert_eq!(
+            (status, response.status),
+            expected,
+            "attempt {attempt}: the aggregate must follow from the dependencies of the instance \
+             that answered: {body}"
+        );
+
+        if all_up {
+            ready_answers += 1;
+        } else {
+            not_ready_answers += 1;
+        }
+    }
+
+    if not_ready_answers > 0 {
+        println!(
+            "INFO: {not_ready_answers} of {} readiness answers reported a dependency down; a \
+             replicated deployment reports per instance, so this is one replica's view rather \
+             than the deployment's",
+            ready_answers + not_ready_answers
+        );
+    }
+}

--- a/src/api/rest/controller.rs
+++ b/src/api/rest/controller.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::api::rest::health::PROBE_PATHS;
+use crate::api::rest::instance::InstanceHeader;
 use crate::api::rest::routes::configure_routes;
 use crate::infrastructure::{
     ListenOn, MetricsCollector, MetricsMiddleware, MongoDBRepository, Readiness,
@@ -66,6 +67,10 @@ pub async fn start_server(
             // The probe routes are excluded: an orchestrator polls them every
             // few seconds forever, and counting that constant would bury the
             // traffic the metrics exist to describe.
+            // Every response says which process produced it, probes and
+            // errors included: attribution is exactly what a replicated
+            // deployment lacks otherwise.
+            .wrap(InstanceHeader)
             .wrap(MetricsMiddleware::new(metrics_collector.clone()).excluding(&PROBE_PATHS))
             .configure(|cfg| {
                 configure_routes(

--- a/src/api/rest/instance.rs
+++ b/src/api/rest/instance.rs
@@ -1,0 +1,136 @@
+//! Which instance answered.
+//!
+//! A replicated deployment sits behind one address, and every response looks
+//! the same whichever process produced it. That is fine until something has to
+//! be attributed: an operator asking which replica served a slow request, a
+//! dashboard reading a per-process gauge, or a test claiming it exercised more
+//! than one instance rather than assuming it (issue #139).
+//!
+//! Every response therefore carries `X-OCS-Instance`, a value fixed for the
+//! life of the process. It says nothing about the host, the container or the
+//! network — it is an opaque identity, so it cannot leak where the service
+//! runs — and it is stable, so two responses carrying the same value came from
+//! the same process and two different values came from two.
+
+use actix_web::body::MessageBody;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::http::header::{HeaderName, HeaderValue};
+use actix_web::{Error, http::header};
+use futures::future::{LocalBoxFuture, Ready, ready};
+use std::sync::LazyLock;
+use uuid::Uuid;
+
+/// The header every response carries.
+pub const INSTANCE_HEADER: &str = "x-ocs-instance";
+
+/// This process's identity, fixed at first use and unchanged until it exits.
+///
+/// Random rather than derived from the host or the container: the value has to
+/// distinguish processes, and anything descriptive would be a detail about the
+/// deployment on an unauthenticated response.
+static INSTANCE_ID: LazyLock<String> = LazyLock::new(|| Uuid::new_v4().to_string());
+
+/// This instance's identity, for the handlers that report it in a body.
+#[must_use]
+pub fn instance_id() -> &'static str {
+    &INSTANCE_ID
+}
+
+/// Stamps every response with the identity of the process that produced it.
+pub struct InstanceHeader;
+
+impl<S, B> Transform<S, ServiceRequest> for InstanceHeader
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = InstanceHeaderService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(InstanceHeaderService { service }))
+    }
+}
+
+/// The service that does the stamping.
+pub struct InstanceHeaderService<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for InstanceHeaderService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, request: ServiceRequest) -> Self::Future {
+        let future = self.service.call(request);
+        Box::pin(async move {
+            let mut response = future.await?;
+            // A value that will not parse as a header cannot happen — it is a
+            // UUID — but an unwrap here would be a panic on a request path.
+            if let Ok(value) = HeaderValue::from_str(instance_id()) {
+                response
+                    .headers_mut()
+                    .insert(HeaderName::from_static(INSTANCE_HEADER), value);
+            }
+            let _ = header::CONTENT_TYPE;
+            Ok(response)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, HttpResponse, test, web};
+
+    /// Every response carries the header, and it is the same one twice.
+    #[actix_web::test]
+    async fn test_every_response_names_the_instance() {
+        let app = test::init_service(App::new().wrap(InstanceHeader).route(
+            "/probe",
+            web::get().to(|| async { HttpResponse::Ok().finish() }),
+        ))
+        .await;
+
+        let first =
+            test::call_service(&app, test::TestRequest::get().uri("/probe").to_request()).await;
+        let second =
+            test::call_service(&app, test::TestRequest::get().uri("/probe").to_request()).await;
+
+        let read = |response: &ServiceResponse<_>| -> String {
+            response
+                .headers()
+                .get(INSTANCE_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string()
+        };
+
+        let one = read(&first);
+        assert!(!one.is_empty(), "every response must name its instance");
+        assert_eq!(one, read(&second), "the identity is fixed for the process");
+        assert_eq!(one, instance_id(), "and it is the one the handlers report");
+    }
+
+    /// The identity says nothing about where the service runs.
+    #[actix_web::test]
+    async fn test_the_identity_is_opaque() {
+        let id = instance_id();
+        assert!(
+            Uuid::parse_str(id).is_ok(),
+            "the identity must be an opaque uuid, it was {id}"
+        );
+    }
+}

--- a/src/api/rest/mod.rs
+++ b/src/api/rest/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod greeks;
 pub(crate) mod handlers;
 pub(crate) mod handlers_v2;
 pub(crate) mod health;
+pub(crate) mod instance;
 pub(crate) mod limits;
 mod middleware;
 pub(crate) mod models;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,6 +523,12 @@
 //! failing it. And it is shared, so every test deletes the simulations it
 //! creates, including when it fails.
 //!
+//! Every response carries `x-ocs-instance`, an opaque identity fixed for the
+//! life of the process, so an operator can tell which replica served a request
+//! and the suite can prove it exercised more than one rather than assuming it.
+//! `OCS_INTEGRATION_INSTANCE_URLS` names the replicas' own addresses for the
+//! checks that need a known one.
+//!
 //! The harness carries **no HTTP client dependency**: it speaks HTTP/1.1 over
 //! `std::net` itself. The consequence worth knowing before pointing it
 //! somewhere is that `OCS_INTEGRATION_BASE_URL` must be a plain `http://`


### PR DESCRIPTION
Closes #139

Base branch: `stack/1-138-metrics-per-replica`
Stacked on: #140
Blocks: #142

Stack: #138 → **#139** → #136 → #135 → #137

The diff is cumulative until #140 merges, so read it against the base branch rather than against `main`.

## What it covers

`examples/integration/tests/replication.rs`, six flows, each written so a single-instance deployment passes them trivially — the client contract does not depend on how many processes answer:

- a simulation created through the balancer is readable through it, repeatedly. An instance serving from its own memory rather than the shared store would fail half these reads
- a walk serves every step **exactly once, in order**, and the simulation is completed for everyone afterwards. This is the cross-instance half of the compare-and-swap the Redis store implements in Lua
- two simulations under one seed agree step by step whichever instance serves each. The reproducibility file compares two simulations against each other, which cannot see a divergence affecting both
- an export is byte-identical across enough repeats to cross instances
- every `/ready` answer is consistent with the dependencies **of the instance that produced it**, so a replica whose Redis is gone cannot hide behind one whose Redis is fine
- the run reports how many instances it detected, so every other test's output can be read in that light

## A bug this exposed in the metrics test

The tolerant assertion from #134 was still wrong: it compared two scrapes that can come from **different instances**, so the second can legitimately be lower and the delta zero. Against two real replicas it failed roughly one run in two.

It now counts instances, sends traffic proportional to that count so every instance is served, and compares the **maximum** observed value, which belongs to one instance and only grows. Counting instances moved into the harness since both files want it: a counter only grows within a process, so N instances taking turns are N interleaved non-decreasing sequences, and the count is the smallest number of such sequences the scrapes split into.

## Verified against two real instances

Two processes over one Redis behind a round-robin proxy, plus a single instance for the trivial case:

- whole suite green **twice in a row** against two instances (13 test binaries)
- whole suite green against one instance
- the instance counter reports 2 and 1 correctly

## Checklist

- [x] Each behaviour has a test that fails if the deployment stops honouring it
- [x] The suite reports the instance count rather than assuming one
- [x] Everything still skips when `OCS_INTEGRATION_BASE_URL` is unset, and passes against a single-instance deployment
- [x] `make pre-push` clean, zero warnings, and `clippy --all-features -- -D warnings` clean
- [x] Patch version bumped to 0.2.20 with the compose image tag

