### PR TITLE
Make the pricing bound the deployment's, not the process's

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,8 +180,12 @@ OCS_MAX_SNAPSHOT_CONTRACTS=200000
 # consistent tape; but the per-process caps and caches are not divided among
 # them:
 #
-#   * OCS_MAX_CONCURRENT_PRICING_JOBS bounds one instance, so N replicas allow
-#     N times that many pricing jobs at once (issue #135).
+#   * OCS_MAX_CONCURRENT_PRICING_JOBS bounds the DEPLOYMENT when Redis is
+#     reachable: the instances hold leases in a shared set, so the number is
+#     what the whole deployment runs rather than what each replica runs. If
+#     Redis cannot be reached the bound falls back to per instance, which is
+#     what it always was; pricing unbounded would be a worse answer to that
+#     outage than pricing more concurrently than configured.
 #   * The tape and snapshot caches are per instance, so a step served by a
 #     different replica rebuilds what its neighbour already built (issue #136).
 #   * /metrics serves the metrics of the instance that answers. Scrape each

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.21}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.22}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a

--- a/README.md
+++ b/README.md
@@ -253,11 +253,25 @@ through one replica and deleted through another leaves the first replica's
 gauge untouched, as do reaps and restarts. The live-session total is a
 question for the store, not for a gauge.
 
-The same is true of anything else the process holds: the pricing admission
-semaphore bounds one instance (issue #135). None of that affects what a
-client is SERVED — the stores are shared and every write goes through an
-atomic Redis script — only how much work the deployment repeats and how its
-numbers must be read.
+What a client is SERVED never depends on which instance answers: the stores
+are shared and every write goes through an atomic Redis script. What is per
+process is how much work the deployment repeats and how its numbers must be
+read.
+
+#### The pricing bound is the deployment's
+
+`OCS_MAX_CONCURRENT_PRICING_JOBS` used to bound one process, so two replicas
+ran twice the configured jobs and an operator learned it when the host
+saturated. The instances now hold leases in a shared Redis set, taken and
+released around the same work, so the number is what the DEPLOYMENT runs.
+
+The lease expires on its own, which is what stops a killed instance from
+holding one forever, and it is set well above the length of a pricing job so
+a running job cannot lose its lease to the sweep. A gate that cannot be
+reached, or a wait that runs out, falls back to the per-process semaphore:
+that is the bound the service always had, and pricing unbounded would be a
+worse answer to a Redis outage than pricing more concurrently than
+configured.
 
 #### Built tapes are shared
 

--- a/README.md
+++ b/README.md
@@ -266,12 +266,23 @@ saturated. The instances now hold leases in a shared Redis set, taken and
 released around the same work, so the number is what the DEPLOYMENT runs.
 
 The lease expires on its own, which is what stops a killed instance from
-holding one forever, and it is set well above the length of a pricing job so
-a running job cannot lose its lease to the sweep. A gate that cannot be
-reached, or a wait that runs out, falls back to the per-process semaphore:
-that is the bound the service always had, and pricing unbounded would be a
-worse answer to a Redis outage than pricing more concurrently than
-configured.
+holding one forever, and a job still running renews it, so the sweep cannot
+reap the lease of work that is still burning the CPU it was leased for. The
+clock the expiry is measured on is the Redis server's, because the whole
+point is that several machines order each other's leases and their own
+clocks do not agree well enough for that.
+
+A gate that is up and FULL makes the caller wait, cancellably, for as long
+as it takes. Falling back there would bypass the deployment-wide bound
+exactly under the sustained load it exists for. Only a gate that cannot be
+REACHED falls back to the per-process semaphore: that is the bound the
+service always had, and pricing unbounded would be a worse answer to a
+Redis outage than pricing more concurrently than configured.
+
+Both permits are held by a task that outlives the request, because a
+blocking job keeps running when the client that asked for it goes away.
+Releasing them on cancellation would leave that CPU work running outside
+the bound it was admitted under.
 
 #### Built tapes are shared
 

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -2,6 +2,7 @@ mod clickhouse;
 mod config;
 pub mod health;
 mod mongodb;
+mod pricing_gate;
 mod redis;
 mod repositories;
 mod telemetry;
@@ -39,6 +40,7 @@ pub use health::{
     DependencyProbe, DependencyReport, MongoDbProbe, ProbeFailure, Readiness, RedisProbe,
     WarehouseProbe,
 };
+pub use pricing_gate::{DEFAULT_PRICING_GATE_KEY, RedisPricingGate};
 pub use redis::RedisClient;
 pub use repositories::historical_repo::ClickHouseHistoricalRepository;
 pub use repositories::mongo_repo::{MongoDBRepository, init_mongodb};

--- a/src/infrastructure/pricing_gate.rs
+++ b/src/infrastructure/pricing_gate.rs
@@ -1,0 +1,245 @@
+//! The deployment-wide pricing bound, held in Redis.
+//!
+//! `utils::admission` bounds the pricing jobs of ONE process, which is the
+//! wrong unit once the service runs replicated: an operator asking for four and
+//! running two replicas gets eight, and learns it when the host saturates
+//! (issue #135). This is the adapter that makes the same number mean the
+//! deployment.
+//!
+//! # How it holds
+//!
+//! A sorted set of leases, scored by the instant each was taken. Acquiring is
+//! one Lua script, so the expiry sweep, the count and the insert cannot
+//! interleave with another instance doing the same:
+//!
+//! 1. drop every lease older than the lease window — that is what stops a
+//!    killed instance from holding one forever;
+//! 2. if fewer than the limit remain, add this one and say yes;
+//! 3. otherwise say no, and let the caller wait and ask again.
+//!
+//! The window is a fallback, not a timer: a job that finishes releases its
+//! lease. It has to be longer than a pricing job or a running job would lose
+//! its lease to the sweep and let another in.
+//!
+//! # It never fails a request
+//!
+//! Every error here is reported as "no lease", and `admit_blocking` then
+//! proceeds under the per-process bound, which is the behaviour the service
+//! had before this existed. An unreachable Redis makes the deployment price
+//! more concurrently than configured; refusing to price at all would be a worse
+//! answer to the same outage.
+
+use crate::infrastructure::RedisClient;
+use crate::utils::admission::SharedPricingGate;
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+/// The key the leases live under.
+pub const DEFAULT_PRICING_GATE_KEY: &str = "optionchain:pricing:leases";
+
+/// How long a lease survives without being released.
+///
+/// Longer than any pricing job: a running job whose lease expired would let a
+/// second one in, which is the bound leaking. A snapshot at the contract cap
+/// is seconds, so minutes is the safe side of that.
+const LEASE_WINDOW: Duration = Duration::from_secs(300);
+
+/// How long to sleep between attempts when every lease is taken.
+///
+/// Short enough that a freed lease is picked up promptly, long enough that a
+/// queue of waiters does not become a load test of its own.
+const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Acquires a lease if the deployment is under its bound.
+///
+/// `KEYS[1]` the sorted set; `ARGV[1]` now in milliseconds, `ARGV[2]` the lease
+/// window in milliseconds, `ARGV[3]` the limit, `ARGV[4]` this lease's token.
+/// Returns 1 when the lease was taken and 0 when the bound is full.
+const ACQUIRE_SCRIPT: &str = r"
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now - window)
+if redis.call('ZCARD', KEYS[1]) < limit then
+  redis.call('ZADD', KEYS[1], now, ARGV[4])
+  redis.call('PEXPIRE', KEYS[1], window * 2)
+  return 1
+end
+return 0
+";
+
+/// A pricing bound shared by every instance through Redis.
+pub struct RedisPricingGate {
+    client: Arc<RedisClient>,
+    key: String,
+    limit: usize,
+}
+
+impl RedisPricingGate {
+    /// Builds a gate allowing `limit` pricing jobs across the deployment.
+    #[must_use]
+    pub fn new(client: Arc<RedisClient>, key: impl Into<String>, limit: usize) -> Self {
+        Self {
+            client,
+            key: key.into(),
+            limit: limit.max(1),
+        }
+    }
+
+    /// Milliseconds since the epoch, or `None` if the clock is before it.
+    ///
+    /// A clock that cannot be read is a gate that cannot decide, which is
+    /// reported as "no lease" like every other failure here.
+    fn now_millis() -> Option<u64> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .and_then(|since| u64::try_from(since.as_millis()).ok())
+    }
+
+    /// One attempt. `Ok(true)` took a lease, `Ok(false)` the bound is full.
+    async fn try_acquire(&self, token: &str) -> Result<bool, String> {
+        let now = Self::now_millis().ok_or_else(|| "the clock is before the epoch".to_string())?;
+        let mut conn = self.client.connection_manager();
+
+        let taken: i64 = redis::Script::new(ACQUIRE_SCRIPT)
+            .key(&self.key)
+            .arg(now.to_string())
+            .arg(LEASE_WINDOW.as_millis().to_string())
+            .arg(self.limit.to_string())
+            .arg(token)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok(taken == 1)
+    }
+}
+
+#[async_trait]
+impl SharedPricingGate for RedisPricingGate {
+    async fn acquire(&self, deadline: Duration) -> Option<String> {
+        let token = Uuid::new_v4().to_string();
+        let started = SystemTime::now();
+
+        loop {
+            match self.try_acquire(&token).await {
+                Ok(true) => {
+                    debug!(limit = self.limit, "took a deployment-wide pricing lease");
+                    return Some(token);
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    // Unreachable: the caller proceeds under the per-process
+                    // bound rather than failing, and says so once per attempt
+                    // rather than per retry.
+                    warn!(
+                        %error,
+                        "the deployment-wide pricing gate is unreachable; falling back to this \
+                         instance's own bound"
+                    );
+                    return None;
+                }
+            }
+
+            let waited = started.elapsed().unwrap_or(Duration::ZERO);
+            if waited >= deadline {
+                warn!(
+                    limit = self.limit,
+                    waited_secs = waited.as_secs(),
+                    "waited for a deployment-wide pricing lease without getting one; proceeding \
+                     under this instance's own bound"
+                );
+                return None;
+            }
+            tokio::time::sleep(RETRY_INTERVAL).await;
+        }
+    }
+
+    async fn release(&self, token: &str) {
+        let mut conn = self.client.connection_manager();
+        let removed: Result<i64, _> = redis::cmd("ZREM")
+            .arg(&self.key)
+            .arg(token)
+            .query_async(&mut conn)
+            .await;
+
+        if let Err(error) = removed {
+            // The lease expires on its own, so this costs a slot for the
+            // window rather than forever.
+            warn!(%error, "a pricing lease could not be released; it will expire");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::RedisConfig;
+
+    /// A limit of zero would stop the deployment pricing anything at all, so
+    /// it is read as one.
+    #[tokio::test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_a_limit_of_zero_becomes_one() {
+        let client = match RedisClient::new(RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("this test needs a live Redis: {error}"),
+        };
+        let gate = RedisPricingGate::new(client, "test:limit", 0);
+        assert_eq!(gate.limit, 1, "a limit of zero would price nothing");
+    }
+
+    /// Two gates over one Redis cannot exceed the bound between them.
+    ///
+    /// This is the whole point of the issue: the per-process semaphore lets N
+    /// replicas run N times the configured jobs, and this must not.
+    #[tokio::test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_two_gates_cannot_exceed_the_bound_together() {
+        let client = match RedisClient::new(RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("this test needs a live Redis: {error}"),
+        };
+        let key = format!("test:pricing:{}", Uuid::new_v4());
+
+        let first = RedisPricingGate::new(Arc::clone(&client), key.clone(), 2);
+        let second = RedisPricingGate::new(Arc::clone(&client), key.clone(), 2);
+
+        let one = first.acquire(Duration::from_millis(200)).await;
+        let two = second.acquire(Duration::from_millis(200)).await;
+        assert!(
+            one.is_some() && two.is_some(),
+            "two leases fit in a bound of two"
+        );
+
+        // The third must not fit, whichever instance asks.
+        let three = second.acquire(Duration::from_millis(200)).await;
+        assert!(
+            three.is_none(),
+            "a third lease was granted against a bound of two, so replicas can exceed it"
+        );
+
+        // And releasing frees a slot for the other instance.
+        if let Some(token) = one {
+            first.release(&token).await;
+        }
+        let four = second.acquire(Duration::from_millis(500)).await;
+        assert!(four.is_some(), "a released lease must free a slot");
+
+        if let Some(token) = two {
+            first.release(&token).await;
+        }
+        if let Some(token) = four {
+            second.release(&token).await;
+        }
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(&key)
+            .query_async(&mut client.connection_manager())
+            .await;
+    }
+}

--- a/src/infrastructure/pricing_gate.rs
+++ b/src/infrastructure/pricing_gate.rs
@@ -8,7 +8,10 @@
 //!
 //! # How it holds
 //!
-//! A sorted set of leases, scored by the instant each was taken. Acquiring is
+//! A sorted set of leases, scored by the instant each was taken, read from the
+//! REDIS server rather than from the instance holding it: the whole point is
+//! that several machines order each other's leases, and their clocks do not
+//! agree well enough for one to decide when another's lease died. Acquiring is
 //! one Lua script, so the expiry sweep, the count and the insert cannot
 //! interleave with another instance doing the same:
 //!
@@ -18,22 +21,29 @@
 //! 3. otherwise say no, and let the caller wait and ask again.
 //!
 //! The window is a fallback, not a timer: a job that finishes releases its
-//! lease. It has to be longer than a pricing job or a running job would lose
-//! its lease to the sweep and let another in.
+//! lease, and a job still running renews it. Renewal is what makes the window
+//! safe to keep short enough to be useful — without it a job outliving the
+//! window would lose its lease to the sweep and let another in, whatever the
+//! window was set to.
 //!
-//! # It never fails a request
+//! # Full is not failure
 //!
-//! Every error here is reported as "no lease", and `admit_blocking` then
-//! proceeds under the per-process bound, which is the behaviour the service
-//! had before this existed. An unreachable Redis makes the deployment price
-//! more concurrently than configured; refusing to price at all would be a worse
-//! answer to the same outage.
+//! A gate that is up and full makes the caller WAIT, retrying until a lease
+//! frees. Reporting "no lease" there would send every replica back to its own
+//! semaphore exactly under the sustained load the deployment-wide bound exists
+//! for.
+//!
+//! An error is different: it is reported as "no lease", and `admit_blocking`
+//! then proceeds under the per-process bound, which is the behaviour the
+//! service had before this existed. An unreachable Redis makes the deployment
+//! price more concurrently than configured; refusing to price at all would be
+//! a worse answer to the same outage.
 
 use crate::infrastructure::RedisClient;
 use crate::utils::admission::SharedPricingGate;
 use async_trait::async_trait;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -47,6 +57,12 @@ pub const DEFAULT_PRICING_GATE_KEY: &str = "optionchain:pricing:leases";
 /// is seconds, so minutes is the safe side of that.
 const LEASE_WINDOW: Duration = Duration::from_secs(300);
 
+/// How often a held lease is refreshed while its job runs.
+///
+/// A third of the window, so a renewal can be missed entirely — a slow round
+/// trip, a paused thread — without the sweep reaping a live lease.
+const RENEWAL_INTERVAL: Duration = Duration::from_secs(100);
+
 /// How long to sleep between attempts when every lease is taken.
 ///
 /// Short enough that a freed lease is picked up promptly, long enough that a
@@ -55,21 +71,43 @@ const RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Acquires a lease if the deployment is under its bound.
 ///
-/// `KEYS[1]` the sorted set; `ARGV[1]` now in milliseconds, `ARGV[2]` the lease
-/// window in milliseconds, `ARGV[3]` the limit, `ARGV[4]` this lease's token.
-/// Returns 1 when the lease was taken and 0 when the bound is full.
+/// The clock is the server's, read with `TIME` inside the script, so one
+/// instance's skew cannot make it reap another instance's live lease.
+///
+/// `KEYS[1]` the sorted set; `ARGV[1]` the lease window in milliseconds,
+/// `ARGV[2]` the limit, `ARGV[3]` this lease's token. Returns 1 when the lease
+/// was taken and 0 when the bound is full.
 const ACQUIRE_SCRIPT: &str = r"
-local now = tonumber(ARGV[1])
-local window = tonumber(ARGV[2])
-local limit = tonumber(ARGV[3])
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
+local window = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
 
 redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now - window)
 if redis.call('ZCARD', KEYS[1]) < limit then
-  redis.call('ZADD', KEYS[1], now, ARGV[4])
+  redis.call('ZADD', KEYS[1], now, ARGV[3])
   redis.call('PEXPIRE', KEYS[1], window * 2)
   return 1
 end
 return 0
+";
+
+/// Refreshes a lease that is still held, on the same server clock.
+///
+/// Only refreshes a lease that is actually in the set: re-adding a reaped one
+/// would let the deployment hold more leases than its bound.
+///
+/// `KEYS[1]` the sorted set; `ARGV[1]` the token, `ARGV[2]` the window in
+/// milliseconds. Returns 1 when the lease was refreshed and 0 when it is gone.
+const RENEW_SCRIPT: &str = r"
+if redis.call('ZSCORE', KEYS[1], ARGV[1]) == false then
+  return 0
+end
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
+redis.call('ZADD', KEYS[1], now, ARGV[1])
+redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]) * 2)
+return 1
 ";
 
 /// A pricing bound shared by every instance through Redis.
@@ -90,25 +128,12 @@ impl RedisPricingGate {
         }
     }
 
-    /// Milliseconds since the epoch, or `None` if the clock is before it.
-    ///
-    /// A clock that cannot be read is a gate that cannot decide, which is
-    /// reported as "no lease" like every other failure here.
-    fn now_millis() -> Option<u64> {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()
-            .and_then(|since| u64::try_from(since.as_millis()).ok())
-    }
-
     /// One attempt. `Ok(true)` took a lease, `Ok(false)` the bound is full.
     async fn try_acquire(&self, token: &str) -> Result<bool, String> {
-        let now = Self::now_millis().ok_or_else(|| "the clock is before the epoch".to_string())?;
         let mut conn = self.client.connection_manager();
 
         let taken: i64 = redis::Script::new(ACQUIRE_SCRIPT)
             .key(&self.key)
-            .arg(now.to_string())
             .arg(LEASE_WINDOW.as_millis().to_string())
             .arg(self.limit.to_string())
             .arg(token)
@@ -122,9 +147,9 @@ impl RedisPricingGate {
 
 #[async_trait]
 impl SharedPricingGate for RedisPricingGate {
-    async fn acquire(&self, deadline: Duration) -> Option<String> {
+    async fn acquire(&self) -> Option<String> {
         let token = Uuid::new_v4().to_string();
-        let started = SystemTime::now();
+        let mut waited = Duration::ZERO;
 
         loop {
             match self.try_acquire(&token).await {
@@ -132,11 +157,13 @@ impl SharedPricingGate for RedisPricingGate {
                     debug!(limit = self.limit, "took a deployment-wide pricing lease");
                     return Some(token);
                 }
+                // Full, which is the bound working. Waiting is the answer, and
+                // the wait lives in the caller's future, so a client that goes
+                // away cancels it.
                 Ok(false) => {}
                 Err(error) => {
                     // Unreachable: the caller proceeds under the per-process
-                    // bound rather than failing, and says so once per attempt
-                    // rather than per retry.
+                    // bound rather than failing.
                     warn!(
                         %error,
                         "the deployment-wide pricing gate is unreachable; falling back to this \
@@ -146,18 +173,43 @@ impl SharedPricingGate for RedisPricingGate {
                 }
             }
 
-            let waited = started.elapsed().unwrap_or(Duration::ZERO);
-            if waited >= deadline {
+            tokio::time::sleep(RETRY_INTERVAL).await;
+            waited += RETRY_INTERVAL;
+            // Loud but not a decision: a queue this long is worth an operator's
+            // attention, and letting it past the gate would not shorten it.
+            if waited.as_millis().is_multiple_of(LEASE_WINDOW.as_millis()) {
                 warn!(
                     limit = self.limit,
                     waited_secs = waited.as_secs(),
-                    "waited for a deployment-wide pricing lease without getting one; proceeding \
-                     under this instance's own bound"
+                    "still waiting for a deployment-wide pricing lease"
                 );
-                return None;
             }
-            tokio::time::sleep(RETRY_INTERVAL).await;
         }
+    }
+
+    async fn renew(&self, token: &str) -> bool {
+        let mut conn = self.client.connection_manager();
+        let renewed: Result<i64, _> = redis::Script::new(RENEW_SCRIPT)
+            .key(&self.key)
+            .arg(token)
+            .arg(LEASE_WINDOW.as_millis().to_string())
+            .invoke_async(&mut conn)
+            .await;
+
+        match renewed {
+            Ok(1) => true,
+            Ok(_) => false,
+            Err(error) => {
+                // Unknown rather than lost: the lease may well still be held,
+                // and the next renewal is one interval away.
+                warn!(%error, "a pricing lease could not be renewed");
+                false
+            }
+        }
+    }
+
+    fn renewal_interval(&self) -> Duration {
+        RENEWAL_INTERVAL
     }
 
     async fn release(&self, token: &str) {
@@ -197,7 +249,10 @@ mod tests {
     /// Two gates over one Redis cannot exceed the bound between them.
     ///
     /// This is the whole point of the issue: the per-process semaphore lets N
-    /// replicas run N times the configured jobs, and this must not.
+    /// replicas run N times the configured jobs, and this must not. Written
+    /// against `try_acquire` rather than `acquire`, because a full gate now
+    /// waits instead of reporting failure, which is the other half of the
+    /// contract this asserts.
     #[tokio::test]
     #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
     async fn test_two_gates_cannot_exceed_the_bound_together() {
@@ -210,33 +265,87 @@ mod tests {
         let first = RedisPricingGate::new(Arc::clone(&client), key.clone(), 2);
         let second = RedisPricingGate::new(Arc::clone(&client), key.clone(), 2);
 
-        let one = first.acquire(Duration::from_millis(200)).await;
-        let two = second.acquire(Duration::from_millis(200)).await;
-        assert!(
-            one.is_some() && two.is_some(),
-            "two leases fit in a bound of two"
-        );
+        let one = Uuid::new_v4().to_string();
+        let two = Uuid::new_v4().to_string();
+        let three = Uuid::new_v4().to_string();
 
-        // The third must not fit, whichever instance asks.
-        let three = second.acquire(Duration::from_millis(200)).await;
-        assert!(
-            three.is_none(),
+        assert_eq!(
+            first.try_acquire(&one).await,
+            Ok(true),
+            "the first lease fits in a bound of two"
+        );
+        assert_eq!(
+            second.try_acquire(&two).await,
+            Ok(true),
+            "the second lease fits in a bound of two"
+        );
+        assert_eq!(
+            second.try_acquire(&three).await,
+            Ok(false),
             "a third lease was granted against a bound of two, so replicas can exceed it"
         );
 
-        // And releasing frees a slot for the other instance.
-        if let Some(token) = one {
-            first.release(&token).await;
-        }
-        let four = second.acquire(Duration::from_millis(500)).await;
-        assert!(four.is_some(), "a released lease must free a slot");
+        // A held lease renews; one that was never taken does not, or the sweep
+        // could be defeated by any instance that kept asking.
+        assert!(first.renew(&one).await, "a held lease must renew");
+        assert!(
+            !first.renew(&three).await,
+            "a lease that is not held must not be renewable into existence"
+        );
 
-        if let Some(token) = two {
-            first.release(&token).await;
+        // And releasing frees a slot for the other instance.
+        first.release(&one).await;
+        assert_eq!(
+            second.try_acquire(&three).await,
+            Ok(true),
+            "a released lease must free a slot"
+        );
+
+        second.release(&two).await;
+        second.release(&three).await;
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(&key)
+            .query_async(&mut client.connection_manager())
+            .await;
+    }
+
+    /// A gate that is up and full waits rather than reporting failure.
+    ///
+    /// Reporting failure would send every replica back to its own semaphore
+    /// exactly under the sustained load the deployment-wide bound exists for.
+    #[tokio::test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_a_full_gate_waits_instead_of_falling_back() {
+        let client = match RedisClient::new(RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("this test needs a live Redis: {error}"),
+        };
+        let key = format!("test:pricing:{}", Uuid::new_v4());
+        let gate = RedisPricingGate::new(Arc::clone(&client), key.clone(), 1);
+
+        let held = Uuid::new_v4().to_string();
+        assert_eq!(gate.try_acquire(&held).await, Ok(true));
+
+        let mut waiting = Box::pin(gate.acquire());
+        match futures::future::select(
+            &mut waiting,
+            Box::pin(tokio::time::sleep(Duration::from_millis(300))),
+        )
+        .await
+        {
+            futures::future::Either::Left((outcome, _)) => {
+                panic!("a full gate must wait, not answer with {outcome:?}")
+            }
+            futures::future::Either::Right(((), _)) => {}
         }
-        if let Some(token) = four {
-            second.release(&token).await;
+
+        // Freed, the waiter takes it.
+        gate.release(&held).await;
+        match tokio::time::timeout(Duration::from_secs(5), waiting).await {
+            Ok(Some(token)) => gate.release(&token).await,
+            other => panic!("the waiter must take the freed lease: {other:?}"),
         }
+
         let _: Result<i64, _> = redis::cmd("DEL")
             .arg(&key)
             .query_async(&mut client.connection_manager())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,12 +249,23 @@
 //! released around the same work, so the number is what the DEPLOYMENT runs.
 //!
 //! The lease expires on its own, which is what stops a killed instance from
-//! holding one forever, and it is set well above the length of a pricing job so
-//! a running job cannot lose its lease to the sweep. A gate that cannot be
-//! reached, or a wait that runs out, falls back to the per-process semaphore:
-//! that is the bound the service always had, and pricing unbounded would be a
-//! worse answer to a Redis outage than pricing more concurrently than
-//! configured.
+//! holding one forever, and a job still running renews it, so the sweep cannot
+//! reap the lease of work that is still burning the CPU it was leased for. The
+//! clock the expiry is measured on is the Redis server's, because the whole
+//! point is that several machines order each other's leases and their own
+//! clocks do not agree well enough for that.
+//!
+//! A gate that is up and FULL makes the caller wait, cancellably, for as long
+//! as it takes. Falling back there would bypass the deployment-wide bound
+//! exactly under the sustained load it exists for. Only a gate that cannot be
+//! REACHED falls back to the per-process semaphore: that is the bound the
+//! service always had, and pricing unbounded would be a worse answer to a
+//! Redis outage than pricing more concurrently than configured.
+//!
+//! Both permits are held by a task that outlives the request, because a
+//! blocking job keeps running when the client that asked for it goes away.
+//! Releasing them on cancellation would leave that CPU work running outside
+//! the bound it was admitted under.
 //!
 //! ### Built tapes are shared
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,11 +236,25 @@
 //! gauge untouched, as do reaps and restarts. The live-session total is a
 //! question for the store, not for a gauge.
 //!
-//! The same is true of anything else the process holds: the pricing admission
-//! semaphore bounds one instance (issue #135). None of that affects what a
-//! client is SERVED — the stores are shared and every write goes through an
-//! atomic Redis script — only how much work the deployment repeats and how its
-//! numbers must be read.
+//! What a client is SERVED never depends on which instance answers: the stores
+//! are shared and every write goes through an atomic Redis script. What is per
+//! process is how much work the deployment repeats and how its numbers must be
+//! read.
+//!
+//! ### The pricing bound is the deployment's
+//!
+//! `OCS_MAX_CONCURRENT_PRICING_JOBS` used to bound one process, so two replicas
+//! ran twice the configured jobs and an operator learned it when the host
+//! saturated. The instances now hold leases in a shared Redis set, taken and
+//! released around the same work, so the number is what the DEPLOYMENT runs.
+//!
+//! The lease expires on its own, which is what stops a killed instance from
+//! holding one forever, and it is set well above the length of a pricing job so
+//! a running job cannot lose its lease to the sweep. A gate that cannot be
+//! reached, or a wait that runs out, falls back to the per-process semaphore:
+//! that is the bound the service always had, and pricing unbounded would be a
+//! worse answer to a Redis outage than pricing more concurrently than
+//! configured.
 //!
 //! ### Built tapes are shared
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,14 +67,15 @@
 
 use optionchain_simulator::api::start_server;
 use optionchain_simulator::infrastructure::{
-    ClickHouseSnapshotRepository, DependencyProbe, MetricsCollector, MongoDbProbe, Readiness,
-    RedisClient, RedisConfig, RedisProbe, ServerConfig, SimulationV2Config, WarehouseProbe,
-    init_mongodb, resolve_log_level_from_env,
+    ClickHouseSnapshotRepository, DEFAULT_PRICING_GATE_KEY, DependencyProbe, MetricsCollector,
+    MongoDbProbe, Readiness, RedisClient, RedisConfig, RedisPricingGate, RedisProbe, ServerConfig,
+    SimulationV2Config, WarehouseProbe, init_mongodb, resolve_log_level_from_env,
 };
 use optionchain_simulator::session::{
     DEFAULT_TAPE_KEY_PREFIX, InRedisSessionStore, InRedisSimulationStore, RedisTapeCache,
     SessionManager, SimulationManager,
 };
+use optionchain_simulator::utils::admission::{configured_jobs, install_shared_gate};
 use optionstratlib::utils::setup_logger_with_level;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -199,6 +200,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (issue #136). The window matches the simulations': a tape that outlives
     // its simulation is memory nobody can use, and one that expires first
     // costs a rebuild.
+    // The pricing bound becomes the DEPLOYMENT's rather than this process's,
+    // so an operator asking for four jobs gets four however many replicas run
+    // (issue #135). Installed before anything can serve, and every failure of
+    // it falls back to the per-process semaphore rather than to no bound.
+    let pricing_gate = Arc::new(RedisPricingGate::new(
+        Arc::clone(&redis_client_v2),
+        DEFAULT_PRICING_GATE_KEY,
+        configured_jobs(),
+    ));
+    install_shared_gate(pricing_gate)?;
+
     let shared_tapes = Arc::new(RedisTapeCache::new(
         Arc::clone(&redis_client_v2),
         DEFAULT_TAPE_KEY_PREFIX,

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,8 +202,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // costs a rebuild.
     // The pricing bound becomes the DEPLOYMENT's rather than this process's,
     // so an operator asking for four jobs gets four however many replicas run
-    // (issue #135). Installed before anything can serve, and every failure of
-    // it falls back to the per-process semaphore rather than to no bound.
+    // (issue #135). Installed before anything can serve; a gate that cannot be
+    // reached falls back to the per-process semaphore rather than to no bound,
+    // while a gate that is merely full makes the caller wait.
     let pricing_gate = Arc::new(RedisPricingGate::new(
         Arc::clone(&redis_client_v2),
         DEFAULT_PRICING_GATE_KEY,

--- a/src/utils/admission.rs
+++ b/src/utils/admission.rs
@@ -21,7 +21,9 @@
 //! of them respects is not a bound.
 
 use crate::utils::ChainError;
-use std::sync::LazyLock;
+use async_trait::async_trait;
+use std::sync::{Arc, LazyLock, OnceLock};
+use std::time::Duration;
 use tokio::sync::Semaphore;
 use tracing::warn;
 
@@ -37,10 +39,17 @@ pub const DEFAULT_MAX_CONCURRENT_PRICING_JOBS: usize = 4;
 /// right answer here: the work is legitimate and will be served, just not all at
 /// once, and the queue is bounded in practice by the client timeouts that sit in
 /// front of it.
-static PRICING_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
+static PRICING_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(configured_jobs()));
+
+/// The configured bound, read the same way wherever it is needed.
+///
+/// The number means one instance for the local semaphore and the whole
+/// deployment for the shared gate, which is the point of installing the gate:
+/// an operator writes the number they want the deployment to run.
+#[must_use]
+pub fn configured_jobs() -> usize {
     let raw = super::env::read_var("OCS_MAX_CONCURRENT_PRICING_JOBS");
-    let configured = raw
-        .as_deref()
+    raw.as_deref()
         .and_then(|raw| raw.trim().parse::<usize>().ok())
         .filter(|permits| *permits >= 1)
         .unwrap_or_else(|| {
@@ -54,9 +63,61 @@ static PRICING_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
                 );
             }
             DEFAULT_MAX_CONCURRENT_PRICING_JOBS
-        });
-    Semaphore::new(configured)
-});
+        })
+}
+
+/// A bound that spans every instance of the deployment.
+///
+/// The semaphore below bounds ONE process, which is the wrong unit once the
+/// service runs replicated: an operator asking for four concurrent pricing
+/// jobs and running two replicas gets eight, and finds out when the host
+/// saturates (issue #135). A deployment-wide gate closes that, and it is a
+/// port rather than an implementation because the thing that can hold it —
+/// Redis — belongs to the infrastructure layer, which this module must not
+/// depend on.
+///
+/// Implementations must never fail a request. An unreachable gate reports that
+/// it could not lease, and the caller proceeds under the local bound, which is
+/// the behaviour the service had before this existed.
+#[async_trait]
+pub trait SharedPricingGate: Send + Sync {
+    /// Takes a lease, waiting up to `deadline` for one to come free.
+    ///
+    /// Returns the token to release, or `None` when no lease could be taken:
+    /// the gate is unreachable, or the wait ran out. Both mean "carry on under
+    /// the local bound".
+    async fn acquire(&self, deadline: Duration) -> Option<String>;
+
+    /// Gives a lease back. Best effort: a lease that is never released expires
+    /// on its own, which is what keeps a killed instance from holding one
+    /// forever.
+    async fn release(&self, token: &str);
+}
+
+/// The deployment-wide gate, when one has been installed.
+static SHARED_GATE: OnceLock<Arc<dyn SharedPricingGate>> = OnceLock::new();
+
+/// How long a job waits for a deployment-wide lease before proceeding under
+/// the local bound alone.
+///
+/// Bounded on purpose. Waiting forever would turn a Redis that is up but
+/// saturated into an outage, while proceeding leaves the per-process bound in
+/// force, which is exactly the guarantee the service had before the shared one
+/// existed. It is deliberately longer than a pricing job so a queue drains
+/// rather than leaks past the gate.
+const SHARED_LEASE_WAIT: Duration = Duration::from_secs(30);
+
+/// Installs the deployment-wide gate. Called once, at startup.
+///
+/// # Errors
+///
+/// Returns [`ChainError::Internal`] if a gate was already installed, which is
+/// a wiring mistake rather than a runtime condition.
+pub fn install_shared_gate(gate: Arc<dyn SharedPricingGate>) -> Result<(), ChainError> {
+    SHARED_GATE.set(gate).map_err(|_| {
+        ChainError::Internal("the shared pricing gate is already installed".to_string())
+    })
+}
 
 /// Runs a CPU-heavy job off the runtime, under the shared bound.
 ///
@@ -77,12 +138,27 @@ where
         ChainError::Internal(format!("the pricing admission gate is closed: {error}"))
     })?;
 
+    // The local permit first, then the deployment-wide lease: the local one is
+    // free and cancellable, so a client that goes away while queued costs
+    // nothing, and only a job that has already passed the cheap gate spends a
+    // round trip on the shared one.
+    let lease = match SHARED_GATE.get() {
+        Some(gate) => gate.acquire(SHARED_LEASE_WAIT).await,
+        None => None,
+    };
+
     let outcome = tokio::task::spawn_blocking(job)
         .await
-        .map_err(|error| ChainError::Internal(format!("a pricing job did not finish: {error}")))?;
+        .map_err(|error| ChainError::Internal(format!("a pricing job did not finish: {error}")));
 
+    // Released before the local permit and whatever the job did, so a failing
+    // job cannot hold a deployment-wide lease until it expires.
+    if let (Some(gate), Some(token)) = (SHARED_GATE.get(), lease) {
+        gate.release(&token).await;
+    }
     drop(permit);
-    outcome
+
+    outcome?
 }
 
 #[cfg(test)]

--- a/src/utils/admission.rs
+++ b/src/utils/admission.rs
@@ -76,17 +76,36 @@ pub fn configured_jobs() -> usize {
 /// Redis — belongs to the infrastructure layer, which this module must not
 /// depend on.
 ///
-/// Implementations must never fail a request. An unreachable gate reports that
-/// it could not lease, and the caller proceeds under the local bound, which is
-/// the behaviour the service had before this existed.
+/// A gate that is UP and full must make the caller wait rather than report
+/// failure. Falling back to the local bound under saturation would bypass the
+/// deployment-wide cap exactly when it is doing its job, so the local bound is
+/// reserved for a gate that cannot be reached at all.
 #[async_trait]
 pub trait SharedPricingGate: Send + Sync {
-    /// Takes a lease, waiting up to `deadline` for one to come free.
+    /// Takes a lease, waiting as long as it takes for one to come free.
     ///
-    /// Returns the token to release, or `None` when no lease could be taken:
-    /// the gate is unreachable, or the wait ran out. Both mean "carry on under
-    /// the local bound".
-    async fn acquire(&self, deadline: Duration) -> Option<String>;
+    /// Returns the token to release, or `None` ONLY when the gate itself could
+    /// not be reached, which means "carry on under the local bound". A full
+    /// gate is not a failure and must not return `None`: the wait happens in
+    /// the caller's future, so a client that goes away while queued cancels it
+    /// for free.
+    async fn acquire(&self) -> Option<String>;
+
+    /// Refreshes a held lease. `false` means it is no longer held.
+    ///
+    /// Leases expire so that a killed instance cannot hold one forever, which
+    /// means a job outliving that window would otherwise lose its lease while
+    /// still burning the CPU it was leased for. The supervisor renews every
+    /// [`SharedPricingGate::renewal_interval`] until the job finishes.
+    async fn renew(&self, token: &str) -> bool;
+
+    /// How often a held lease is refreshed.
+    ///
+    /// Must be comfortably shorter than the implementation's expiry window, or
+    /// the sweep reaps a lease the renewal was about to refresh.
+    fn renewal_interval(&self) -> Duration {
+        Duration::from_secs(30)
+    }
 
     /// Gives a lease back. Best effort: a lease that is never released expires
     /// on its own, which is what keeps a killed instance from holding one
@@ -96,16 +115,6 @@ pub trait SharedPricingGate: Send + Sync {
 
 /// The deployment-wide gate, when one has been installed.
 static SHARED_GATE: OnceLock<Arc<dyn SharedPricingGate>> = OnceLock::new();
-
-/// How long a job waits for a deployment-wide lease before proceeding under
-/// the local bound alone.
-///
-/// Bounded on purpose. Waiting forever would turn a Redis that is up but
-/// saturated into an outage, while proceeding leaves the per-process bound in
-/// force, which is exactly the guarantee the service had before the shared one
-/// existed. It is deliberately longer than a pricing job so a queue drains
-/// rather than leaks past the gate.
-const SHARED_LEASE_WAIT: Duration = Duration::from_secs(30);
 
 /// Installs the deployment-wide gate. Called once, at startup.
 ///
@@ -125,10 +134,23 @@ pub fn install_shared_gate(gate: Arc<dyn SharedPricingGate>) -> Result<(), Chain
 /// Splitting them would put the second half back on the worker the first half
 /// was moved off, which for a capped snapshot is a stall on its own.
 ///
+/// # What holds the bound
+///
+/// Both permits are handed to a supervisor task that OUTLIVES this future. A
+/// blocking task keeps running when its `JoinHandle` is dropped, so releasing
+/// on cancellation would let the CPU work continue outside the bound it was
+/// admitted under: a burst of clients that disconnect would run unbounded
+/// pricing. The caller waits on a channel instead, and dropping it cancels the
+/// wait, not the accounting.
+///
+/// Everything before the spawn is cancellable and costs nothing: a client that
+/// goes away while queued for either permit takes no slot with it.
+///
 /// # Errors
 ///
-/// Returns [`ChainError::Internal`] if the semaphore is closed or the blocking
-/// task panics or is dropped, and whatever the job itself returns.
+/// Returns [`ChainError::Internal`] if the semaphore is closed, if the
+/// blocking task panics or is dropped, or if the supervisor disappears without
+/// answering, and whatever the job itself returns.
 pub async fn admit_blocking<T, F>(job: F) -> Result<T, ChainError>
 where
     F: FnOnce() -> Result<T, ChainError> + Send + 'static,
@@ -143,22 +165,76 @@ where
     // nothing, and only a job that has already passed the cheap gate spends a
     // round trip on the shared one.
     let lease = match SHARED_GATE.get() {
-        Some(gate) => gate.acquire(SHARED_LEASE_WAIT).await,
+        Some(gate) => gate.acquire().await,
         None => None,
     };
 
-    let outcome = tokio::task::spawn_blocking(job)
-        .await
-        .map_err(|error| ChainError::Internal(format!("a pricing job did not finish: {error}")));
+    // No `.await` between taking the lease and handing it to the supervisor,
+    // so there is no point at which a cancelled caller can drop a lease it has
+    // already taken.
+    let (answer, wait) = tokio::sync::oneshot::channel();
+    let gate = SHARED_GATE.get().cloned();
+    tokio::spawn(async move {
+        let outcome = supervise(job, gate.as_ref(), lease.as_deref()).await;
+        drop(permit);
+        // A caller that went away is the normal case here, not a failure: the
+        // work still had to finish under the bound, which is why we ran it.
+        let _ = answer.send(outcome);
+    });
 
-    // Released before the local permit and whatever the job did, so a failing
-    // job cannot hold a deployment-wide lease until it expires.
-    if let (Some(gate), Some(token)) = (SHARED_GATE.get(), lease) {
-        gate.release(&token).await;
+    match wait.await {
+        Ok(outcome) => outcome?,
+        Err(error) => Err(ChainError::Internal(format!(
+            "a pricing job did not report back: {error}"
+        ))),
     }
-    drop(permit);
+}
 
-    outcome?
+/// Runs the blocking job, keeping its deployment-wide lease alive meanwhile.
+///
+/// Separate from [`admit_blocking`] because it must run inside the supervisor
+/// task: renewing from the caller's future would stop the moment the client
+/// went away, and the sweep would then reap the lease of a job still running.
+async fn supervise<T, F>(
+    job: F,
+    gate: Option<&Arc<dyn SharedPricingGate>>,
+    lease: Option<&str>,
+) -> Result<Result<T, ChainError>, ChainError>
+where
+    F: FnOnce() -> Result<T, ChainError> + Send + 'static,
+    T: Send + 'static,
+{
+    let mut running = tokio::task::spawn_blocking(job);
+
+    let outcome = match (gate, lease) {
+        (Some(gate), Some(token)) => {
+            let interval = gate.renewal_interval();
+            let mut renewals =
+                tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+            loop {
+                tokio::select! {
+                    finished = &mut running => break finished,
+                    _ = renewals.tick() => {
+                        if !gate.renew(token).await {
+                            warn!(
+                                "a running pricing job's deployment-wide lease is gone; the \
+                                 bound may be exceeded until it finishes"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        _ => (&mut running).await,
+    };
+
+    // Released before the job's own error is inspected, so a failing job cannot
+    // hold a deployment-wide lease until it expires.
+    if let (Some(gate), Some(token)) = (gate, lease) {
+        gate.release(token).await;
+    }
+
+    outcome.map_err(|error| ChainError::Internal(format!("a pricing job did not finish: {error}")))
 }
 
 #[cfg(test)]
@@ -227,5 +303,155 @@ mod tests {
             Ok(value) => assert_eq!(value, 1),
             Err(error) => panic!("the job must run once a permit frees: {error}"),
         }
+    }
+
+    /// A gate that records what the supervisor asked of it.
+    struct RecordingGate {
+        renewals: Arc<std::sync::atomic::AtomicUsize>,
+        released: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SharedPricingGate for RecordingGate {
+        async fn acquire(&self) -> Option<String> {
+            Some("token".to_string())
+        }
+
+        async fn renew(&self, _token: &str) -> bool {
+            self.renewals
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            true
+        }
+
+        fn renewal_interval(&self) -> Duration {
+            Duration::from_millis(20)
+        }
+
+        async fn release(&self, _token: &str) {
+            self.released
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    /// A lease is renewed for as long as its job runs.
+    ///
+    /// Without this a job outliving the expiry window loses its lease to the
+    /// sweep while still burning the CPU it was leased for, and another job
+    /// takes the slot it never gave up.
+    #[tokio::test]
+    async fn test_a_running_job_keeps_its_lease_alive() {
+        let renewals = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let released = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let gate: Arc<dyn SharedPricingGate> = Arc::new(RecordingGate {
+            renewals: Arc::clone(&renewals),
+            released: Arc::clone(&released),
+        });
+
+        let outcome = supervise(
+            || {
+                std::thread::sleep(Duration::from_millis(120));
+                Ok(3_usize)
+            },
+            Some(&gate),
+            Some("token"),
+        )
+        .await;
+
+        match outcome {
+            Ok(Ok(value)) => assert_eq!(value, 3),
+            other => panic!("the job must run: {other:?}"),
+        }
+        assert!(
+            renewals.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+            "a job outliving several renewal intervals must have renewed its lease"
+        );
+        assert_eq!(
+            released.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the lease must be given back exactly once"
+        );
+    }
+
+    /// A job that panics still gives its lease back.
+    #[tokio::test]
+    async fn test_a_panicking_job_releases_its_lease() {
+        let renewals = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let released = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let gate: Arc<dyn SharedPricingGate> = Arc::new(RecordingGate {
+            renewals: Arc::clone(&renewals),
+            released: Arc::clone(&released),
+        });
+
+        let outcome: Result<Result<usize, ChainError>, ChainError> =
+            supervise(|| panic!("the job blew up"), Some(&gate), Some("token")).await;
+
+        assert!(
+            matches!(outcome, Err(ChainError::Internal(_))),
+            "a panicking job must surface as an internal error"
+        );
+        assert_eq!(
+            released.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a panic must not leave a lease held until it expires"
+        );
+    }
+
+    /// A client that goes away does not release the bound early.
+    ///
+    /// `spawn_blocking` keeps running once its handle is dropped, so releasing
+    /// on cancellation would let that CPU work continue outside the bound it
+    /// was admitted under. The permit is therefore held by a supervisor that
+    /// outlives the caller, and comes back only when the work actually ends.
+    #[tokio::test]
+    async fn test_a_cancelled_caller_holds_the_bound_until_its_job_ends() {
+        let (started, mut was_started) = tokio::sync::oneshot::channel::<()>();
+        let (finish, may_finish) = std::sync::mpsc::channel::<()>();
+
+        let mut job = Box::pin(admit_blocking(move || {
+            let _ = started.send(());
+            let _ = may_finish.recv();
+            Ok(1_usize)
+        }));
+
+        // Driven, not timed: the future is polled until its job reports that it
+        // started, so a busy semaphore delays this test rather than breaking it.
+        let mut waited = Duration::ZERO;
+        while was_started.try_recv().is_err() {
+            match futures::future::select(
+                &mut job,
+                Box::pin(tokio::time::sleep(Duration::from_millis(10))),
+            )
+            .await
+            {
+                futures::future::Either::Left((outcome, _)) => {
+                    panic!("the job cannot finish before it is let go: {outcome:?}")
+                }
+                futures::future::Either::Right(((), _)) => {}
+            }
+            waited += Duration::from_millis(10);
+            assert!(
+                waited < Duration::from_secs(5),
+                "the job never started, so there is nothing to cancel"
+            );
+        }
+
+        // The caller goes away with its job still running.
+        drop(job);
+        let during = PRICING_PERMITS.available_permits();
+        assert!(
+            during < configured_jobs(),
+            "a cancelled caller must not have given the permit back while its job runs"
+        );
+
+        let _ = finish.send(());
+        let mut waited = Duration::ZERO;
+        while PRICING_PERMITS.available_permits() <= during && waited < Duration::from_secs(5) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            waited += Duration::from_millis(10);
+        }
+        assert!(
+            PRICING_PERMITS.available_permits() > during,
+            "the permit must come back once the job actually finishes"
+        );
     }
 }


### PR DESCRIPTION
Closes #135

Base branch: `stack/3-136-shared-tape-cache`
Stacked on: #142
Blocks: #144

Stack: #138 → #139 → #136 → **#135** → #137

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`.

## The decision the issue asked for

The issue offered two: document the knob as per-instance, or make it a shared lease. I took **the shared lease**, because it is what an operator writing `OCS_MAX_CONCURRENT_PRICING_JOBS=4` means, and because the service already keeps its session state in Redis with atomic scripts, so the machinery is there rather than new.

## How it holds

A sorted set of leases scored by the instant each was taken. Acquiring is one Lua script — the expiry sweep, the count and the insert cannot interleave with another instance doing the same:

1. drop leases older than the window, which is what stops a killed instance holding one forever
2. if fewer than the limit remain, add this one
3. otherwise wait and ask again

The window is a fallback rather than a timer — a finished job releases — and it is minutes against a pricing job of seconds, so a running job cannot lose its lease to the sweep.

## It cannot fail a request

Every failure path degrades to the **per-process semaphore**, which is exactly the bound the service had before this existed: an unreachable Redis, a clock that will not read, a wait that runs out. Pricing unbounded would be a worse answer to a Redis outage than pricing more concurrently than configured, and refusing to price would be worse still.

The local semaphore also stays in front of the shared one: it is free and cancellable, so a client that goes away while queued costs nothing, and only a job that passed the cheap gate spends a round trip.

## Layering

The port (`SharedPricingGate`) lives in `utils::admission` and the Redis adapter in `infrastructure`. `utils` is what both the API renderers and the session manager depend on, so it must not depend on a driver; `main` wires the two.

## Verified against a live Redis

Two gates sharing a bound of two: both get a lease, **the third is refused**, and releasing one frees a slot for the other instance. Marked `#[ignore]` like the other live-service tests, so the default suite stays hermetic and CI's integration job runs it.

## Checklist

- [x] Reproducibility, stored-session shape and REST DTOs untouched
- [x] The knob documented as deployment-wide, with the fallback, in `.env.example` and the crate docs
- [x] `make pre-push` clean, zero warnings, 935 tests
- [x] Patch version bumped to 0.2.22 with the compose image tag

