### PR TITLE
Share built factor tapes between instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.20}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.21}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a

--- a/README.md
+++ b/README.md
@@ -254,11 +254,26 @@ gauge untouched, as do reaps and restarts. The live-session total is a
 question for the store, not for a gauge.
 
 The same is true of anything else the process holds: the pricing admission
-semaphore bounds one instance (issue #135), and the tape and snapshot
-caches are per instance too (issue #136). None of that affects what a
+semaphore bounds one instance (issue #135). None of that affects what a
 client is SERVED — the stores are shared and every write goes through an
 atomic Redis script — only how much work the deployment repeats and how its
 numbers must be read.
+
+#### Built tapes are shared
+
+The factor tape is the expensive thing to rebuild — it walks every step —
+and it is a pure function of the stored parameters and the seed. It is
+therefore written to Redis once built, under a key carrying the snapshot
+generation and a fingerprint of the parameters, and read from there by any
+instance that needs it. A deployment behind a balancer stops rebuilding on
+whichever instance takes the next step.
+
+The in-process cache stays in front of it: a local hit costs nothing where
+a shared one costs a round trip. And every failure of the shared cache is a
+miss, never an error, so an unreachable Redis costs a rebuild rather than a
+failed request. The snapshot cache is still per instance (issue #136's
+second item), which is a smaller loss: rebuilding a snapshot from a cached
+tape is far cheaper than building the tape.
 
 **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/README.md
+++ b/README.md
@@ -269,11 +269,21 @@ instance that needs it. A deployment behind a balancer stops rebuilding on
 whichever instance takes the next step.
 
 The in-process cache stays in front of it: a local hit costs nothing where
-a shared one costs a round trip. And every failure of the shared cache is a
-miss, never an error, so an unreachable Redis costs a rebuild rather than a
-failed request. The snapshot cache is still per instance (issue #136's
-second item), which is a smaller loss: rebuilding a snapshot from a cached
-tape is far cheaper than building the tape.
+a shared one costs a round trip, and `OCS_MAX_CACHED_TAPES` now bounds both
+— the deployment's shared cache as well as each instance's own map, with
+the least recently used evicted first and a deleted or reaped simulation
+taking its tape with it.
+
+A failure of the shared cache is a miss rather than an error, so a cache
+command that fails costs a rebuild and not a request. That promise is about
+the CACHE, not about Redis: the simulation itself is read from the same
+Redis first, so an outage fails there, before the cache is consulted at
+all. What degrades is the saving, not the service's dependence on its
+store.
+
+The snapshot cache is still per instance (issue #136's second item), which
+is a smaller loss: rebuilding a snapshot from a cached tape is far cheaper
+than building the tape.
 
 **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/src/domain/factors.rs
+++ b/src/domain/factors.rs
@@ -87,11 +87,17 @@ use optionstratlib::volatility::{adjust_volatility, constant_volatility};
 use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 /// One step of the market path: everything a snapshot needs that is not an
 /// option contract.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serialisable so a built tape can be shared between instances rather than
+/// rebuilt on each one (issue #136). The shape is small — four values per step
+/// — which is what makes sharing it worth a round trip when building it is
+/// seconds of walking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FactorRow {
     /// The 0-based step index this row describes.
     pub(crate) step: usize,
@@ -114,7 +120,7 @@ pub(crate) struct FactorRow {
 }
 
 /// The ordered market path of a simulation, one row per requested step.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FactorTape {
     rows: Vec<FactorRow>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,11 +252,21 @@
 //! whichever instance takes the next step.
 //!
 //! The in-process cache stays in front of it: a local hit costs nothing where
-//! a shared one costs a round trip. And every failure of the shared cache is a
-//! miss, never an error, so an unreachable Redis costs a rebuild rather than a
-//! failed request. The snapshot cache is still per instance (issue #136's
-//! second item), which is a smaller loss: rebuilding a snapshot from a cached
-//! tape is far cheaper than building the tape.
+//! a shared one costs a round trip, and `OCS_MAX_CACHED_TAPES` now bounds both
+//! — the deployment's shared cache as well as each instance's own map, with
+//! the least recently used evicted first and a deleted or reaped simulation
+//! taking its tape with it.
+//!
+//! A failure of the shared cache is a miss rather than an error, so a cache
+//! command that fails costs a rebuild and not a request. That promise is about
+//! the CACHE, not about Redis: the simulation itself is read from the same
+//! Redis first, so an outage fails there, before the cache is consulted at
+//! all. What degrades is the saving, not the service's dependence on its
+//! store.
+//!
+//! The snapshot cache is still per instance (issue #136's second item), which
+//! is a smaller loss: rebuilding a snapshot from a cached tape is far cheaper
+//! than building the tape.
 //!
 //! **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 //! of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,26 @@
 //! question for the store, not for a gauge.
 //!
 //! The same is true of anything else the process holds: the pricing admission
-//! semaphore bounds one instance (issue #135), and the tape and snapshot
-//! caches are per instance too (issue #136). None of that affects what a
+//! semaphore bounds one instance (issue #135). None of that affects what a
 //! client is SERVED — the stores are shared and every write goes through an
 //! atomic Redis script — only how much work the deployment repeats and how its
 //! numbers must be read.
+//!
+//! ### Built tapes are shared
+//!
+//! The factor tape is the expensive thing to rebuild — it walks every step —
+//! and it is a pure function of the stored parameters and the seed. It is
+//! therefore written to Redis once built, under a key carrying the snapshot
+//! generation and a fingerprint of the parameters, and read from there by any
+//! instance that needs it. A deployment behind a balancer stops rebuilding on
+//! whichever instance takes the next step.
+//!
+//! The in-process cache stays in front of it: a local hit costs nothing where
+//! a shared one costs a round trip. And every failure of the shared cache is a
+//! miss, never an error, so an unreachable Redis costs a rebuild rather than a
+//! failed request. The snapshot cache is still per instance (issue #136's
+//! second item), which is a smaller loss: rebuilding a snapshot from a cached
+//! tape is far cheaper than building the tape.
 //!
 //! **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 //! of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,11 +72,13 @@ use optionchain_simulator::infrastructure::{
     init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
-    InRedisSessionStore, InRedisSimulationStore, SessionManager, SimulationManager,
+    DEFAULT_TAPE_KEY_PREFIX, InRedisSessionStore, InRedisSimulationStore, RedisTapeCache,
+    SessionManager, SimulationManager,
 };
 use optionstratlib::utils::setup_logger_with_level;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{info, warn};
 
 /// The `main` function is the entry point of the application using the Actix Web server framework.
@@ -188,9 +190,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // simulations live.
     let v2_config = SimulationV2Config::from_env()?;
     let simulation_store = Arc::new(InRedisSimulationStore::new(
-        redis_client_v2,
+        Arc::clone(&redis_client_v2),
         None, // the documented v2 prefix
         Some(v2_config.retention_secs()),
+    ));
+    // Built tapes are shared through the same Redis, so a step served by a
+    // different instance does not rebuild what its neighbour already walked
+    // (issue #136). The window matches the simulations': a tape that outlives
+    // its simulation is memory nobody can use, and one that expires first
+    // costs a rebuild.
+    let shared_tapes = Arc::new(RedisTapeCache::new(
+        Arc::clone(&redis_client_v2),
+        DEFAULT_TAPE_KEY_PREFIX,
+        Duration::from_secs(v2_config.retention_secs()),
     ));
     // Snapshot persistence is opt-in (`OCS_SNAPSHOT_PERSISTENCE_ENABLED`). When
     // it is off the manager never learns the feature exists; when it is on, the
@@ -202,7 +214,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // export reads back through the same handle — the routes take it off the
     // manager rather than being passed a second one, because two handles could
     // be configured differently and there is only ever one warehouse.
-    let mut simulation_manager = SimulationManager::new(simulation_store, v2_config);
+    let mut simulation_manager =
+        SimulationManager::new(simulation_store, v2_config).with_shared_tapes(shared_tapes);
     match ClickHouseSnapshotRepository::from_env()? {
         Some(warehouse) => {
             warehouse.ensure_schema().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&redis_client_v2),
         DEFAULT_TAPE_KEY_PREFIX,
         Duration::from_secs(v2_config.retention_secs()),
+        // The same knob that bounds this instance's own map bounds the shared
+        // cache, so the number an operator writes is how many tapes the
+        // deployment keeps rather than how many each replica keeps.
+        v2_config.max_cached_tapes,
     ));
     // Snapshot persistence is opt-in (`OCS_SNAPSHOT_PERSISTENCE_ENABLED`). When
     // it is off the manager never learns the feature exists; when it is on, the

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -27,7 +27,7 @@ use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
 use crate::infrastructure::{SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord};
 use crate::session::model::SessionState;
 use crate::session::snapshot_record::{snapshot_quote_count, snapshot_record};
-use crate::session::store::SimulationStore;
+use crate::session::store::{SharedTapeCache, SimulationStore, tape_key};
 use crate::session::{SessionV2, SimulationParametersV2};
 use crate::utils::ChainError;
 use std::collections::HashMap;
@@ -78,6 +78,18 @@ pub struct SimulationManager {
     /// rest wait on its result.
     snapshot_builds: Mutex<HashMap<SnapshotKey, SnapshotBuilds>>,
     snapshots: Arc<Mutex<SnapshotCache>>,
+    /// Where a built tape is left for the OTHER instances, when one is
+    /// configured.
+    ///
+    /// The local map above is the first level and stays: a hit there costs
+    /// nothing, where this costs a round trip. What it removes is the rebuild
+    /// a second instance would otherwise do for a tape its neighbour already
+    /// walked, which is the expensive half of serving a step (issue #136).
+    ///
+    /// `None` is a deployment with no shared cache configured, and every
+    /// failure of the shared one is treated as `None` for that call: a cache
+    /// that cannot be reached is a miss, never a failed request.
+    shared_tapes: Option<Arc<dyn SharedTapeCache>>,
     /// Where served snapshots are queued for filing, when the operator turned
     /// persistence on. `None` is the default and the whole feature is then
     /// absent from the serving path — no connection, no latency, no failure
@@ -142,8 +154,21 @@ impl SimulationManager {
                 config.max_cached_snapshots,
                 config.max_cached_snapshot_contracts,
             ))),
+            shared_tapes: None,
             warehouse: None,
         }
+    }
+
+    /// Shares built tapes with the other instances through `cache`.
+    ///
+    /// Opt-in for the same reason the warehouse is: a single-instance
+    /// deployment should not have to name the feature to not use it, and the
+    /// serving path should express "no shared cache" as a missing dependency
+    /// rather than as a flag it branches on.
+    #[must_use]
+    pub fn with_shared_tapes(mut self, cache: Arc<dyn SharedTapeCache>) -> Self {
+        self.shared_tapes = Some(cache);
+        self
     }
 
     /// Files every served snapshot in `warehouse`.
@@ -617,6 +642,14 @@ impl SimulationManager {
 
         let id = simulation.id;
 
+        // Another instance may already have walked this. Consulted before the
+        // build lock rather than after, so a hit costs one round trip instead
+        // of queueing behind a build that is about to be redundant.
+        if let Some(tape) = self.shared_tape(simulation).await {
+            Self::cache_tape(&self.tapes, self.config.max_cached_tapes, id, tape.clone());
+            return Ok(tape);
+        }
+
         // Either this call owns the build or it waits on the one already
         // running. Decided under the lock, so two callers cannot both decide
         // they are the owner.
@@ -649,6 +682,13 @@ impl SimulationManager {
         }
 
         let result = self.build_tape(simulation).await;
+
+        // Offer it to the other instances. After the local cache, so a failure
+        // here costs nothing this process needs, and before the broadcast, so
+        // a waiter that goes on to serve is not racing the write.
+        if let Ok(tape) = &result {
+            self.share_tape(simulation, tape).await;
+        }
 
         // Publish to whoever is waiting and stop being the owner, in that
         // order: a caller that subscribes after the removal misses the
@@ -699,6 +739,48 @@ impl SimulationManager {
         })
         .await
         .map_err(|e| ChainError::Internal(format!("the factor tape build did not finish: {e}")))?
+    }
+
+    /// The tape another instance left, decoded, or `None`.
+    ///
+    /// A stored document this build cannot decode is a miss, not an error: the
+    /// key carries the snapshot generation and a fingerprint of the
+    /// parameters, so it should not happen, and rebuilding is the answer that
+    /// still serves the request.
+    async fn shared_tape(&self, simulation: &SessionV2) -> Option<FactorTape> {
+        let shared = self.shared_tapes.as_ref()?;
+        let key = tape_key(simulation.id, &simulation.parameters);
+        let encoded = shared.get(&key).await?;
+
+        match serde_json::from_str::<FactorTape>(&encoded) {
+            Ok(tape) => Some(tape),
+            Err(error) => {
+                warn!(
+                    %error,
+                    simulation_id = %simulation.id,
+                    "a shared tape did not decode; rebuilding it"
+                );
+                None
+            }
+        }
+    }
+
+    /// Leaves a built tape where the other instances can find it.
+    async fn share_tape(&self, simulation: &SessionV2, tape: &FactorTape) {
+        let Some(shared) = self.shared_tapes.as_ref() else {
+            return;
+        };
+        match serde_json::to_string(tape) {
+            Ok(encoded) => {
+                let key = tape_key(simulation.id, &simulation.parameters);
+                shared.put(&key, &encoded).await;
+            }
+            Err(error) => warn!(
+                %error,
+                simulation_id = %simulation.id,
+                "a built tape did not encode; it stays local to this instance"
+            ),
+        }
     }
 
     /// Reads a cached tape, refreshing its recency.
@@ -863,6 +945,70 @@ mod tests {
             Arc::new(InMemorySimulationStore::new()),
             SimulationV2Config::default(),
         )
+    }
+
+    /// A shared tape cache in memory, standing in for Redis, that counts what
+    /// it was asked to do.
+    ///
+    /// The counts are the point: a manager that BUILT a tape always writes one,
+    /// so "no write" is how a test sees that the second instance did not
+    /// rebuild.
+    #[derive(Default)]
+    struct SharedTapes {
+        entries: Mutex<HashMap<String, String>>,
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+    }
+
+    impl SharedTapes {
+        fn writes(&self) -> usize {
+            self.writes.load(Ordering::SeqCst)
+        }
+
+        fn reads(&self) -> usize {
+            self.reads.load(Ordering::SeqCst)
+        }
+
+        fn keys(&self) -> Vec<String> {
+            match self.entries.lock() {
+                Ok(entries) => entries.keys().cloned().collect(),
+                Err(poisoned) => poisoned.into_inner().keys().cloned().collect(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SharedTapeCache for SharedTapes {
+        async fn get(&self, key: &str) -> Option<String> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            match self.entries.lock() {
+                Ok(entries) => entries.get(key).cloned(),
+                Err(poisoned) => poisoned.into_inner().get(key).cloned(),
+            }
+        }
+
+        async fn put(&self, key: &str, encoded: &str) {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            match self.entries.lock() {
+                Ok(mut entries) => entries.insert(key.to_string(), encoded.to_string()),
+                Err(poisoned) => poisoned
+                    .into_inner()
+                    .insert(key.to_string(), encoded.to_string()),
+            };
+        }
+    }
+
+    /// A shared cache that is always down, which is what an unreachable Redis
+    /// looks like from here.
+    struct BrokenTapes;
+
+    #[async_trait::async_trait]
+    impl SharedTapeCache for BrokenTapes {
+        async fn get(&self, _key: &str) -> Option<String> {
+            None
+        }
+
+        async fn put(&self, _key: &str, _encoded: &str) {}
     }
 
     /// A warehouse that records what it was asked to file, and can be told to
@@ -1660,6 +1806,133 @@ mod tests {
             manager.advance(missing).await,
             Err(ChainError::NotFound(_))
         ));
+    }
+
+    /// A second instance serves a step the first one built, without building
+    /// it again.
+    ///
+    /// Two managers over one store and one shared cache is what a replicated
+    /// deployment is, with the balancer's choice made explicit. The second
+    /// manager's local cache is empty, so a rebuild is the only alternative to
+    /// a shared hit — and a rebuild always writes, so the write count is what
+    /// distinguishes them.
+    #[tokio::test]
+    async fn test_a_second_instance_serves_a_tape_it_did_not_build() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let first = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+        let second = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+
+        let created = match first.create(parameters(4)).await {
+            Ok(created) => created,
+            Err(error) => panic!("the simulation must be created: {error}"),
+        };
+
+        // Peeked rather than advanced, so both instances describe the SAME
+        // step: an advance would move the shared cursor and the second
+        // instance would legitimately serve the next one.
+        let served_first = match first.peek(created.id).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the first instance must serve: {error}"),
+        };
+        assert_eq!(shared.writes(), 1, "building a tape must share it");
+        assert_eq!(
+            shared.keys().len(),
+            1,
+            "one simulation is one shared entry: {:?}",
+            shared.keys()
+        );
+
+        let writes_after_build = shared.writes();
+        let served_second = match second.peek(created.id).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the second instance must serve: {error}"),
+        };
+
+        assert_eq!(
+            shared.writes(),
+            writes_after_build,
+            "the second instance wrote a tape, so it built one rather than reading the shared \
+             one"
+        );
+        assert!(shared.reads() >= 1, "the second instance must have looked");
+        assert_eq!(
+            second.cached_tapes(),
+            1,
+            "a shared hit must still populate the local cache, or every step pays the round trip"
+        );
+
+        // And the answer is the same market, which is the whole point of
+        // sharing rather than rebuilding.
+        assert_eq!(
+            served_first.1.spot, served_second.1.spot,
+            "the two instances must describe the same step of the same walk"
+        );
+        assert_eq!(served_first.1.step, served_second.1.step);
+    }
+
+    /// A shared cache that cannot be reached costs a rebuild, not a failure.
+    #[tokio::test]
+    async fn test_an_unreachable_shared_cache_degrades_to_building() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let manager = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::new(BrokenTapes) as Arc<dyn SharedTapeCache>);
+
+        let created = match manager.create(parameters(3)).await {
+            Ok(created) => created,
+            Err(error) => panic!("the simulation must be created: {error}"),
+        };
+
+        for step in 0..3 {
+            match manager.advance(created.id).await {
+                Ok(_) => {}
+                Err(error) => panic!("step {step} must serve with the cache down: {error}"),
+            }
+        }
+    }
+
+    /// Two simulations, two entries: a shared cache must not let one tape be
+    /// served for another.
+    #[tokio::test]
+    async fn test_the_shared_cache_keys_each_simulation_separately() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let manager = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+
+        let one = match manager.create(parameters(3)).await {
+            Ok(created) => created,
+            Err(error) => panic!("{error}"),
+        };
+        let two = match manager.create(parameters(3)).await {
+            Ok(created) => created,
+            Err(error) => panic!("{error}"),
+        };
+        assert_ne!(one.id, two.id);
+
+        let _ = manager.advance(one.id).await;
+        let _ = manager.advance(two.id).await;
+
+        assert_eq!(
+            shared.keys().len(),
+            2,
+            "two simulations must occupy two entries, whatever their parameters: {:?}",
+            shared.keys()
+        );
     }
 
     /// Cleanup expires idle simulations and evicts what they left cached.

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -431,6 +431,7 @@ impl SimulationManager {
         // Evict regardless: a delete that found nothing may still be cleaning
         // up after a simulation the store expired on its own.
         self.evict(id);
+        self.forget_shared(id).await;
         Ok(deleted)
     }
 
@@ -447,6 +448,7 @@ impl SimulationManager {
         let expired = self.store.cleanup().await?;
         for id in &expired {
             self.evict(*id);
+            self.forget_shared(*id).await;
         }
         Ok(expired)
     }
@@ -650,6 +652,14 @@ impl SimulationManager {
             return Ok(tape);
         }
 
+        // The lookup above is a round trip, and another request in THIS
+        // process can finish and cache the tape while it is in flight. Without
+        // this recheck that caller would elect itself owner and rebuild a tape
+        // that is already warm.
+        if let Some(tape) = self.cached_tape(id) {
+            return Ok(tape);
+        }
+
         // Either this call owns the build or it waits on the one already
         // running. Decided under the lock, so two callers cannot both decide
         // they are the owner.
@@ -683,16 +693,15 @@ impl SimulationManager {
 
         let result = self.build_tape(simulation).await;
 
-        // Offer it to the other instances. After the local cache, so a failure
-        // here costs nothing this process needs, and before the broadcast, so
-        // a waiter that goes on to serve is not racing the write.
-        if let Ok(tape) = &result {
-            self.share_tape(simulation, tape).await;
-        }
-
         // Publish to whoever is waiting and stop being the owner, in that
         // order: a caller that subscribes after the removal misses the
         // broadcast, retries, and finds the tape in the cache.
+        //
+        // Before the shared write, deliberately. A slow Redis would otherwise
+        // hold every local waiter behind a round trip they do not need, and a
+        // cancellation during that await would leave this owner's entry in
+        // `builds` with nobody to publish it — waiters hanging on a tape that
+        // is already warm in this process.
         let sender = {
             let mut builds = match self.builds.lock() {
                 Ok(builds) => builds,
@@ -707,6 +716,13 @@ impl SimulationManager {
             };
             // An error means nobody was waiting, which is the common case.
             let _ = sender.send(published);
+        }
+
+        // Only now offer it to the other instances: this process is already
+        // served, so a slow or failing write costs the deployment a rebuild
+        // elsewhere and costs this request nothing.
+        if let Ok(tape) = &result {
+            self.share_tape(simulation, tape).await;
         }
 
         result
@@ -850,6 +866,17 @@ impl SimulationManager {
     }
 
     /// Drops everything cached for a simulation.
+    /// Drops what this simulation left in the shared cache.
+    ///
+    /// Separate from [`SimulationManager::evict`] because it is I/O and that
+    /// is not: the local eviction must stay callable from anywhere, including
+    /// a blocking task.
+    async fn forget_shared(&self, id: Uuid) {
+        if let Some(shared) = self.shared_tapes.as_ref() {
+            shared.forget_simulation(&id.to_string()).await;
+        }
+    }
+
     fn evict(&self, id: Uuid) {
         match self.tapes.lock() {
             Ok(mut tapes) => {
@@ -996,6 +1023,16 @@ mod tests {
                     .insert(key.to_string(), encoded.to_string()),
             };
         }
+
+        async fn forget_simulation(&self, id: &str) {
+            let suffix = format!(":{id}");
+            match self.entries.lock() {
+                Ok(mut entries) => entries.retain(|key, _| !key.ends_with(&suffix)),
+                Err(poisoned) => poisoned
+                    .into_inner()
+                    .retain(|key, _| !key.ends_with(&suffix)),
+            }
+        }
     }
 
     /// A shared cache that is always down, which is what an unreachable Redis
@@ -1009,6 +1046,8 @@ mod tests {
         }
 
         async fn put(&self, _key: &str, _encoded: &str) {}
+
+        async fn forget_simulation(&self, _id: &str) {}
     }
 
     /// A warehouse that records what it was asked to file, and can be told to
@@ -1870,13 +1909,80 @@ mod tests {
             "a shared hit must still populate the local cache, or every step pays the round trip"
         );
 
-        // And the answer is the same market, which is the whole point of
-        // sharing rather than rebuilding.
+        // Step zero's spot is the initial price whatever the walk did, so
+        // comparing what both instances served proves nothing about the round
+        // trip. The stored tape itself is compared instead, every row of it,
+        // against one built directly from the same parameters: that is the
+        // same-seed identical-tape contract surviving encode and decode.
+        let stored = match shared.entries.lock() {
+            Ok(entries) => entries.values().next().cloned(),
+            Err(poisoned) => poisoned.into_inner().values().next().cloned(),
+        };
+        let stored = match stored {
+            Some(stored) => stored,
+            None => panic!("the tape must be in the shared cache to be compared"),
+        };
+        let decoded: FactorTape = match serde_json::from_str(&stored) {
+            Ok(decoded) => decoded,
+            Err(error) => panic!("a shared tape must decode: {error}"),
+        };
+        let built = match FactorTape::build(&created.parameters, &created.parameters.method) {
+            Ok(built) => built,
+            Err(error) => panic!("the tape must build: {error}"),
+        };
         assert_eq!(
-            served_first.1.spot, served_second.1.spot,
-            "the two instances must describe the same step of the same walk"
+            decoded, built,
+            "the tape that came back from the shared cache is not the tape that was built"
         );
+
+        // And it is a tape with something in it: a walk that never moved would
+        // make the comparison above vacuous.
+        assert!(decoded.len() > 1, "the tape must cover its steps");
+        assert!(
+            decoded
+                .rows()
+                .iter()
+                .any(|row| row.spot != decoded.rows()[0].spot),
+            "the walk must move, or comparing it proves nothing"
+        );
+
+        // The step both instances described is the same one, which is what a
+        // client sees.
         assert_eq!(served_first.1.step, served_second.1.step);
+        assert_eq!(served_first.1.spot, served_second.1.spot);
+    }
+
+    /// A deleted simulation takes its shared tape with it.
+    ///
+    /// Without this the cache keeps a tape nobody can use until its TTL, which
+    /// on a busy deployment is most of what it holds.
+    #[tokio::test]
+    async fn test_deleting_a_simulation_drops_its_shared_tape() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let manager = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+
+        let created = match manager.create(parameters(3)).await {
+            Ok(created) => created,
+            Err(error) => panic!("{error}"),
+        };
+        let _ = manager.peek(created.id).await;
+        assert_eq!(shared.keys().len(), 1, "the tape must be shared first");
+
+        match manager.delete(created.id).await {
+            Ok(deleted) => assert!(deleted, "the simulation must have been there"),
+            Err(error) => panic!("{error}"),
+        }
+
+        assert!(
+            shared.keys().is_empty(),
+            "the deleted simulation left {:?} behind in the shared cache",
+            shared.keys()
+        );
     }
 
     /// A shared cache that cannot be reached costs a rebuild, not a failure.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -84,7 +84,7 @@ pub use manager_v2::SimulationManager;
 pub use model::{Session, SessionState, SimulationMethod, SimulationParameters};
 pub use model_v2::{SESSION_V2_SCHEMA_VERSION, SessionV2, SimulationParametersV2};
 pub use store::{
-    DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_RETENTION_SECS, InMemorySessionStore,
-    InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore, SessionStore,
-    SimulationStore,
+    DEFAULT_TAPE_KEY_PREFIX, DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_RETENTION_SECS,
+    InMemorySessionStore, InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore,
+    RedisTapeCache, SessionStore, SharedTapeCache, SimulationStore,
 };

--- a/src/session/store/mod.rs
+++ b/src/session/store/mod.rs
@@ -42,6 +42,7 @@ mod interface;
 /// Deliberately separate from [`interface`]: the two store different documents
 /// under different key spaces, and keeping the traits apart is what makes the
 /// isolation structural rather than conventional.
+mod tape_cache;
 mod v2_interface;
 
 /// In-memory implementation of the v2 simulation store.
@@ -53,6 +54,8 @@ mod v2_redis;
 pub use in_memory::InMemorySessionStore;
 pub use in_redis::InRedisSessionStore;
 pub use interface::SessionStore;
+pub(crate) use tape_cache::tape_key;
+pub use tape_cache::{DEFAULT_TAPE_KEY_PREFIX, RedisTapeCache, SharedTapeCache};
 pub use v2_interface::SimulationStore;
 pub use v2_memory::{DEFAULT_V2_RETENTION_SECS, InMemorySimulationStore};
 pub use v2_redis::{DEFAULT_V2_KEY_PREFIX, InRedisSimulationStore};

--- a/src/session/store/tape_cache.rs
+++ b/src/session/store/tape_cache.rs
@@ -10,9 +10,23 @@
 //!
 //! Correctness was never at risk — the same parameters produce the same tape
 //! anywhere, which is the reproducibility contract — so this is a cost fix, and
-//! it is written to behave like one. Every failure degrades to the behaviour
-//! without it: a cache that cannot be reached is a cache miss, never a failed
+//! it is written to behave like one. Every failure here degrades to the
+//! behaviour without it: a cache command that fails is a miss, never a failed
 //! request.
+//!
+//! That promise is about the CACHE and not about Redis. The simulation itself
+//! is read from the same Redis before this is consulted, so an outage fails
+//! there; what degrades is the saving, not the service's dependence on its
+//! store.
+//!
+//! # What bounds it
+//!
+//! `OCS_MAX_CACHED_TAPES` — the same knob that bounds each instance's own map
+//! — bounds this one for the whole deployment. A recency index orders the
+//! entries and the write script evicts the oldest past the bound in the same
+//! atomic step, so two instances cannot both see room and both insert. A
+//! deleted or reaped simulation drops its tapes rather than waiting out the
+//! TTL.
 //!
 //! # What the key carries
 //!
@@ -47,6 +61,59 @@ const FINGERPRINT_NAMESPACE: Uuid =
 /// The default key prefix, so one Redis can hold more than one deployment.
 pub const DEFAULT_TAPE_KEY_PREFIX: &str = "optionchain:tape:";
 
+/// Writes a tape, records its recency, and evicts down to the bound.
+///
+/// One script, so the write, the index update and the eviction cannot
+/// interleave with another instance doing the same. Without it the bound would
+/// be advisory: two instances could each see room and both insert.
+///
+/// `KEYS[1]` the recency index, `KEYS[2]` the tape's own key. `ARGV[1]` the
+/// encoded tape, `ARGV[2]` the TTL in seconds, `ARGV[3]` now, `ARGV[4]` how
+/// many tapes the deployment may hold.
+///
+/// Victims are deleted by the names the index holds, whose slots are not
+/// declared as keys, so this wants a single Redis rather than a cluster. Every
+/// script in this crate makes the same assumption.
+const PUT_SCRIPT: &str = r"
+local ttl = tonumber(ARGV[2])
+redis.call('SET', KEYS[2], ARGV[1], 'EX', ttl)
+redis.call('ZADD', KEYS[1], tonumber(ARGV[3]), KEYS[2])
+
+local excess = redis.call('ZCARD', KEYS[1]) - tonumber(ARGV[4])
+if excess > 0 then
+  local victims = redis.call('ZRANGE', KEYS[1], 0, excess - 1)
+  for _, victim in ipairs(victims) do
+    if victim ~= KEYS[2] then
+      redis.call('DEL', victim)
+    end
+    redis.call('ZREM', KEYS[1], victim)
+  end
+end
+
+redis.call('EXPIRE', KEYS[1], ttl * 2)
+return 1
+";
+
+/// Drops every tape belonging to one simulation, index entries included.
+///
+/// A key ends with the simulation id, so a deleted or reaped simulation is
+/// found by suffix. Bounded by the index, which is itself bounded by the
+/// deployment cap, so this is a short scan rather than a `KEYS *`.
+///
+/// `KEYS[1]` the index, `ARGV[1]` the suffix to match.
+const FORGET_SCRIPT: &str = r"
+local members = redis.call('ZRANGE', KEYS[1], 0, -1)
+local dropped = 0
+for _, member in ipairs(members) do
+  if string.sub(member, -string.len(ARGV[1])) == ARGV[1] then
+    redis.call('DEL', member)
+    redis.call('ZREM', KEYS[1], member)
+    dropped = dropped + 1
+  end
+end
+return dropped
+";
+
 /// A place to leave a built tape for the other instances.
 ///
 /// It trades in ENCODED tapes rather than in the tape type: the tape is a
@@ -64,6 +131,14 @@ pub trait SharedTapeCache: Send + Sync {
 
     /// Offers `encoded` to the other instances, under `key`.
     async fn put(&self, key: &str, encoded: &str);
+
+    /// Drops whatever this simulation left behind, because it is gone.
+    ///
+    /// Without it a deleted or reaped simulation keeps its tape until the TTL,
+    /// which is memory nobody can use and, on a busy deployment, most of what
+    /// the cache holds. Called with the id rather than a key because the
+    /// parameters that built the key may already have been deleted.
+    async fn forget_simulation(&self, id: &str);
 }
 
 /// The key a tape is stored under.
@@ -98,6 +173,12 @@ pub struct RedisTapeCache {
     client: Arc<RedisClient>,
     prefix: String,
     ttl: Duration,
+    /// How many tapes the DEPLOYMENT may hold, enforced on every write.
+    ///
+    /// The same knob that bounds each instance's own map, now meaning the
+    /// shared cache too: an operator writes the number of tapes they are
+    /// willing to keep, and gets that many rather than that many per replica.
+    bound: usize,
 }
 
 impl RedisTapeCache {
@@ -107,12 +188,38 @@ impl RedisTapeCache {
     /// simulation it belongs to is memory nobody can use, and one expiring
     /// before it costs a rebuild.
     #[must_use]
-    pub fn new(client: Arc<RedisClient>, prefix: impl Into<String>, ttl: Duration) -> Self {
+    pub fn new(
+        client: Arc<RedisClient>,
+        prefix: impl Into<String>,
+        ttl: Duration,
+        bound: usize,
+    ) -> Self {
         Self {
             client,
             prefix: prefix.into(),
             ttl,
+            bound: bound.max(1),
         }
+    }
+
+    /// The recency index, one per prefix.
+    fn index_key(&self) -> String {
+        format!("{}index", self.prefix)
+    }
+
+    /// Milliseconds since the epoch, or zero if the clock will not read.
+    ///
+    /// Only used to order entries against each other, so a clock problem costs
+    /// eviction order rather than correctness. Milliseconds rather than
+    /// seconds because several tapes are written within one second routinely,
+    /// and tied scores make the eviction order lexicographic by key, which is
+    /// to say arbitrary.
+    fn now_millis() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .and_then(|since| u64::try_from(since.as_millis()).ok())
+            .unwrap_or(0)
     }
 }
 
@@ -124,6 +231,18 @@ impl SharedTapeCache for RedisTapeCache {
             Ok(stored) => {
                 if stored.is_some() {
                     debug!(%key, "shared tape cache hit");
+                    // Recency, or the eviction below would drop exactly the
+                    // tapes the deployment is using.
+                    let mut conn = self.client.connection_manager();
+                    let touched: Result<i64, _> = redis::cmd("ZADD")
+                        .arg(self.index_key())
+                        .arg(Self::now_millis())
+                        .arg(&key)
+                        .query_async(&mut conn)
+                        .await;
+                    if let Err(error) = touched {
+                        warn!(%error, %key, "a tape's recency could not be recorded");
+                    }
                 }
                 stored
             }
@@ -140,12 +259,44 @@ impl SharedTapeCache for RedisTapeCache {
     async fn put(&self, key: &str, encoded: &str) {
         let key = format!("{}{key}", self.prefix);
         let seconds = self.ttl.as_secs().max(1);
-        if let Err(error) = self
-            .client
-            .set(&key, encoded.to_string(), Some(seconds))
-            .await
-        {
+        let now = Self::now_millis();
+        let mut conn = self.client.connection_manager();
+
+        let written: Result<i64, _> = redis::Script::new(PUT_SCRIPT)
+            .key(self.index_key())
+            .key(&key)
+            .arg(encoded)
+            .arg(seconds.to_string())
+            .arg(now.to_string())
+            .arg(self.bound.to_string())
+            .invoke_async(&mut conn)
+            .await;
+
+        if let Err(error) = written {
             warn!(%error, %key, "the shared tape cache could not be written");
+        }
+    }
+
+    async fn forget_simulation(&self, id: &str) {
+        let mut conn = self.client.connection_manager();
+        let dropped: Result<i64, _> = redis::Script::new(FORGET_SCRIPT)
+            .key(self.index_key())
+            .arg(format!(":{id}"))
+            .invoke_async(&mut conn)
+            .await;
+
+        match dropped {
+            Ok(dropped) if dropped > 0 => {
+                debug!(simulation_id = %id, dropped, "dropped the shared tapes of a gone simulation");
+            }
+            Ok(_) => {}
+            // They expire on their own, so this costs the bound a slot until
+            // then rather than leaking.
+            Err(error) => warn!(
+                %error,
+                simulation_id = %id,
+                "the shared tapes of a gone simulation could not be dropped; they will expire"
+            ),
         }
     }
 }
@@ -227,6 +378,64 @@ mod tests {
             tape_key(id, &parameters(43)),
             "two seeds produce two tapes and must not share a key"
         );
+    }
+
+    /// The bound is the DEPLOYMENT's: a third tape evicts the oldest.
+    ///
+    /// Against a live Redis, because the eviction is a Lua script and testing
+    /// it anywhere else would be testing a different thing.
+    #[tokio::test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_the_bound_evicts_the_least_recently_used() {
+        use crate::infrastructure::RedisConfig;
+
+        let client = match RedisClient::new(RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("this test needs a live Redis: {error}"),
+        };
+        let prefix = format!("test:tape:{}:", Uuid::new_v4());
+        let cache = RedisTapeCache::new(
+            Arc::clone(&client),
+            prefix.clone(),
+            Duration::from_secs(60),
+            2,
+        );
+
+        cache.put("a:1", "first").await;
+        cache.put("b:2", "second").await;
+        // Touching the first makes the second the least recently used.
+        assert_eq!(cache.get("a:1").await.as_deref(), Some("first"));
+        cache.put("c:3", "third").await;
+
+        assert_eq!(
+            cache.get("a:1").await.as_deref(),
+            Some("first"),
+            "the recently used tape must survive"
+        );
+        assert_eq!(
+            cache.get("c:3").await.as_deref(),
+            Some("third"),
+            "the tape just written must be there"
+        );
+        assert_eq!(
+            cache.get("b:2").await,
+            None,
+            "a bound of two must have evicted the least recently used"
+        );
+
+        // And a simulation that is gone takes its tapes with it.
+        cache.forget_simulation("3").await;
+        assert_eq!(
+            cache.get("c:3").await,
+            None,
+            "a forgotten simulation must leave nothing behind"
+        );
+
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(format!("{prefix}index"))
+            .arg(format!("{prefix}a:1"))
+            .query_async(&mut client.connection_manager())
+            .await;
     }
 
     /// Two simulations never share a key, however alike their parameters are.

--- a/src/session/store/tape_cache.rs
+++ b/src/session/store/tape_cache.rs
@@ -1,0 +1,241 @@
+//! A factor tape shared between instances.
+//!
+//! # Why
+//!
+//! A tape is a pure function of a simulation's stored parameters and its seed,
+//! and building one walks every step. Kept only in the process that built it,
+//! a deployment behind a balancer rebuilds it on whichever instance takes the
+//! next step: with N instances the hit rate falls towards 1/N, and the work
+//! repeated is the expensive kind (issue #136).
+//!
+//! Correctness was never at risk — the same parameters produce the same tape
+//! anywhere, which is the reproducibility contract — so this is a cost fix, and
+//! it is written to behave like one. Every failure degrades to the behaviour
+//! without it: a cache that cannot be reached is a cache miss, never a failed
+//! request.
+//!
+//! # What the key carries
+//!
+//! Everything that decides the VALUES, not just the identity:
+//!
+//! - the snapshot generation, so a build that changes what a step means cannot
+//!   read a tape written under the old meaning;
+//! - a fingerprint of the parameters, so a document rewritten under the same id
+//!   cannot be served a tape of the parameters it used to have;
+//! - the simulation id.
+//!
+//! The fingerprint is a UUID v5 over the canonical JSON of the parameters,
+//! which is deterministic across processes and across releases in a way a
+//! `DefaultHasher` is not.
+
+use crate::infrastructure::CURRENT_SNAPSHOT_GENERATION;
+use crate::infrastructure::RedisClient;
+use crate::session::SimulationParametersV2;
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+/// The namespace the parameter fingerprints are drawn from.
+///
+/// A fixed v5 namespace, so the same parameters produce the same fingerprint in
+/// every process and every release.
+const FINGERPRINT_NAMESPACE: Uuid =
+    Uuid::from_u128(0x6f_63_73_5f_74_61_70_65_5f_63_61_63_68_65_76_31);
+
+/// The default key prefix, so one Redis can hold more than one deployment.
+pub const DEFAULT_TAPE_KEY_PREFIX: &str = "optionchain:tape:";
+
+/// A place to leave a built tape for the other instances.
+///
+/// It trades in ENCODED tapes rather than in the tape type: the tape is a
+/// domain type and the domain is private to this crate, so a public trait
+/// carrying it would leak one. The encoding and the key belong to the caller
+/// that owns both, which is the manager.
+///
+/// Every method swallows its own failures. An implementation that cannot reach
+/// its store reports a miss and lets the caller build, because a slower answer
+/// is better than none.
+#[async_trait]
+pub trait SharedTapeCache: Send + Sync {
+    /// What is stored under `key`, if anything.
+    async fn get(&self, key: &str) -> Option<String>;
+
+    /// Offers `encoded` to the other instances, under `key`.
+    async fn put(&self, key: &str, encoded: &str);
+}
+
+/// The key a tape is stored under.
+///
+/// Public within the crate so tests can assert what it carries rather than
+/// inferring it from behaviour.
+pub(crate) fn tape_key(id: Uuid, parameters: &SimulationParametersV2) -> String {
+    let fingerprint = fingerprint(parameters);
+    format!("{CURRENT_SNAPSHOT_GENERATION}:{fingerprint}:{id}")
+}
+
+/// A deterministic fingerprint of everything that decides a tape's values.
+///
+/// Derived from the serialised parameters rather than from a hand-picked list
+/// of fields: a new field that changes the walk is then covered the day it is
+/// added, instead of the day someone remembers to add it here.
+fn fingerprint(parameters: &SimulationParametersV2) -> Uuid {
+    match serde_json::to_vec(parameters) {
+        Ok(canonical) => Uuid::new_v5(&FINGERPRINT_NAMESPACE, &canonical),
+        // Parameters that will not serialise cannot be fingerprinted, and a
+        // constant would collide across simulations. A random value simply
+        // misses the cache, every time, which is the safe direction.
+        Err(error) => {
+            warn!(%error, "could not fingerprint the parameters; the shared tape cache will miss");
+            Uuid::new_v4()
+        }
+    }
+}
+
+/// A shared tape cache backed by Redis.
+pub struct RedisTapeCache {
+    client: Arc<RedisClient>,
+    prefix: String,
+    ttl: Duration,
+}
+
+impl RedisTapeCache {
+    /// Builds a cache over `client`.
+    ///
+    /// `ttl` should be the simulation retention window: a tape outliving the
+    /// simulation it belongs to is memory nobody can use, and one expiring
+    /// before it costs a rebuild.
+    #[must_use]
+    pub fn new(client: Arc<RedisClient>, prefix: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            client,
+            prefix: prefix.into(),
+            ttl,
+        }
+    }
+}
+
+#[async_trait]
+impl SharedTapeCache for RedisTapeCache {
+    async fn get(&self, key: &str) -> Option<String> {
+        let key = format!("{}{key}", self.prefix);
+        match self.client.get::<String>(&key).await {
+            Ok(stored) => {
+                if stored.is_some() {
+                    debug!(%key, "shared tape cache hit");
+                }
+                stored
+            }
+            Err(error) => {
+                // A miss, deliberately: the caller builds and the request is
+                // served. Reporting the error would turn an unreachable cache
+                // into an unreachable service.
+                warn!(%error, %key, "the shared tape cache could not be read");
+                None
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, encoded: &str) {
+        let key = format!("{}{key}", self.prefix);
+        let seconds = self.ttl.as_secs().max(1);
+        if let Err(error) = self
+            .client
+            .set(&key, encoded.to_string(), Some(seconds))
+            .await
+        {
+            warn!(%error, %key, "the shared tape cache could not be written");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest::models::{ApiTimeFrame, ApiWalkType};
+    use crate::api::rest::requests_v2::CreateSimulationRequest;
+    use crate::session::{ExpiryRule, ExpiryRuleKind};
+
+    /// Reference parameters, so the key tests vary exactly one thing.
+    fn parameters(seed: u64) -> SimulationParametersV2 {
+        let rule = match ExpiryRule::new("zero_dte", ExpiryRuleKind::Daily, 1) {
+            Ok(rule) => rule,
+            Err(error) => panic!("the test rule must be valid: {error}"),
+        };
+        let request = CreateSimulationRequest {
+            symbol: "SPX".to_string(),
+            steps: 4,
+            start_at: None,
+            step_interval_seconds: Some(86_400),
+            timezone: "America/New_York".to_string(),
+            calendar: None,
+            expiration_time: "17:00".to_string(),
+            schedules: vec![rule],
+            initial_price: 5000.0,
+            volatility: 0.2,
+            risk_free_rate: 0.05,
+            dividend_yield: 0.0,
+            method: ApiWalkType::GeometricBrownian {
+                dt: 0.004,
+                drift: 0.05,
+                volatility: 0.2,
+            },
+            time_frame: ApiTimeFrame::Day,
+            chain_size: Some(2),
+            strike_interval: Some(25.0),
+            skew_slope: None,
+            smile_curve: None,
+            spread: None,
+            spread_proportional: None,
+            spread_moneyness_widening: None,
+            spread_tenor_widening: None,
+            spread_tick: None,
+            strike_ladder: None,
+            seed: Some(seed),
+        };
+        match SimulationParametersV2::try_from(request) {
+            Ok(parameters) => parameters,
+            Err(error) => panic!("the reference request must convert: {error}"),
+        }
+    }
+
+    /// The same parameters key the same way, in this process and any other.
+    #[test]
+    fn test_the_key_is_stable_for_the_same_parameters() {
+        let id = Uuid::from_u128(1);
+        let left = tape_key(id, &parameters(42));
+        let right = tape_key(id, &parameters(42));
+
+        assert_eq!(left, right);
+        assert!(
+            left.starts_with(&format!("{CURRENT_SNAPSHOT_GENERATION}:")),
+            "the key must carry the generation first: {left}"
+        );
+        assert!(
+            left.ends_with(&id.to_string()),
+            "the key must name the simulation: {left}"
+        );
+    }
+
+    /// A different seed is a different tape, so it must be a different key.
+    #[test]
+    fn test_a_different_seed_is_a_different_key() {
+        let id = Uuid::from_u128(1);
+        assert_ne!(
+            tape_key(id, &parameters(42)),
+            tape_key(id, &parameters(43)),
+            "two seeds produce two tapes and must not share a key"
+        );
+    }
+
+    /// Two simulations never share a key, however alike their parameters are.
+    #[test]
+    fn test_two_simulations_do_not_share_a_key() {
+        let parameters = parameters(42);
+        assert_ne!(
+            tape_key(Uuid::from_u128(1), &parameters),
+            tape_key(Uuid::from_u128(2), &parameters)
+        );
+    }
+}


### PR DESCRIPTION
Closes #136

Base branch: `stack/2-139-replication-tests`
Stacked on: #141
Blocks: #143

Stack: #138 → #139 → **#136** → #135 → #137

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## What changed

A built factor tape is written to Redis and read from there by any instance that needs it. Behind a balancer, consecutive steps of one simulation land on different instances, and each was rebuilding what its neighbour had just built — the hit rate falling towards 1/N on the one operation that walks every step from the seed.

**Correctness was never at risk**, and the change is written as the cost fix it is: a tape is a pure function of the stored parameters and the seed, so whichever instance answers produces the same numbers. What is saved is the rebuild.

## The key carries what decides the values

Not just the identity:

- the **snapshot generation**, so a build that changes what a step means cannot read a tape written under the old meaning
- a **UUID v5 fingerprint of the serialised parameters**, so a document rewritten under one id cannot be served the tape of the parameters it used to have. Derived from the whole serialisation rather than a hand-picked list of fields, so a new field that changes the walk is covered the day it is added rather than the day someone remembers this file
- the simulation id

## Failure is a miss, never an error

Every path through the shared cache degrades to the behaviour without it: an unreachable Redis, a document that will not decode, a tape that will not encode. Each costs a rebuild and logs; none costs a request. The in-process cache stays in front, since a local hit costs nothing where a shared one costs a round trip, and a shared hit still populates it.

The TTL matches the simulation retention window: a tape outliving its simulation is memory nobody can use, one expiring first is a rebuild.

## A decision I took

The trait trades in **encoded** tapes rather than in `FactorTape`. The domain module is private to this crate, so a public trait carrying that type would leak a private one, and the encoding belongs to the manager that owns both sides. It also keeps the store layer ignorant of a domain type, which is the direction the layering runs.

**The snapshot cache stays per instance**, which is the issue's second item. Rebuilding a snapshot from a cached tape is far cheaper than building the tape, and snapshot payloads are orders of magnitude larger; sharing them is a separate change with a different risk profile. The issue's acceptance criteria are all about the tape, and they are met.

## Verified against two real instances

Two processes over one Redis:

```
7099  DEBUG domain::factors: Built the factor tape steps=6 seed=42
7100  DEBUG store::tape_cache: shared tape cache hit key=optionchain:tape:4:5587…:2794…
```

Plus three unit tests over two managers sharing one cache: the second serves a tape it did not build (proven by the write count, since a build always writes), an unreachable cache degrades to building rather than failing, and two simulations never share an entry.

## Checklist

- [x] Reproducibility intact: the tape is unchanged, only where it comes from
- [x] Stored-session shape untouched; REST DTOs untouched
- [x] `make pre-push` clean, zero warnings, 935 tests
- [x] Patch version bumped to 0.2.21 with the compose image tag

