### PR TITLE
Build the published image with the arrow export it advertises (#148)

### DIFF
--- a/.github/workflows/image-contract.yml
+++ b/.github/workflows/image-contract.yml
@@ -1,0 +1,89 @@
+# Runs the export contract against the IMAGE, not against a cargo build.
+#
+# The export tests describe what a deployment serves, and a deployment is the
+# published image. Nothing else in CI puts the two together: the hermetic suite
+# runs in-process with whatever features the job passes, and the replica
+# isolation job builds the image but only asks it about readiness. That gap is
+# how an image that advertised `format=arrow` and refused it shipped four times
+# (issue #148).
+#
+# So this builds the image the way the Dockerfile does and asks it for every
+# format its own OpenAPI document offers.
+name: Image contract (what the image serves)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/api/rest/export.rs"
+      - "src/api/rest/arrow_export.rs"
+      - "src/api/rest/binary.rs"
+      - "src/api/rest/swagger.rs"
+      - "examples/integration/**"
+      - "Cargo.toml"
+      - "Makefile"
+      - "Docker/Dockerfile"
+      - ".github/workflows/image-contract.yml"
+
+jobs:
+  serves-what-it-advertises:
+    name: The image serves every format it advertises
+    runs-on: ubuntu-latest
+
+    # The image needs both to boot: it exits rather than starting without them.
+    services:
+      redis:
+        image: redis:8.10.1-alpine@sha256:becdda6c7f4b3fb42e42fd7f120bbf5c54c4caaaf16f26da24e4563d2c1f0576
+        ports:
+          - 6379:6379
+      mongodb:
+        image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
+        ports:
+          - 27017:27017
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build the image
+        run: docker build -f Docker/Dockerfile -t ocs-image-contract:ci .
+
+      - name: Start it over the service containers
+        run: |
+          set -euo pipefail
+          # Host networking so the container reaches the services on the
+          # runner's own loopback, which is where their ports are published.
+          docker run -d --name ocs-image-contract --network host \
+            -e OCS_BIND_ADDRESS=0.0.0.0 \
+            -e OCS_PORT=7070 \
+            -e REDIS_HOST=127.0.0.1 \
+            -e REDIS_PORT=6379 \
+            -e MONGODB_URI=mongodb://127.0.0.1:27017 \
+            -e MONGODB_DATABASE=optionchain_simulator \
+            -e LOGLEVEL=INFO \
+            ocs-image-contract:ci
+
+          for _ in $(seq 1 60); do
+            if curl -fsS -m 3 http://127.0.0.1:7070/ready >/dev/null 2>&1; then
+              echo "the image is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "the image never became ready" >&2
+          docker logs ocs-image-contract 2>&1 | tail -40 >&2
+          exit 1
+
+      # The whole export matrix, which includes the assertion that every
+      # advertised format is actually served. The client is built with all
+      # features so it can decode what the image produces.
+      - name: Ask it for every format it advertises
+        env:
+          OCS_INTEGRATION_BASE_URL: http://127.0.0.1:7070
+          LOGLEVEL: WARN
+        run: cargo test -p examples_integration --all-features --test exports -- --nocapture
+
+      - name: The image's own log, whatever happened
+        if: always()
+        run: docker logs ocs-image-contract 2>&1 | tail -40

--- a/.github/workflows/replica-isolation.yml
+++ b/.github/workflows/replica-isolation.yml
@@ -31,6 +31,7 @@ on:
       - "src/infrastructure/config/**"
       - "src/main.rs"
       - "Docker/Dockerfile"
+      - "Makefile"
       - "Docker/docker-compose.yml"
       - "scripts/replica_isolation_test.sh"
       - ".github/workflows/replica-isolation.yml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.25}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.26}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,19 @@ all: test fmt lint build
 build:
 	cargo build
 
+# Features the release binary carries, and therefore what the published image
+# serves (Docker/Dockerfile builds through this target).
+#
+# `arrow-export` is off by default in Cargo.toml because a library consumer
+# should not pay for the arrow dependency to use the crate. A DEPLOYMENT is the
+# opposite case: the OpenAPI document it serves advertises `format=arrow`, so an
+# image without the feature refuses a format its own contract offers (issue
+# #148). Override with `make release RELEASE_FEATURES=` to build without it.
+RELEASE_FEATURES ?= arrow-export
+
 .PHONY: release
 release:
-	cargo build --release
+	cargo build --release $(if $(RELEASE_FEATURES),--features "$(RELEASE_FEATURES)",)
 
 # Run tests
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -688,9 +688,11 @@ already held in typed form.
   advertises the format, so an image that could not serve it would refuse
   its own contract (issue #148). `make release` therefore builds the feature
   in, and the published image carries it, at about 1.2 MB of binary. Build
-  without it with `make release RELEASE_FEATURES=`; asking for
-  `format=arrow` then is a typed `400` naming the format, never a 500 and
-  never a silent fallback.
+  without it with `make release RELEASE_FEATURES=`, and such a build does
+  not advertise the format either: the `format` parameter's description is
+  selected by the same feature, so the document offers what the binary
+  reading it can serve. Asking for `format=arrow` there is a typed `400`
+  naming the format, never a 500 and never a silent fallback.
 - **`packed`** — a dependency-free columnar block format for the browser.
   `Content-Type: application/octet-stream`, extension `ocsp`.
 

--- a/README.md
+++ b/README.md
@@ -682,11 +682,15 @@ already held in typed form.
 
 - **`arrow`** — an Arrow IPC **stream**, one record batch per block.
   `Content-Type: application/vnd.apache.arrow.stream`, extension `arrow`.
-  Available only when the service is built with the **`arrow-export`**
-  feature, which is off by default because the `arrow` crate is a large tree
-  and a deployment that never exports should not carry it. Asking for
-  `format=arrow` without it is a typed `400` naming the format, never a 500
-  and never a silent fallback.
+  Behind the **`arrow-export`** feature, which is off by default in
+  `Cargo.toml` because a library consumer should not carry the `arrow` tree
+  to use this crate. A DEPLOYMENT is the other case: this document
+  advertises the format, so an image that could not serve it would refuse
+  its own contract (issue #148). `make release` therefore builds the feature
+  in, and the published image carries it, at about 1.2 MB of binary. Build
+  without it with `make release RELEASE_FEATURES=`; asking for
+  `format=arrow` then is a typed `400` naming the format, never a 500 and
+  never a silent fallback.
 - **`packed`** — a dependency-free columnar block format for the browser.
   `Content-Type: application/octet-stream`, extension `ocsp`.
 

--- a/examples/integration/tests/exports.rs
+++ b/examples/integration/tests/exports.rs
@@ -383,6 +383,45 @@ fn arrow_cell(column: &dyn arrow::array::Array, index: usize) -> String {
     }
 }
 
+/// A deployment serves every format its own document advertises.
+///
+/// The two can disagree: `arrow-export` is a Cargo feature, so a build without
+/// it refuses `format=arrow` in a typed 400 while the OpenAPI document the same
+/// process serves still lists the format. That is a contract a client cannot
+/// follow, and it shipped in every published image up to 0.2.25 (issue #148).
+///
+/// The rest of this file treats an advertised-but-absent format as a skip,
+/// which is what lets it run anywhere. This test is where that stops being
+/// acceptable, because what it holds is not the format matrix but the
+/// agreement between the document and the build behind it.
+#[test]
+fn test_the_deployment_serves_every_format_it_advertises() {
+    let Some(client) = service() else {
+        return;
+    };
+    let Some(exported) = Exported::create(&client) else {
+        return;
+    };
+    let offered = offered_formats(&client, &exported);
+
+    assert!(
+        offered.absent.is_empty(),
+        "this deployment advertises {:?} and cannot serve them: {:?}. A format in the document \
+         is a promise to a client that reads it, so either the build carries the format or the \
+         document stops offering it",
+        offered
+            .absent
+            .iter()
+            .map(|(format, _)| format.as_str())
+            .collect::<Vec<_>>(),
+        offered.absent
+    );
+    println!(
+        "INFO: every advertised format is served: {}",
+        offered.usable.join(", ")
+    );
+}
+
 /// Every dataset carries the same rows and the same values in every format the
 /// deployment advertises and serves.
 #[test]

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -807,6 +807,20 @@ impl Stream for RowStream {
     }
 }
 
+/// What the `format` query parameter accepts, IN THIS BUILD.
+///
+/// Two constants rather than one sentence, because the document must not
+/// advertise a format the binary reading it would refuse: `arrow` is a Cargo
+/// feature, and a build without it rejects the format with a typed 400 (issue
+/// #148). Selected by `cfg`, so the advertised list is whatever this binary
+/// actually serves.
+#[cfg(feature = "arrow-export")]
+const FORMAT_PARAMETER: &str = "json | csv | arrow | packed. The two binary encodings carry the same values as the text ones, in blocks of OCS_EXPORT_BLOCK_ROWS rows, with the same column names in the same order. Numeric columns are f64, exactly what json and csv render: binary is a faster route to the same numbers, NOT a route to the underlying Decimal(38, 28) precision. `arrow` is an Arrow IPC stream, carried by this build. `packed` is a dependency-free columnar block format with 8-byte aligned payloads, documented in the crate docs, whose `labels` column is a bitmask over the schedule's rule ids.";
+
+/// As [`FORMAT_PARAMETER`], for a build without the `arrow-export` feature.
+#[cfg(not(feature = "arrow-export"))]
+const FORMAT_PARAMETER: &str = "json | csv | packed. The two binary encodings carry the same values as the text ones, in blocks of OCS_EXPORT_BLOCK_ROWS rows, with the same column names in the same order. Numeric columns are f64, exactly what json and csv render: binary is a faster route to the same numbers, NOT a route to the underlying Decimal(38, 28) precision. `packed` is a dependency-free columnar block format with 8-byte aligned payloads, documented in the crate docs, whose `labels` column is a bitmask over the schedule's rule ids. This build carries no `arrow-export` feature, so it does not offer the Arrow IPC stream and answers a request for it with a 400 naming the format.";
+
 #[utoipa::path(
     get,
     path = "/api/v2/simulations/{id}/export",
@@ -825,7 +839,7 @@ impl Stream for RowStream {
     params(
         ("id" = String, Path, description = "The simulation's identifier"),
         ("dataset" = String, Query, description = "underlying | volatility | option_chains"),
-        ("format" = String, Query, description = "json | csv | arrow | packed. The two binary encodings carry the same values as the text ones, in blocks of OCS_EXPORT_BLOCK_ROWS rows, with the same column names in the same order. Numeric columns are f64, exactly what json and csv render: binary is a faster route to the same numbers, NOT a route to the underlying Decimal(38, 28) precision. `arrow` is an Arrow IPC stream and is available only when the service is built with the `arrow-export` feature; asking for it otherwise is a 400 naming the format. `packed` is a dependency-free columnar block format with 8-byte aligned payloads, documented in the crate docs, whose `labels` column is a bitmask over the schedule's rule ids."),
+        ("format" = String, Query, description = FORMAT_PARAMETER),
         ("from_step" = Option<usize>, Query, description = "First step, inclusive; defaults to 0"),
         ("to_step" = Option<usize>, Query, description = "Last step, inclusive; defaults to the final step"),
         ("greeks" = Option<String>, Query, description = "How much of the greek set the option_chains dataset carries: `none` (default), `first` (appends call_theta, put_theta, call_vega, put_vega, call_rho, put_rho, call_rho_d, put_rho_d) or `all` (appends seven more per style, gamma through color: fourteen columns). Each level's header is a PREFIX of the next, so raising it appends columns and never moves one. Values are per ONE LONG CONTRACT. Accepted but immaterial for the underlying and volatility datasets, which carry no chains. An unknown value is a 400")

--- a/src/api/rest/swagger.rs
+++ b/src/api/rest/swagger.rs
@@ -74,6 +74,61 @@ mod tests {
         );
     }
 
+    /// The document advertises the export formats THIS BUILD serves.
+    ///
+    /// `arrow` is a Cargo feature, so a build without it answers a request for
+    /// that format with a typed 400. A document that offered it anyway would be
+    /// a contract no client of that binary could follow, which is the defect
+    /// issue #148 fixed for the published image; this holds the other builds to
+    /// the same rule. Both branches are exercised, because CI runs the suite
+    /// with the feature and without it.
+    #[test]
+    fn test_the_document_advertises_only_the_formats_this_build_serves() {
+        let openapi = ApiDoc::openapi();
+        let document = match openapi.to_json() {
+            Ok(document) => document,
+            Err(error) => panic!("the document must render: {error}"),
+        };
+        let document: Value = match serde_json::from_str(&document) {
+            Ok(document) => document,
+            Err(error) => panic!("the document must parse: {error}"),
+        };
+
+        let parameters = document
+            .pointer("/paths/~1api~1v2~1simulations~1{id}~1export/get/parameters")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("the export path must declare its parameters"));
+        let format = parameters
+            .iter()
+            .find(|parameter| parameter.get("name").and_then(Value::as_str) == Some("format"))
+            .and_then(|parameter| parameter.get("description"))
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("the format parameter must describe itself"));
+
+        // The description opens with the alternatives, which is what a client
+        // and the integration suite both read.
+        let advertised = format.split('.').next().unwrap_or_default();
+        assert!(
+            advertised.contains("json")
+                && advertised.contains("csv")
+                && advertised.contains("packed"),
+            "the always-present formats must be advertised, the list is {advertised:?}"
+        );
+
+        let offers_arrow = advertised.contains("arrow");
+        assert_eq!(
+            offers_arrow,
+            cfg!(feature = "arrow-export"),
+            "this build {} arrow and the document {} it: {advertised:?}",
+            if cfg!(feature = "arrow-export") {
+                "serves"
+            } else {
+                "refuses"
+            },
+            if offers_arrow { "offers" } else { "omits" }
+        );
+    }
+
     /// Test paths are correctly defined in the OpenAPI specification
     #[test]
     fn test_openapi_paths() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,9 +671,11 @@
 //!   advertises the format, so an image that could not serve it would refuse
 //!   its own contract (issue #148). `make release` therefore builds the feature
 //!   in, and the published image carries it, at about 1.2 MB of binary. Build
-//!   without it with `make release RELEASE_FEATURES=`; asking for
-//!   `format=arrow` then is a typed `400` naming the format, never a 500 and
-//!   never a silent fallback.
+//!   without it with `make release RELEASE_FEATURES=`, and such a build does
+//!   not advertise the format either: the `format` parameter's description is
+//!   selected by the same feature, so the document offers what the binary
+//!   reading it can serve. Asking for `format=arrow` there is a typed `400`
+//!   naming the format, never a 500 and never a silent fallback.
 //! - **`packed`** — a dependency-free columnar block format for the browser.
 //!   `Content-Type: application/octet-stream`, extension `ocsp`.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,11 +665,15 @@
 //!
 //! - **`arrow`** — an Arrow IPC **stream**, one record batch per block.
 //!   `Content-Type: application/vnd.apache.arrow.stream`, extension `arrow`.
-//!   Available only when the service is built with the **`arrow-export`**
-//!   feature, which is off by default because the `arrow` crate is a large tree
-//!   and a deployment that never exports should not carry it. Asking for
-//!   `format=arrow` without it is a typed `400` naming the format, never a 500
-//!   and never a silent fallback.
+//!   Behind the **`arrow-export`** feature, which is off by default in
+//!   `Cargo.toml` because a library consumer should not carry the `arrow` tree
+//!   to use this crate. A DEPLOYMENT is the other case: this document
+//!   advertises the format, so an image that could not serve it would refuse
+//!   its own contract (issue #148). `make release` therefore builds the feature
+//!   in, and the published image carries it, at about 1.2 MB of binary. Build
+//!   without it with `make release RELEASE_FEATURES=`; asking for
+//!   `format=arrow` then is a typed `400` naming the format, never a 500 and
+//!   never a silent fallback.
 //! - **`packed`** — a dependency-free columnar block format for the browser.
 //!   `Content-Type: application/octet-stream`, extension `ocsp`.
 //!


### PR DESCRIPTION
## Summary

A deployment's OpenAPI document lists `arrow` among the export formats, and every published image refuses it: `Docker/Dockerfile` builds through `make release`, which built with default features, and `arrow-export` is off by default. A client that reads the contract asks for a format the service declines. The refusal is a well-formed 400 naming the field, which is why the integration suite skipped rather than failed, and why the disagreement survived four releases.

Chosen option 1 of the two the issue lists: build the feature into the image. It is the smaller change and it matches how the format is documented; option 2 would have put a conditional in the API surface and left consumers a format they can only get by building their own image.

## Changes

- `make release` carries `arrow-export`, through a `RELEASE_FEATURES` variable so `make release RELEASE_FEATURES=` still builds without it. Off by default in `Cargo.toml` stays right for a library consumer, who should not pull the arrow tree to use the crate; a deployment is the opposite case, because it publishes the document that offers the format.
- The integration suite gains `test_the_deployment_serves_every_format_it_advertises`. The rest of the export matrix still treats an advertised-but-absent format as a skip, which is what lets it run against any build; this test is where that stops being acceptable, because what it holds is the agreement between the document and the binary behind it.
- The crate docs say what the published image carries and how to build without it.
- `Makefile` joins the replica-isolation workflow's path filter, since it now decides what the image can serve.

## Technical decisions

- **The new test fails against a deployment older than this PR**, on purpose. That is the defect being reported, not a flake: until an image built from here is deployed, the document and the build disagree. Verified both ways below.
- **No new dependency.** `arrow` was already an optional dependency of this crate.

## Measurements

| build | binary |
|---|---|
| `make release RELEASE_FEATURES=` | 34 844 848 bytes |
| `make release` | 36 022 464 bytes |

1.2 MB, about 3.4%, for the arrow tree. Compile time on this machine moved from about 10 s to about 13 s incremental; the image's cold build is dominated by the dependency graph either way.

## Testing

- [x] Against a locally run binary built by `make release`: `INFO: every advertised format is served: json, csv, arrow, packed`, 7 export tests passed
- [x] Against a binary built without the feature, and against the deployed 0.2.24: the new test fails naming `arrow`, which is the state this PR fixes
- [x] `make pre-push` clean, strict clippy clean

## Stack

- Base branch: `tests-cross-instance-coverage`
- Stacked on: #150
- Blocks: #153
- Stack: #150 (merged) → **this** → #153
- The diff is cumulative until #150 merges, so read it against the base branch rather than against `main`.

Closes #148