### PR TITLE
One instance builds a tape, not one per instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.22}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.23}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a

--- a/README.md
+++ b/README.md
@@ -310,6 +310,13 @@ The snapshot cache is still per instance (issue #136's second item), which
 is a smaller loss: rebuilding a snapshot from a cached tape is far cheaper
 than building the tape.
 
+Only ONE instance builds a given tape. A build is claimed in the same
+Redis before it starts, so the coalescing that stops N concurrent readers
+of one process starting N identical builds now spans the deployment. The
+claim expires, and a waiter that does not see the tape in time builds it
+anyway: an instance killed mid-build costs a duplicated build rather than
+a request that never answers.
+
 **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the
 cursor and then advances it, so a session with `steps = N` serves EXACTLY indices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,13 @@
 //! is a smaller loss: rebuilding a snapshot from a cached tape is far cheaper
 //! than building the tape.
 //!
+//! Only ONE instance builds a given tape. A build is claimed in the same
+//! Redis before it starts, so the coalescing that stops N concurrent readers
+//! of one process starting N identical builds now spans the deployment. The
+//! claim expires, and a waiter that does not see the tape in time builds it
+//! anyway: an instance killed mid-build costs a duplicated build rather than
+//! a request that never answers.
+//!
 //! **Step cursor semantics (serve-then-advance):** `current_step` is the 0-based index
 //! of the NEXT snapshot to serve. `POST /api/v1/chain/step` serves the snapshot at the
 //! cursor and then advances it, so a session with `steps = N` serves EXACTLY indices

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -33,10 +33,30 @@ use crate::utils::ChainError;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
+
+/// How long a caller waits for the instance that claimed a build.
+///
+/// Long enough for a tape of the maximum step count, short enough that an
+/// owner which died leaves the others building rather than waiting out the
+/// claim's own expiry.
+const SHARED_BUILD_WAIT: Duration = Duration::from_secs(30);
+
+/// How often a waiter looks for the tape the owner is building.
+const SHARED_BUILD_POLL: Duration = Duration::from_millis(50);
+
+/// What asking for the deployment-wide build claim produced.
+enum SharedBuild {
+    /// This caller builds.
+    Owner,
+    /// Another instance built it, and here it is.
+    Waited(FactorTape),
+    /// Another instance owns the claim but published nothing in time.
+    Unavailable,
+}
 
 /// One cached factor tape and the last time it was used.
 struct TapeEntry {
@@ -90,6 +110,13 @@ pub struct SimulationManager {
     /// failure of the shared one is treated as `None` for that call: a cache
     /// that cannot be reached is a miss, never a failed request.
     shared_tapes: Option<Arc<dyn SharedTapeCache>>,
+    /// How long to wait for the instance that claimed a build before building
+    /// it here.
+    ///
+    /// A field rather than a constant so a test can prove the give-up path
+    /// without waiting out the production value, which is deliberately as long
+    /// as the slowest build.
+    shared_build_wait: Duration,
     /// Where served snapshots are queued for filing, when the operator turned
     /// persistence on. `None` is the default and the whole feature is then
     /// absent from the serving path — no connection, no latency, no failure
@@ -155,6 +182,7 @@ impl SimulationManager {
                 config.max_cached_snapshot_contracts,
             ))),
             shared_tapes: None,
+            shared_build_wait: SHARED_BUILD_WAIT,
             warehouse: None,
         }
     }
@@ -168,6 +196,17 @@ impl SimulationManager {
     #[must_use]
     pub fn with_shared_tapes(mut self, cache: Arc<dyn SharedTapeCache>) -> Self {
         self.shared_tapes = Some(cache);
+        self
+    }
+
+    /// How long to wait for another instance's build before building here.
+    ///
+    /// Exists for tests: production wants the default, which is sized for the
+    /// slowest build, and a test that has to reach the give-up path should not
+    /// spend that long doing it.
+    #[must_use]
+    pub fn with_shared_build_wait(mut self, wait: Duration) -> Self {
+        self.shared_build_wait = wait;
         self
     }
 
@@ -691,7 +730,24 @@ impl SimulationManager {
             };
         }
 
-        let result = self.build_tape(simulation).await;
+        // Within this process one caller builds and the rest wait, which is
+        // what `builds` above decided. Across instances the same question is
+        // asked of the shared cache: without it, N instances all believing
+        // they are the only builder run N copies of the one job the
+        // coalescing exists to avoid (issue #137).
+        let claim = self.claim_shared_build(simulation).await;
+        let owns_claim = matches!(claim, SharedBuild::Owner);
+        // A tape another instance published is already shared; only a tape
+        // built here is worth offering back.
+        let built_here = !matches!(claim, SharedBuild::Waited(_));
+        let result = match claim {
+            SharedBuild::Owner => self.build_tape(simulation).await,
+            SharedBuild::Waited(tape) => Ok(tape),
+            // Another instance owns it and did not publish in time. Building
+            // is the answer that still serves the request; the duplicate work
+            // is the price of not hanging.
+            SharedBuild::Unavailable => self.build_tape(simulation).await,
+        };
 
         // Publish to whoever is waiting and stop being the owner, in that
         // order: a caller that subscribes after the removal misses the
@@ -721,8 +777,16 @@ impl SimulationManager {
         // Only now offer it to the other instances: this process is already
         // served, so a slow or failing write costs the deployment a rebuild
         // elsewhere and costs this request nothing.
-        if let Ok(tape) = &result {
+        if let (true, Ok(tape)) = (built_here, &result) {
             self.share_tape(simulation, tape).await;
+        }
+
+        // The claim goes back after the shared write, not before: an instance
+        // that wakes on the release must find the tape rather than an empty
+        // key. Released whether the build succeeded or not, so a failure does
+        // not make the others wait out the expiry for a tape nobody wrote.
+        if owns_claim {
+            self.release_shared_build(simulation).await;
         }
 
         result
@@ -755,6 +819,52 @@ impl SimulationManager {
         })
         .await
         .map_err(|e| ChainError::Internal(format!("the factor tape build did not finish: {e}")))?
+    }
+
+    /// Claims the deployment-wide right to build this tape, or waits for the
+    /// instance that holds it.
+    ///
+    /// The wait is bounded and polls the shared cache rather than a channel:
+    /// there is no channel between processes, and an owner that dies would
+    /// otherwise leave every waiter hanging until its claim expired. When the
+    /// wait runs out this caller builds, which is duplicated work rather than
+    /// a request that never answers.
+    async fn claim_shared_build(&self, simulation: &SessionV2) -> SharedBuild {
+        let Some(shared) = self.shared_tapes.as_ref() else {
+            return SharedBuild::Owner;
+        };
+        let key = tape_key(simulation.id, &simulation.parameters);
+
+        if shared.claim_build(&key).await {
+            return SharedBuild::Owner;
+        }
+
+        debug!(
+            simulation_id = %simulation.id,
+            "another instance is building this tape; waiting for it"
+        );
+        let deadline = Instant::now() + self.shared_build_wait;
+        while Instant::now() < deadline {
+            tokio::time::sleep(SHARED_BUILD_POLL).await;
+            if let Some(tape) = self.shared_tape(simulation).await {
+                return SharedBuild::Waited(tape);
+            }
+        }
+
+        warn!(
+            simulation_id = %simulation.id,
+            waited_secs = self.shared_build_wait.as_secs(),
+            "the instance building this tape did not publish in time; building it here"
+        );
+        SharedBuild::Unavailable
+    }
+
+    /// Gives up the deployment-wide build claim.
+    async fn release_shared_build(&self, simulation: &SessionV2) {
+        if let Some(shared) = self.shared_tapes.as_ref() {
+            let key = tape_key(simulation.id, &simulation.parameters);
+            shared.release_build(&key).await;
+        }
     }
 
     /// The tape another instance left, decoded, or `None`.
@@ -983,8 +1093,11 @@ mod tests {
     #[derive(Default)]
     struct SharedTapes {
         entries: Mutex<HashMap<String, String>>,
+        /// The keys some instance has claimed the right to build.
+        building: Mutex<std::collections::HashSet<String>>,
         reads: AtomicUsize,
         writes: AtomicUsize,
+        claims: AtomicUsize,
     }
 
     impl SharedTapes {
@@ -994,6 +1107,10 @@ mod tests {
 
         fn reads(&self) -> usize {
             self.reads.load(Ordering::SeqCst)
+        }
+
+        fn claims(&self) -> usize {
+            self.claims.load(Ordering::SeqCst)
         }
 
         fn keys(&self) -> Vec<String> {
@@ -1033,6 +1150,23 @@ mod tests {
                     .retain(|key, _| !key.ends_with(&suffix)),
             }
         }
+
+        async fn claim_build(&self, key: &str) -> bool {
+            self.claims.fetch_add(1, Ordering::SeqCst);
+            let mut held = match self.building.lock() {
+                Ok(held) => held,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            held.insert(key.to_string())
+        }
+
+        async fn release_build(&self, key: &str) {
+            let mut held = match self.building.lock() {
+                Ok(held) => held,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            held.remove(key);
+        }
     }
 
     /// A shared cache that is always down, which is what an unreachable Redis
@@ -1048,6 +1182,14 @@ mod tests {
         async fn put(&self, _key: &str, _encoded: &str) {}
 
         async fn forget_simulation(&self, _id: &str) {}
+
+        /// A gate that cannot be reached must let the caller build, or an
+        /// unreachable Redis becomes an unanswerable request.
+        async fn claim_build(&self, _key: &str) -> bool {
+            true
+        }
+
+        async fn release_build(&self, _key: &str) {}
     }
 
     /// A warehouse that records what it was asked to file, and can be told to
@@ -1983,6 +2125,96 @@ mod tests {
             "the deleted simulation left {:?} behind in the shared cache",
             shared.keys()
         );
+    }
+
+    /// Only one instance builds a tape, even when both ask at once.
+    ///
+    /// Two managers over one store and one shared cache, both told to serve
+    /// the same simulation at the same moment. The write count is what
+    /// distinguishes a build from a read, and exactly one build may happen:
+    /// this is the coalescing that exists inside a process, extended across
+    /// them.
+    #[tokio::test]
+    async fn test_only_one_instance_builds_a_tape() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let first = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+        let second = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>);
+
+        let created = match first.create(parameters(4)).await {
+            Ok(created) => created,
+            Err(error) => panic!("the simulation must be created: {error}"),
+        };
+
+        // Both peek the same step at the same time, which is the shape a
+        // balancer produces when two clients arrive together.
+        let (one, two) = tokio::join!(first.peek(created.id), second.peek(created.id));
+        let one = match one {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the first instance must serve: {error}"),
+        };
+        let two = match two {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("the second instance must serve: {error}"),
+        };
+
+        assert_eq!(
+            shared.writes(),
+            1,
+            "two instances wrote {} tapes for one simulation, so both built it",
+            shared.writes()
+        );
+        assert!(
+            shared.claims() >= 2,
+            "both instances must have asked for the build claim, got {}",
+            shared.claims()
+        );
+        assert_eq!(
+            one.1.spot, two.1.spot,
+            "the instance that waited must serve what the builder built"
+        );
+    }
+
+    /// A claim that nobody releases does not wedge the next caller.
+    ///
+    /// The claim is held and never given back, which is what an instance
+    /// killed mid-build leaves behind. The next caller waits, gives up, and
+    /// builds rather than hanging.
+    #[tokio::test]
+    async fn test_an_abandoned_claim_does_not_block_a_build() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let manager = SimulationManager::new(
+            Arc::clone(&store) as Arc<dyn SimulationStore>,
+            SimulationV2Config::default(),
+        )
+        .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>)
+        .with_shared_build_wait(Duration::from_millis(200));
+
+        let created = match manager.create(parameters(3)).await {
+            Ok(created) => created,
+            Err(error) => panic!("{error}"),
+        };
+
+        // Somebody else claims the build and dies without publishing.
+        let key = tape_key(created.id, &created.parameters);
+        assert!(
+            shared.claim_build(&key).await,
+            "the claim must be free first"
+        );
+
+        match manager.peek(created.id).await {
+            Ok(_) => {}
+            Err(error) => panic!("an abandoned claim must not stop a build: {error}"),
+        }
     }
 
     /// A shared cache that cannot be reached costs a rebuild, not a failure.

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -27,7 +27,7 @@ use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
 use crate::infrastructure::{SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord};
 use crate::session::model::SessionState;
 use crate::session::snapshot_record::{snapshot_quote_count, snapshot_record};
-use crate::session::store::{SharedTapeCache, SimulationStore, tape_key};
+use crate::session::store::{BuildClaim, SharedTapeCache, SimulationStore, tape_key};
 use crate::session::{SessionV2, SimulationParametersV2};
 use crate::utils::ChainError;
 use std::collections::HashMap;
@@ -50,12 +50,147 @@ const SHARED_BUILD_POLL: Duration = Duration::from_millis(50);
 
 /// What asking for the deployment-wide build claim produced.
 enum SharedBuild {
-    /// This caller builds.
-    Owner,
+    /// This caller builds. The token, when there is one, is what releases the
+    /// claim; there is none when no cache is configured, when the cache could
+    /// not answer, or when the wait for another instance ran out.
+    Owner(Option<String>),
     /// Another instance built it, and here it is.
     Waited(FactorTape),
-    /// Another instance owns the claim but published nothing in time.
-    Unavailable,
+}
+
+/// Everything the owner of a tape build needs, owned rather than borrowed.
+///
+/// Owned because the workflow runs in a task that outlives the request that
+/// started it: the build cannot be cancelled once it is on the blocking pool,
+/// and the waiters, the shared cache and the deployment-wide claim must be
+/// settled whether the caller is still there or not.
+struct OwnedBuild {
+    id: Uuid,
+    /// The tape's shared-cache key, computed once by the caller.
+    key: String,
+    parameters: SimulationParametersV2,
+    tapes: Arc<Mutex<HashMap<Uuid, TapeEntry>>>,
+    builds: Arc<Mutex<HashMap<Uuid, TapeBuilds>>>,
+    shared: Option<Arc<dyn SharedTapeCache>>,
+    max_cached_tapes: usize,
+    shared_build_wait: Duration,
+}
+
+impl OwnedBuild {
+    /// Builds the tape (or takes another instance's), publishes it, and gives
+    /// back every claim it took.
+    async fn run(self, sender: TapeBuilds) {
+        let claim = self.claim().await;
+        let built_here = !matches!(claim, SharedBuild::Waited(_));
+        // Kept out of the match, which consumes the claim, because the token
+        // is what releases it at the end.
+        let token = match &claim {
+            SharedBuild::Owner(token) => token.clone(),
+            SharedBuild::Waited(_) => None,
+        };
+
+        let result = match claim {
+            SharedBuild::Waited(tape) => {
+                SimulationManager::cache_tape(
+                    &self.tapes,
+                    self.max_cached_tapes,
+                    self.id,
+                    tape.clone(),
+                );
+                Ok(tape)
+            }
+            SharedBuild::Owner(_) => {
+                SimulationManager::build_tape_into(
+                    self.parameters.clone(),
+                    self.id,
+                    Arc::clone(&self.tapes),
+                    self.max_cached_tapes,
+                )
+                .await
+            }
+        };
+
+        // Publish to whoever is waiting and stop being the owner, in that
+        // order: a caller that subscribes after the removal misses the
+        // broadcast, retries, and finds the tape in the cache.
+        //
+        // Before the shared write, deliberately. A slow Redis would otherwise
+        // hold every local waiter behind a round trip they do not need.
+        {
+            let mut builds = match self.builds.lock() {
+                Ok(builds) => builds,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            builds.remove(&self.id);
+        }
+        let published = match &result {
+            Ok(tape) => Ok(tape.clone()),
+            Err(error) => Err(error.to_string()),
+        };
+        // An error means nobody was waiting, which happens whenever the
+        // request that started this went away.
+        let _ = sender.send(published);
+
+        // Only now offer it to the other instances: this process is already
+        // served, so a slow or failing write costs the deployment a rebuild
+        // elsewhere and costs this request nothing. A tape another instance
+        // published is already there, so only one built here is worth writing.
+        if let (Some(shared), true, Ok(tape)) = (self.shared.as_ref(), built_here, &result) {
+            SimulationManager::share_tape_to(shared.as_ref(), &self.key, self.id, tape).await;
+        }
+
+        // The claim goes back after the shared write, not before: an instance
+        // that wakes on the release must find the tape rather than an empty
+        // key. Released whether the build succeeded or not, so a failure does
+        // not make the others wait out the expiry for a tape nobody wrote.
+        if let (Some(shared), Some(token)) = (self.shared.as_ref(), &token) {
+            shared.release_build(&self.key, token).await;
+        }
+    }
+
+    /// Claims the deployment-wide right to build this tape, or waits for the
+    /// instance that holds it.
+    ///
+    /// The wait is bounded and polls the shared cache rather than a channel:
+    /// there is no channel between processes, and an owner that dies would
+    /// otherwise leave every waiter hanging until its claim expired. When the
+    /// wait runs out this caller builds, which is duplicated work rather than
+    /// a request that never answers.
+    async fn claim(&self) -> SharedBuild {
+        let Some(shared) = self.shared.as_ref() else {
+            return SharedBuild::Owner(None);
+        };
+
+        match shared.claim_build(&self.key).await {
+            // Nothing to release: without a claim there is nothing this
+            // instance holds, and deleting the key would take a claim another
+            // instance owns.
+            BuildClaim::Unclaimed => return SharedBuild::Owner(None),
+            BuildClaim::Held(token) => return SharedBuild::Owner(Some(token)),
+            BuildClaim::Taken => {}
+        }
+
+        debug!(
+            simulation_id = %self.id,
+            "another instance is building this tape; waiting for it"
+        );
+        let deadline = Instant::now() + self.shared_build_wait;
+        while Instant::now() < deadline {
+            tokio::time::sleep(SHARED_BUILD_POLL).await;
+            if let Some(tape) =
+                SimulationManager::shared_tape_from(shared.as_ref(), &self.key, self.id).await
+            {
+                return SharedBuild::Waited(tape);
+            }
+        }
+
+        warn!(
+            simulation_id = %self.id,
+            waited_secs = self.shared_build_wait.as_secs(),
+            "the instance building this tape did not publish in time; building it here"
+        );
+        SharedBuild::Owner(None)
+    }
 }
 
 /// One cached factor tape and the last time it was used.
@@ -74,6 +209,9 @@ type SnapshotKey = (Uuid, usize);
 /// internal error, which is what the owner would have reported anyway.
 type SnapshotBuilds = broadcast::Sender<Result<SeriesSnapshot, String>>;
 
+/// How a tape build publishes its result to the callers waiting on it.
+type TapeBuilds = broadcast::Sender<Result<FactorTape, String>>;
+
 /// Owns the lifecycle of v2 rolling simulations.
 pub struct SimulationManager {
     store: Arc<dyn SimulationStore>,
@@ -87,7 +225,7 @@ pub struct SimulationManager {
     /// `spawn_blocking` does not bound that: its pool grows to hundreds of
     /// threads, so the cache would still be cold while every core was busy
     /// filling it with the same answer.
-    builds: Mutex<HashMap<Uuid, broadcast::Sender<Result<FactorTape, String>>>>,
+    builds: Arc<Mutex<HashMap<Uuid, TapeBuilds>>>,
     /// Snapshot builds currently running, one entry per `(simulation, step)`.
     ///
     /// The same argument as [`SimulationManager::builds`], one level down and
@@ -175,7 +313,7 @@ impl SimulationManager {
             store,
             config,
             tapes: Arc::new(Mutex::new(HashMap::new())),
-            builds: Mutex::new(HashMap::new()),
+            builds: Arc::new(Mutex::new(HashMap::new())),
             snapshot_builds: Mutex::new(HashMap::new()),
             snapshots: Arc::new(Mutex::new(SnapshotCache::with_bounds(
                 config.max_cached_snapshots,
@@ -682,11 +820,16 @@ impl SimulationManager {
         }
 
         let id = simulation.id;
+        // Computed ONCE. The key serialises every parameter, and a historical
+        // simulation carries its prices, so recomputing it per lookup — the
+        // waiter below polls twenty times a second — would put a large
+        // synchronous serialization on the runtime for every poll.
+        let key = tape_key(id, &simulation.parameters);
 
         // Another instance may already have walked this. Consulted before the
         // build lock rather than after, so a hit costs one round trip instead
         // of queueing behind a build that is about to be redundant.
-        if let Some(tape) = self.shared_tape(simulation).await {
+        if let Some(tape) = self.shared_tape(&key, id).await {
             Self::cache_tape(&self.tapes, self.config.max_cached_tapes, id, tape.clone());
             return Ok(tape);
         }
@@ -702,94 +845,54 @@ impl SimulationManager {
         // Either this call owns the build or it waits on the one already
         // running. Decided under the lock, so two callers cannot both decide
         // they are the owner.
-        let subscription = {
+        let (mut waiting, owned) = {
             let mut builds = match self.builds.lock() {
                 Ok(builds) => builds,
                 Err(poisoned) => poisoned.into_inner(),
             };
 
             match builds.get(&id) {
-                Some(running) => Some(running.subscribe()),
+                Some(running) => (running.subscribe(), None),
                 None => {
-                    let (sender, _) = broadcast::channel(1);
-                    builds.insert(id, sender);
-                    None
+                    let (sender, receiver) = broadcast::channel(1);
+                    builds.insert(id, sender.clone());
+                    (receiver, Some(sender))
                 }
             }
         };
 
-        if let Some(mut waiting) = subscription {
-            return match waiting.recv().await {
-                Ok(Ok(tape)) => Ok(tape),
-                // The owner failed; report what it reported rather than
-                // starting a second build that would fail the same way.
-                Ok(Err(reason)) => Err(ChainError::Internal(reason)),
-                // The owner's task died without publishing. Rare, and the
-                // honest answer is to build it here rather than hang.
-                Err(_) => self.build_tape(simulation).await,
-            };
+        // The owner's work runs in a task that OUTLIVES this future, and the
+        // owner waits on the same channel as everyone else. A blocking build
+        // keeps running when the client that asked for it disconnects, so
+        // doing this inline would let a cancelled owner leave its entry in
+        // `builds` with nobody to publish it, its deployment-wide claim held
+        // until expiry, and its tape unshared — local waiters hanging on a
+        // tape that was in fact built.
+        if let Some(sender) = owned {
+            tokio::spawn(
+                OwnedBuild {
+                    id,
+                    key,
+                    parameters: simulation.parameters.clone(),
+                    tapes: Arc::clone(&self.tapes),
+                    builds: Arc::clone(&self.builds),
+                    shared: self.shared_tapes.clone(),
+                    max_cached_tapes: self.config.max_cached_tapes,
+                    shared_build_wait: self.shared_build_wait,
+                }
+                .run(sender),
+            );
         }
 
-        // Within this process one caller builds and the rest wait, which is
-        // what `builds` above decided. Across instances the same question is
-        // asked of the shared cache: without it, N instances all believing
-        // they are the only builder run N copies of the one job the
-        // coalescing exists to avoid (issue #137).
-        let claim = self.claim_shared_build(simulation).await;
-        let owns_claim = matches!(claim, SharedBuild::Owner);
-        // A tape another instance published is already shared; only a tape
-        // built here is worth offering back.
-        let built_here = !matches!(claim, SharedBuild::Waited(_));
-        let result = match claim {
-            SharedBuild::Owner => self.build_tape(simulation).await,
-            SharedBuild::Waited(tape) => Ok(tape),
-            // Another instance owns it and did not publish in time. Building
-            // is the answer that still serves the request; the duplicate work
-            // is the price of not hanging.
-            SharedBuild::Unavailable => self.build_tape(simulation).await,
-        };
-
-        // Publish to whoever is waiting and stop being the owner, in that
-        // order: a caller that subscribes after the removal misses the
-        // broadcast, retries, and finds the tape in the cache.
-        //
-        // Before the shared write, deliberately. A slow Redis would otherwise
-        // hold every local waiter behind a round trip they do not need, and a
-        // cancellation during that await would leave this owner's entry in
-        // `builds` with nobody to publish it — waiters hanging on a tape that
-        // is already warm in this process.
-        let sender = {
-            let mut builds = match self.builds.lock() {
-                Ok(builds) => builds,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            builds.remove(&id)
-        };
-        if let Some(sender) = sender {
-            let published = match &result {
-                Ok(tape) => Ok(tape.clone()),
-                Err(error) => Err(error.to_string()),
-            };
-            // An error means nobody was waiting, which is the common case.
-            let _ = sender.send(published);
+        match waiting.recv().await {
+            Ok(Ok(tape)) => Ok(tape),
+            // The owner failed; report what it reported rather than
+            // starting a second build that would fail the same way.
+            Ok(Err(reason)) => Err(ChainError::Internal(reason)),
+            // The owner's task died without publishing. Rare, and the
+            // honest answer is to build it here rather than hang.
+            Err(_) => self.build_tape(simulation).await,
         }
-
-        // Only now offer it to the other instances: this process is already
-        // served, so a slow or failing write costs the deployment a rebuild
-        // elsewhere and costs this request nothing.
-        if let (true, Ok(tape)) = (built_here, &result) {
-            self.share_tape(simulation, tape).await;
-        }
-
-        // The claim goes back after the shared write, not before: an instance
-        // that wakes on the release must find the tape rather than an empty
-        // key. Released whether the build succeeded or not, so a failure does
-        // not make the others wait out the expiry for a tape nobody wrote.
-        if owns_claim {
-            self.release_shared_build(simulation).await;
-        }
-
-        result
     }
 
     /// Builds a tape off the runtime and files it.
@@ -807,11 +910,25 @@ impl SimulationManager {
     /// filing afterwards would throw away a build that ran to completion
     /// anyway.
     async fn build_tape(&self, simulation: &SessionV2) -> Result<FactorTape, ChainError> {
-        let parameters = simulation.parameters.clone();
-        let id = simulation.id;
-        let tapes = Arc::clone(&self.tapes);
-        let max_cached_tapes = self.config.max_cached_tapes;
+        Self::build_tape_into(
+            simulation.parameters.clone(),
+            simulation.id,
+            Arc::clone(&self.tapes),
+            self.config.max_cached_tapes,
+        )
+        .await
+    }
 
+    /// As [`Self::build_tape`], without borrowing the manager.
+    ///
+    /// Owned so the build can run in a task that outlives the request that
+    /// asked for it; see [`OwnedBuild`].
+    async fn build_tape_into(
+        parameters: SimulationParametersV2,
+        id: Uuid,
+        tapes: Arc<Mutex<HashMap<Uuid, TapeEntry>>>,
+        max_cached_tapes: usize,
+    ) -> Result<FactorTape, ChainError> {
         tokio::task::spawn_blocking(move || {
             let tape = FactorTape::build(&parameters, &parameters.method)?;
             Self::cache_tape(&tapes, max_cached_tapes, id, tape.clone());
@@ -821,69 +938,35 @@ impl SimulationManager {
         .map_err(|e| ChainError::Internal(format!("the factor tape build did not finish: {e}")))?
     }
 
-    /// Claims the deployment-wide right to build this tape, or waits for the
-    /// instance that holds it.
-    ///
-    /// The wait is bounded and polls the shared cache rather than a channel:
-    /// there is no channel between processes, and an owner that dies would
-    /// otherwise leave every waiter hanging until its claim expired. When the
-    /// wait runs out this caller builds, which is duplicated work rather than
-    /// a request that never answers.
-    async fn claim_shared_build(&self, simulation: &SessionV2) -> SharedBuild {
-        let Some(shared) = self.shared_tapes.as_ref() else {
-            return SharedBuild::Owner;
-        };
-        let key = tape_key(simulation.id, &simulation.parameters);
-
-        if shared.claim_build(&key).await {
-            return SharedBuild::Owner;
-        }
-
-        debug!(
-            simulation_id = %simulation.id,
-            "another instance is building this tape; waiting for it"
-        );
-        let deadline = Instant::now() + self.shared_build_wait;
-        while Instant::now() < deadline {
-            tokio::time::sleep(SHARED_BUILD_POLL).await;
-            if let Some(tape) = self.shared_tape(simulation).await {
-                return SharedBuild::Waited(tape);
-            }
-        }
-
-        warn!(
-            simulation_id = %simulation.id,
-            waited_secs = self.shared_build_wait.as_secs(),
-            "the instance building this tape did not publish in time; building it here"
-        );
-        SharedBuild::Unavailable
-    }
-
-    /// Gives up the deployment-wide build claim.
-    async fn release_shared_build(&self, simulation: &SessionV2) {
-        if let Some(shared) = self.shared_tapes.as_ref() {
-            let key = tape_key(simulation.id, &simulation.parameters);
-            shared.release_build(&key).await;
-        }
-    }
-
     /// The tape another instance left, decoded, or `None`.
+    ///
+    /// Takes the key rather than the simulation because computing it
+    /// serialises every parameter, which is expensive enough that the caller
+    /// does it once and reuses it.
+    async fn shared_tape(&self, key: &str, id: Uuid) -> Option<FactorTape> {
+        let shared = self.shared_tapes.as_ref()?;
+        Self::shared_tape_from(shared.as_ref(), key, id).await
+    }
+
+    /// As [`Self::shared_tape`], against a cache the caller already has.
     ///
     /// A stored document this build cannot decode is a miss, not an error: the
     /// key carries the snapshot generation and a fingerprint of the
     /// parameters, so it should not happen, and rebuilding is the answer that
     /// still serves the request.
-    async fn shared_tape(&self, simulation: &SessionV2) -> Option<FactorTape> {
-        let shared = self.shared_tapes.as_ref()?;
-        let key = tape_key(simulation.id, &simulation.parameters);
-        let encoded = shared.get(&key).await?;
+    async fn shared_tape_from(
+        shared: &dyn SharedTapeCache,
+        key: &str,
+        id: Uuid,
+    ) -> Option<FactorTape> {
+        let encoded = shared.get(key).await?;
 
         match serde_json::from_str::<FactorTape>(&encoded) {
             Ok(tape) => Some(tape),
             Err(error) => {
                 warn!(
                     %error,
-                    simulation_id = %simulation.id,
+                    simulation_id = %id,
                     "a shared tape did not decode; rebuilding it"
                 );
                 None
@@ -892,18 +975,12 @@ impl SimulationManager {
     }
 
     /// Leaves a built tape where the other instances can find it.
-    async fn share_tape(&self, simulation: &SessionV2, tape: &FactorTape) {
-        let Some(shared) = self.shared_tapes.as_ref() else {
-            return;
-        };
+    async fn share_tape_to(shared: &dyn SharedTapeCache, key: &str, id: Uuid, tape: &FactorTape) {
         match serde_json::to_string(tape) {
-            Ok(encoded) => {
-                let key = tape_key(simulation.id, &simulation.parameters);
-                shared.put(&key, &encoded).await;
-            }
+            Ok(encoded) => shared.put(key, &encoded).await,
             Err(error) => warn!(
                 %error,
-                simulation_id = %simulation.id,
+                simulation_id = %id,
                 "a built tape did not encode; it stays local to this instance"
             ),
         }
@@ -1151,21 +1228,29 @@ mod tests {
             }
         }
 
-        async fn claim_build(&self, key: &str) -> bool {
+        async fn claim_build(&self, key: &str) -> BuildClaim {
             self.claims.fetch_add(1, Ordering::SeqCst);
             let mut held = match self.building.lock() {
                 Ok(held) => held,
                 Err(poisoned) => poisoned.into_inner(),
             };
-            held.insert(key.to_string())
+            if held.insert(key.to_string()) {
+                BuildClaim::Held(format!("token:{key}"))
+            } else {
+                BuildClaim::Taken
+            }
         }
 
-        async fn release_build(&self, key: &str) {
+        async fn release_build(&self, key: &str, token: &str) {
             let mut held = match self.building.lock() {
                 Ok(held) => held,
                 Err(poisoned) => poisoned.into_inner(),
             };
-            held.remove(key);
+            // Ownership-safe like the Redis script: a token that is not this
+            // claim's releases nothing.
+            if token == format!("token:{key}") {
+                held.remove(key);
+            }
         }
     }
 
@@ -1185,11 +1270,11 @@ mod tests {
 
         /// A gate that cannot be reached must let the caller build, or an
         /// unreachable Redis becomes an unanswerable request.
-        async fn claim_build(&self, _key: &str) -> bool {
-            true
+        async fn claim_build(&self, _key: &str) -> BuildClaim {
+            BuildClaim::Unclaimed
         }
 
-        async fn release_build(&self, _key: &str) {}
+        async fn release_build(&self, _key: &str, _token: &str) {}
     }
 
     /// A warehouse that records what it was asked to file, and can be told to
@@ -2207,7 +2292,7 @@ mod tests {
         // Somebody else claims the build and dies without publishing.
         let key = tape_key(created.id, &created.parameters);
         assert!(
-            shared.claim_build(&key).await,
+            matches!(shared.claim_build(&key).await, BuildClaim::Held(_)),
             "the claim must be free first"
         );
 
@@ -2215,6 +2300,58 @@ mod tests {
             Ok(_) => {}
             Err(error) => panic!("an abandoned claim must not stop a build: {error}"),
         }
+    }
+
+    /// A client that goes away mid-build strands nothing.
+    ///
+    /// The build is on the blocking pool and keeps running whatever the caller
+    /// does, so the owner's workflow lives in a task of its own. Were it in the
+    /// request's future, a disconnect would leave the local waiters with an
+    /// entry in `builds` nobody will ever publish, the deployment-wide claim
+    /// held until it expires, and the finished tape unshared.
+    #[tokio::test]
+    async fn test_an_abandoned_owner_still_publishes_and_releases() {
+        let store = Arc::new(InMemorySimulationStore::new());
+        let shared = Arc::new(SharedTapes::default());
+        let manager = Arc::new(
+            SimulationManager::new(
+                Arc::clone(&store) as Arc<dyn SimulationStore>,
+                SimulationV2Config::default(),
+            )
+            .with_shared_tapes(Arc::clone(&shared) as Arc<dyn SharedTapeCache>),
+        );
+
+        let created = match manager.create(parameters(11)).await {
+            Ok(created) => created,
+            Err(error) => panic!("the simulation must be created: {error}"),
+        };
+
+        // The owner starts the build and its client disconnects.
+        let owner = {
+            let manager = Arc::clone(&manager);
+            let id = created.id;
+            tokio::spawn(async move { manager.peek(id).await })
+        };
+        owner.abort();
+
+        // Whoever is left must still be served.
+        match tokio::time::timeout(Duration::from_secs(5), manager.peek(created.id)).await {
+            Ok(Ok(_)) => {}
+            other => panic!("an abandoned owner must not strand the request after it: {other:?}"),
+        }
+
+        // And the deployment-wide claim came back rather than being left to
+        // expire, so another instance is not blocked behind a client that left.
+        let held = match shared.building.lock() {
+            Ok(held) => held.len(),
+            Err(poisoned) => poisoned.into_inner().len(),
+        };
+        assert_eq!(held, 0, "the build claim must have been released");
+        assert_eq!(
+            shared.keys().len(),
+            1,
+            "the built tape must have been shared even though its caller left"
+        );
     }
 
     /// A shared cache that cannot be reached costs a rebuild, not a failure.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -84,7 +84,7 @@ pub use manager_v2::SimulationManager;
 pub use model::{Session, SessionState, SimulationMethod, SimulationParameters};
 pub use model_v2::{SESSION_V2_SCHEMA_VERSION, SessionV2, SimulationParametersV2};
 pub use store::{
-    DEFAULT_TAPE_KEY_PREFIX, DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_RETENTION_SECS,
+    BuildClaim, DEFAULT_TAPE_KEY_PREFIX, DEFAULT_V2_KEY_PREFIX, DEFAULT_V2_RETENTION_SECS,
     InMemorySessionStore, InMemorySimulationStore, InRedisSessionStore, InRedisSimulationStore,
     RedisTapeCache, SessionStore, SharedTapeCache, SimulationStore,
 };

--- a/src/session/store/mod.rs
+++ b/src/session/store/mod.rs
@@ -55,7 +55,7 @@ pub use in_memory::InMemorySessionStore;
 pub use in_redis::InRedisSessionStore;
 pub use interface::SessionStore;
 pub(crate) use tape_cache::tape_key;
-pub use tape_cache::{DEFAULT_TAPE_KEY_PREFIX, RedisTapeCache, SharedTapeCache};
+pub use tape_cache::{BuildClaim, DEFAULT_TAPE_KEY_PREFIX, RedisTapeCache, SharedTapeCache};
 pub use v2_interface::SimulationStore;
 pub use v2_memory::{DEFAULT_V2_RETENTION_SECS, InMemorySimulationStore};
 pub use v2_redis::{DEFAULT_V2_KEY_PREFIX, InRedisSimulationStore};

--- a/src/session/store/tape_cache.rs
+++ b/src/session/store/tape_cache.rs
@@ -136,6 +136,12 @@ for _, member in ipairs(members) do
 end
 return dropped
 ";
+/// How long a build claim survives unreleased.
+///
+/// A ceiling on how long one instance's death can delay another's build, so it
+/// wants to be a little longer than the slowest build rather than as long as
+/// the tape lives. A tape of the maximum step count is seconds to walk.
+const BUILD_CLAIM_SECS: u64 = 120;
 
 /// A place to leave a built tape for the other instances.
 ///
@@ -162,6 +168,27 @@ pub trait SharedTapeCache: Send + Sync {
     /// the cache holds. Called with the id rather than a key because the
     /// parameters that built the key may already have been deleted.
     async fn forget_simulation(&self, id: &str);
+
+    /// Claims the right to build what `key` will hold.
+    ///
+    /// `true` means this caller builds. `false` means another instance is
+    /// already building it, and the caller should wait for the entry rather
+    /// than start a second copy of the same work (issue #137).
+    ///
+    /// The claim EXPIRES: an instance killed mid-build must not wedge the
+    /// others, so a claim nobody released is simply gone after a while and the
+    /// next caller to ask builds it.
+    ///
+    /// An implementation that cannot reach its store answers `true`. Building
+    /// twice is wasteful; not building is a request that never answers.
+    async fn claim_build(&self, key: &str) -> bool;
+
+    /// Gives up a claim, whether the build succeeded or not.
+    ///
+    /// Releasing on failure matters as much as on success: a build that
+    /// errored must not make the other instances wait out the expiry for a
+    /// tape that was never written.
+    async fn release_build(&self, key: &str);
 }
 
 /// The key a tape is stored under.
@@ -202,6 +229,9 @@ pub struct RedisTapeCache {
     /// shared cache too: an operator writes the number of tapes they are
     /// willing to keep, and gets that many rather than that many per replica.
     bound: usize,
+    /// Which instance this is, recorded in a claim so an operator reading
+    /// Redis can see who is building.
+    owner: Uuid,
 }
 
 impl RedisTapeCache {
@@ -222,6 +252,7 @@ impl RedisTapeCache {
             prefix: prefix.into(),
             ttl,
             bound: bound.max(1),
+            owner: Uuid::new_v4(),
         }
     }
 
@@ -310,6 +341,37 @@ impl SharedTapeCache for RedisTapeCache {
                 simulation_id = %id,
                 "the shared tapes of a gone simulation could not be dropped; they will expire"
             ),
+        }
+    }
+
+    async fn claim_build(&self, key: &str) -> bool {
+        let key = format!("{}build:{key}", self.prefix);
+        match self
+            .client
+            .set_nx(&key, self.owner.to_string(), Some(BUILD_CLAIM_SECS))
+            .await
+        {
+            Ok(claimed) => {
+                if claimed {
+                    debug!(%key, "claimed the build");
+                }
+                claimed
+            }
+            Err(error) => {
+                // Unreachable: build. A duplicated build costs CPU; a request
+                // waiting for a claim nobody can grant costs the client.
+                warn!(%error, %key, "the build claim could not be taken; building anyway");
+                true
+            }
+        }
+    }
+
+    async fn release_build(&self, key: &str) {
+        let key = format!("{}build:{key}", self.prefix);
+        if let Err(error) = self.client.delete(&key).await {
+            // It expires on its own, so this delays the next builder rather
+            // than blocking it.
+            warn!(%error, %key, "a build claim could not be released; it will expire");
         }
     }
 }

--- a/src/session/store/tape_cache.rs
+++ b/src/session/store/tape_cache.rs
@@ -136,6 +136,34 @@ for _, member in ipairs(members) do
 end
 return dropped
 ";
+/// What asking for the right to build a tape produced.
+///
+/// A token rather than a bare `true`, because a claim that expired mid-build
+/// may already belong to another instance: releasing then has to prove it is
+/// giving back its OWN claim, or a slow builder deletes the new owner's key
+/// and a third instance walks in.
+#[derive(Debug)]
+pub enum BuildClaim {
+    /// This caller builds, and releases with this token.
+    Held(String),
+    /// Another instance is already building it.
+    Taken,
+    /// The cache could not answer. The caller builds, holding nothing.
+    Unclaimed,
+}
+
+/// Releases a build claim, but only if it is still this caller's.
+///
+/// `KEYS[1]` the claim key, `ARGV[1]` the token it was taken with. Returns 1
+/// when the claim was released and 0 when it had already expired or been
+/// taken by someone else.
+const RELEASE_CLAIM_SCRIPT: &str = r"
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+";
+
 /// How long a build claim survives unreleased.
 ///
 /// A ceiling on how long one instance's death can delay another's build, so it
@@ -171,24 +199,31 @@ pub trait SharedTapeCache: Send + Sync {
 
     /// Claims the right to build what `key` will hold.
     ///
-    /// `true` means this caller builds. `false` means another instance is
-    /// already building it, and the caller should wait for the entry rather
-    /// than start a second copy of the same work (issue #137).
+    /// [`BuildClaim::Held`] means this caller builds. [`BuildClaim::Taken`]
+    /// means another instance is already building it, and the caller should
+    /// wait for the entry rather than start a second copy of the same work
+    /// (issue #137).
     ///
     /// The claim EXPIRES: an instance killed mid-build must not wedge the
     /// others, so a claim nobody released is simply gone after a while and the
     /// next caller to ask builds it.
     ///
-    /// An implementation that cannot reach its store answers `true`. Building
-    /// twice is wasteful; not building is a request that never answers.
-    async fn claim_build(&self, key: &str) -> bool;
+    /// An implementation that cannot reach its store answers
+    /// [`BuildClaim::Unclaimed`]. Building twice is wasteful; not building is
+    /// a request that never answers.
+    async fn claim_build(&self, key: &str) -> BuildClaim;
 
     /// Gives up a claim, whether the build succeeded or not.
     ///
     /// Releasing on failure matters as much as on success: a build that
     /// errored must not make the other instances wait out the expiry for a
     /// tape that was never written.
-    async fn release_build(&self, key: &str);
+    ///
+    /// `token` is what [`BuildClaim::Held`] returned, and the claim is
+    /// released only if it still holds that token: a build slower than the
+    /// expiry must not delete a claim that has since become another
+    /// instance's.
+    async fn release_build(&self, key: &str, token: &str);
 }
 
 /// The key a tape is stored under.
@@ -344,34 +379,51 @@ impl SharedTapeCache for RedisTapeCache {
         }
     }
 
-    async fn claim_build(&self, key: &str) -> bool {
+    async fn claim_build(&self, key: &str) -> BuildClaim {
         let key = format!("{}build:{key}", self.prefix);
+        // The instance so an operator reading Redis can see who is building,
+        // and a fresh id per attempt so one instance's expired claim cannot be
+        // released by its own next one either.
+        let token = format!("{}:{}", self.owner, Uuid::new_v4());
+
         match self
             .client
-            .set_nx(&key, self.owner.to_string(), Some(BUILD_CLAIM_SECS))
+            .set_nx(&key, token.clone(), Some(BUILD_CLAIM_SECS))
             .await
         {
-            Ok(claimed) => {
-                if claimed {
-                    debug!(%key, "claimed the build");
-                }
-                claimed
+            Ok(true) => {
+                debug!(%key, "claimed the build");
+                BuildClaim::Held(token)
             }
+            Ok(false) => BuildClaim::Taken,
             Err(error) => {
                 // Unreachable: build. A duplicated build costs CPU; a request
                 // waiting for a claim nobody can grant costs the client.
                 warn!(%error, %key, "the build claim could not be taken; building anyway");
-                true
+                BuildClaim::Unclaimed
             }
         }
     }
 
-    async fn release_build(&self, key: &str) {
+    async fn release_build(&self, key: &str, token: &str) {
         let key = format!("{}build:{key}", self.prefix);
-        if let Err(error) = self.client.delete(&key).await {
-            // It expires on its own, so this delays the next builder rather
-            // than blocking it.
-            warn!(%error, %key, "a build claim could not be released; it will expire");
+        let mut conn = self.client.connection_manager();
+        let released: Result<i64, _> = redis::Script::new(RELEASE_CLAIM_SCRIPT)
+            .key(&key)
+            .arg(token)
+            .invoke_async(&mut conn)
+            .await;
+
+        match released {
+            Ok(1) => {}
+            // The claim expired and may already be another instance's, so
+            // there was nothing here to give back.
+            Ok(_) => debug!(%key, "a build claim had already expired when it was released"),
+            Err(error) => {
+                // It expires on its own, so this delays the next builder rather
+                // than blocking it.
+                warn!(%error, %key, "a build claim could not be released; it will expire");
+            }
         }
     }
 }
@@ -578,6 +630,77 @@ mod tests {
             }
         }
         let _: Result<i64, _> = cleanup.query_async(&mut client.connection_manager()).await;
+    }
+
+    /// A claim that expired belongs to whoever took it next, not to its
+    /// original holder.
+    ///
+    /// Two caches over one Redis, which is two instances. A builder slower
+    /// than the claim's expiry must not delete the claim that replaced its
+    /// own, or a third instance walks in and the deployment builds the same
+    /// tape three times. The expiry is simulated by deleting the key, because
+    /// waiting out the production window would make this a two-minute test.
+    #[tokio::test]
+    #[ignore = "requires a live Redis matching REDIS_*; run with -- --ignored"]
+    async fn test_an_expired_claim_is_not_released_by_its_old_holder() {
+        use crate::infrastructure::RedisConfig;
+
+        let client = match RedisClient::new(RedisConfig::default()).await {
+            Ok(client) => Arc::new(client),
+            Err(error) => panic!("this test needs a live Redis: {error}"),
+        };
+        let prefix = format!("test:tape:{}:", Uuid::new_v4());
+        let first = RedisTapeCache::new(
+            Arc::clone(&client),
+            prefix.clone(),
+            Duration::from_secs(60),
+            8,
+        );
+        let second = RedisTapeCache::new(
+            Arc::clone(&client),
+            prefix.clone(),
+            Duration::from_secs(60),
+            8,
+        );
+
+        let key = "generation:fingerprint:simulation";
+        let held = match first.claim_build(key).await {
+            BuildClaim::Held(token) => token,
+            other => panic!("the first claim must be granted: {other:?}"),
+        };
+        assert!(
+            matches!(second.claim_build(key).await, BuildClaim::Taken),
+            "a claim another instance holds must not be granted twice"
+        );
+
+        // The first instance is slow and its claim expires.
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(format!("{prefix}build:{key}"))
+            .query_async(&mut client.connection_manager())
+            .await;
+        let taken_over = match second.claim_build(key).await {
+            BuildClaim::Held(token) => token,
+            other => panic!("an expired claim must be grantable: {other:?}"),
+        };
+
+        // The slow builder finishes and gives back what it thinks is its own.
+        first.release_build(key, &held).await;
+        assert!(
+            matches!(first.claim_build(key).await, BuildClaim::Taken),
+            "a stale release deleted the claim its successor holds"
+        );
+
+        // The successor's own release does work.
+        second.release_build(key, &taken_over).await;
+        assert!(
+            matches!(first.claim_build(key).await, BuildClaim::Held(_)),
+            "a released claim must be grantable again"
+        );
+
+        let _: Result<i64, _> = redis::cmd("DEL")
+            .arg(format!("{prefix}build:{key}"))
+            .query_async(&mut client.connection_manager())
+            .await;
     }
 
     /// Two simulations never share a key, however alike their parameters are.


### PR DESCRIPTION
Closes #137

Base branch: `stack/4-135-shared-admission`
Stacked on: #143
Stack: #138 → #139 → #136 → #135 → **#137** (last)

The diff is cumulative until the PRs below merge, so read it against the base branch rather than against `main`. This is the one PR in the chain with a hard dependency: the build claim needs the shared cache from #136.

## What changed

`SimulationManager::builds` coalesces concurrent builds of one tape within a process: the first caller builds, the rest wait. Across instances that map is invisible, so N replicas could each believe they were the only builder and run N copies of exactly the job the coalescing exists to avoid.

A build is now claimed in the same Redis that holds the tape, before it starts, with `SET NX` and an expiry. Two instances cannot both own it, and an instance killed mid-build cannot wedge the others because the claim expires on its own.

## Waiting, and giving up

A waiter polls the shared cache rather than a channel — there is no channel between processes — and gives up after a bounded wait to build the tape itself. That is duplicated work in a rare case, weighed against a request that never answers because it waited on an owner that had died.

Everything else fails towards building too: an unreachable cache **grants** the claim, and a release that does not land expires. Nothing here can turn a Redis problem into an unanswered request.

The wait is a field rather than a constant, so the give-up path is tested in 200 ms instead of the 30 seconds production wants.

## Verified against two real instances

Two processes over one Redis, both asked for the same 400-step simulation at once:

```
7099  0 builds
7100  1 build   ("claimed the build" … "Built the factor tape")
7099        DEBUG peek: another instance is building this tape; waiting for it
```

One build, one waiter, one tape. Plus two unit tests over two managers: only one writes a tape when both peek simultaneously, and an abandoned claim does not stop the next caller building.

## Checklist

- [x] One build of a given tape at a time across the deployment
- [x] A claim that expires, so a killed builder does not wedge the others
- [x] A waiter that times out builds it itself rather than failing
- [x] Two managers over one cache prove only one builds
- [x] `make pre-push` clean, zero warnings, 937 tests
- [x] Patch version bumped to 0.2.23 with the compose image tag
