### PR TITLE
Say which export path a deployment exercises, and compare the two (#149)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.26}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.27}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a
@@ -157,6 +157,23 @@ services:
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-default}
       CLICKHOUSE_PORT: ${CLICKHOUSE_PORT:-8123}
       CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-clickhouse}
+      # This stack SHIPS the warehouse two services up, and still does not use
+      # it by default (issue #149). Set this to true to turn snapshot
+      # persistence on; what that buys is an export that reads back the steps
+      # already served instead of re-walking them.
+      #
+      # What it costs today, measured rather than assumed: an export served
+      # from storage renders a computed price a digit differently from one that
+      # replayed the tape, so two exports of the SAME tape stop being byte
+      # identical (issue #152). The values agree; the bytes do not, and a
+      # consumer that diffs exports sees a change that is not there. The
+      # default flips to true when that is fixed.
+      #
+      # The other consequences an operator should know: the schema is created
+      # at boot, so a warehouse that cannot be reached fails the boot rather
+      # than degrading quietly, and `/ready` gains a `clickhouse` dependency, so
+      # a replica whose warehouse is down reports itself unready.
+      OCS_SNAPSHOT_PERSISTENCE_ENABLED: ${OCS_SNAPSHOT_PERSISTENCE_ENABLED:-false}
       MONGODB_URI: ${MONGODB_URI:-mongodb://admin:password@mongodb:27017}
       MONGODB_DATABASE: ${MONGODB_DATABASE:-optionchain_simulator}
       MONGODB_STEPS_COLLECTION: ${MONGODB_STEPS_COLLECTION:-steps}

--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ itself ready again: an unchanged id is a process that was never restarted.
 CI runs it on a change to the probes, to what they probe, or to how the
 service is packaged.
 
+Whether a deployment persists its snapshots is visible in the readiness
+body: the warehouse probe exists only when the manager has a warehouse, so
+a `clickhouse` dependency there is persistence being on. The integration
+suite reads it and says which of the two export paths a run exercises,
+rather than testing one and reporting as though it had covered both.
+
 Both are unversioned, unauthenticated, and excluded from the request
 metrics: an orchestrator polling forever would otherwise add a constant to
 every series and a flood of 503s to the error series while a dependency is

--- a/README.md
+++ b/README.md
@@ -636,7 +636,16 @@ streams a simulation's tape, which is what turns a
 walked-one-request-at-a-time simulation into something a backtester loads in
 one go. With persistence on it reads the steps the warehouse already holds,
 in windows, and replays the rest; with it off, or for a simulation nobody
-has walked, every step is replayed. Either source renders the same bytes.
+has walked, every step is replayed. Either source renders the same VALUES,
+row for row and column for column.
+
+It does not yet render the same BYTES. A value crosses the storage column's
+own scale on the way in and back, and the shortest rendering of the float
+that comes out can differ in the last digit from the one the replay
+produces, so an export taken after a tape's rows were filed can differ from
+the same export taken before (issue #152). Byte-identical repeats hold on a
+deployment with persistence off, which is the default; where it is on, treat
+the values as the contract until that issue lands.
 
 | Parameter | Values |
 |-----------|--------|

--- a/examples/integration/tests/persistence.rs
+++ b/examples/integration/tests/persistence.rs
@@ -1,0 +1,328 @@
+//! Which of the two export paths a deployment actually exercises.
+//!
+//! An export can be served two ways. With snapshot persistence off, the tape is
+//! replayed: every step is walked again to render the rows. With it on, the
+//! steps a client has already been served are in the warehouse, and the export
+//! reads them back rather than re-walking, which is the whole point of storing
+//! them.
+//!
+//! The rest of this suite cannot tell the two apart, and that is the problem
+//! (issue #149): every comparison it makes has replay on both sides, so a
+//! warehouse returning subtly different rows would be invisible. These tests
+//! say which path the deployment in front of them uses, and hold the two to
+//! producing the same bytes where they can be compared.
+//!
+//! What they cannot do is force the path. Nothing in the client-facing surface
+//! reports whether an export was read back or re-walked, so a deployment with
+//! persistence on and an empty warehouse simply replays and still passes. The
+//! honest claim is the one asserted: the rows a client is served do not depend
+//! on where they came from.
+//!
+//! Skipped entirely when `OCS_INTEGRATION_BASE_URL` is unset.
+
+use examples_integration::{Response, ServiceClient, reference_request, report_cleanup, service};
+
+/// Steps in the tapes compared below.
+const STEPS: usize = 4;
+
+/// How long to let the warehouse queue drain before comparing, in attempts of
+/// a fifth of a second.
+///
+/// The write is detached from the request that produced it — that is what
+/// keeps a degraded warehouse from delaying a response — so a step served is
+/// not a row stored yet.
+const SETTLE_ATTEMPTS: usize = 25;
+
+/// Whether this deployment persists its snapshots.
+///
+/// Read from the readiness probe rather than from a knob nobody exposes: the
+/// warehouse probe is registered only when the manager has a warehouse, so a
+/// `clickhouse` dependency in the body IS persistence being on.
+fn persistence_is_on(client: &ServiceClient) -> Option<bool> {
+    let response = match client.get("/ready") {
+        Ok(response) => response,
+        Err(error) => panic!("{error}"),
+    };
+    if response.status != 200 && response.status != 503 {
+        panic!(
+            "the readiness probe must answer 200 or 503, it answered {}",
+            response.status
+        );
+    }
+    let body: serde_json::Value = match response.json("/ready") {
+        Ok(body) => body,
+        Err(error) => panic!("{error}"),
+    };
+    let dependencies = body
+        .get("dependencies")
+        .and_then(serde_json::Value::as_array)?;
+
+    Some(dependencies.iter().any(|dependency| {
+        dependency.get("name").and_then(serde_json::Value::as_str) == Some("clickhouse")
+    }))
+}
+
+/// A simulation with a chosen seed that deletes itself.
+struct Tape {
+    client: ServiceClient,
+    id: String,
+}
+
+impl Tape {
+    fn create(client: &ServiceClient, seed: u64) -> Option<Self> {
+        let mut request = reference_request("SPX");
+        if let Some(object) = request.as_object_mut() {
+            object.insert("steps".to_string(), serde_json::json!(STEPS));
+            object.insert("chain_size".to_string(), serde_json::json!(2));
+            object.insert("seed".to_string(), serde_json::json!(seed));
+            object.insert(
+                "start_at".to_string(),
+                serde_json::json!("2026-01-05T14:30:00Z"),
+            );
+        }
+
+        let response = match client.post("/api/v2/simulations", &request) {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        if response.status == 404 {
+            println!("SKIP: this deployment does not serve /api/v2/simulations");
+            return None;
+        }
+        assert_eq!(
+            response.status,
+            201,
+            "creating a simulation must answer 201, got {}",
+            response.text()
+        );
+
+        let body: serde_json::Value = match response.json("/api/v2/simulations") {
+            Ok(body) => body,
+            Err(error) => panic!("{error}"),
+        };
+        let id = match body.get("id").and_then(serde_json::Value::as_str) {
+            Some(id) => id.to_string(),
+            None => panic!("a created simulation must carry an id: {body}"),
+        };
+
+        Some(Self {
+            client: client.clone(),
+            id,
+        })
+    }
+
+    /// Serves every step, which is what gives the warehouse something to file.
+    fn walk(&self) {
+        for step in 0..STEPS {
+            let path = format!("/api/v2/simulations/{}/step", self.id);
+            match self.client.request("POST", &path, None) {
+                Ok(response) => assert_eq!(
+                    response.status,
+                    200,
+                    "step {step} must serve: {}",
+                    response.text()
+                ),
+                Err(error) => panic!("{error}"),
+            }
+        }
+    }
+
+    fn export(&self, query: &str) -> Response {
+        let path = format!("/api/v2/simulations/{}/export?{query}", self.id);
+        match self.client.get(&path) {
+            Ok(response) => response,
+            Err(error) => panic!("exporting {query}: {error}"),
+        }
+    }
+}
+
+impl Drop for Tape {
+    fn drop(&mut self) {
+        let path = format!("/api/v2/simulations/{}", self.id);
+        report_cleanup(&self.client, &path, &self.id);
+    }
+}
+
+/// Says which export path this deployment exercises, and never fails on it.
+///
+/// Both are valid deployments. What is not valid is a suite that tests one of
+/// them and reports as though it had covered both, which is what every run
+/// before this did.
+#[test]
+fn test_the_deployment_says_whether_it_persists_its_snapshots() {
+    let Some(client) = service() else {
+        return;
+    };
+    match persistence_is_on(&client) {
+        Some(true) => println!(
+            "INFO: snapshot persistence is ON here, so an export of steps already served can be \
+             read back from the warehouse"
+        ),
+        Some(false) => println!(
+            "INFO: snapshot persistence is OFF here, so every export replays the tape and the \
+             warehouse read path is not exercised by this run"
+        ),
+        None => panic!("the readiness body must list its dependencies"),
+    }
+}
+
+/// A tape whose steps were served exports the same bytes as one exported
+/// straight away.
+///
+/// The first has been through the warehouse where there is one; the second is
+/// rendered from a walk that happens inside the export itself. A row that
+/// survived a round trip through storage differently — a truncated decimal, a
+/// timestamp that lost its zone, a column that came back in another order —
+/// would show here and nowhere else in this suite, because every other
+/// comparison it makes has replay on both sides.
+///
+/// Skipped, loudly, when persistence is off: both sides would then be the same
+/// path and the test would assert nothing.
+#[test]
+fn test_a_stored_tape_exports_what_a_replayed_one_does() {
+    let Some(client) = service() else {
+        return;
+    };
+    match persistence_is_on(&client) {
+        Some(true) => {}
+        Some(false) => {
+            println!(
+                "SKIP: snapshot persistence is off on this deployment, so both sides of this \
+                 comparison would be the same replay"
+            );
+            return;
+        }
+        None => panic!("the readiness body must list its dependencies"),
+    }
+
+    let (Some(served), Some(fresh)) = (Tape::create(&client, 8_191), Tape::create(&client, 8_191))
+    else {
+        return;
+    };
+
+    // Only the first is walked. Its steps are what the warehouse has to file;
+    // the second's tape exists only inside the export that asks for it.
+    served.walk();
+
+    let mut near_misses = 0_usize;
+    for dataset in ["underlying", "option_chains"] {
+        let query = format!("dataset={dataset}&format=csv");
+        let expected = fresh.export(&query);
+        assert_eq!(
+            expected.status,
+            200,
+            "a replayed {dataset} export must serve: {}",
+            expected.text()
+        );
+
+        // The write is detached from the advance that caused it, so the rows
+        // may still be in the queue. Retried rather than slept on once: rows
+        // that arrive make the two agree, and a disagreement that survives the
+        // budget is the finding.
+        let mut stored_body = Vec::new();
+        let mut differences = Vec::new();
+        for _ in 0..SETTLE_ATTEMPTS {
+            let stored = served.export(&query);
+            assert_eq!(
+                stored.status,
+                200,
+                "a stored {dataset} export must serve: {}",
+                stored.text()
+            );
+            stored_body = stored.body.clone();
+            differences = compare(dataset, &stored_body, &expected.body);
+            if differences.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+
+        assert!(
+            differences.is_empty(),
+            "the {dataset} export of a tape whose steps were served differs from the same export \
+             of the same seed rendered on the spot: {differences:?}. Same seed, same parameters, \
+             so the rows must not depend on whether they came back from storage"
+        );
+
+        if stored_body != expected.body {
+            // Equal as values, different as bytes. Storage renders a mid price
+            // a digit or two shorter than the replay does, because it crosses
+            // a float on the way in and back. It is not a corrupted row, and
+            // it is not nothing either: a consumer that diffs two exports of
+            // the same tape sees a change that is not there.
+            near_misses += 1;
+            println!(
+                "INFO: the {dataset} export agrees value by value but not byte for byte, {} bytes \
+                 stored against {} replayed, which is issue #152",
+                stored_body.len(),
+                expected.body.len()
+            );
+        }
+    }
+
+    if near_misses == 0 {
+        println!(
+            "INFO: a stored tape and a replayed one export the same bytes for every dataset \
+             compared"
+        );
+    }
+}
+
+/// Every cell of two CSV exports, compared as values.
+///
+/// Numbers are compared as numbers, within a relative tolerance far tighter
+/// than anything a client could act on but wide enough to ignore the last bit
+/// of a float. Everything else is compared as text, so a timestamp that lost
+/// its zone, a column that came back in another order or a row that never
+/// arrived is a difference, which is what a warehouse can plausibly get wrong.
+fn compare(dataset: &str, stored: &[u8], replayed: &[u8]) -> Vec<String> {
+    let (Ok(stored), Ok(replayed)) = (std::str::from_utf8(stored), std::str::from_utf8(replayed))
+    else {
+        return vec![format!("the {dataset} export is not text")];
+    };
+
+    let stored: Vec<&str> = stored.lines().collect();
+    let replayed: Vec<&str> = replayed.lines().collect();
+    if stored.len() != replayed.len() {
+        return vec![format!(
+            "{dataset} has {} rows stored against {} replayed",
+            stored.len(),
+            replayed.len()
+        )];
+    }
+
+    let mut differences = Vec::new();
+    for (index, (left, right)) in stored.iter().zip(replayed.iter()).enumerate() {
+        let left_cells: Vec<&str> = left.split(',').collect();
+        let right_cells: Vec<&str> = right.split(',').collect();
+        if left_cells.len() != right_cells.len() {
+            differences.push(format!(
+                "{dataset} row {index} has {} columns stored against {}",
+                left_cells.len(),
+                right_cells.len()
+            ));
+            continue;
+        }
+        for (column, (left, right)) in left_cells.iter().zip(right_cells.iter()).enumerate() {
+            if left == right {
+                continue;
+            }
+            match (left.parse::<f64>(), right.parse::<f64>()) {
+                (Ok(left_value), Ok(right_value)) => {
+                    let scale = left_value.abs().max(right_value.abs()).max(1.0);
+                    if (left_value - right_value).abs() > scale * 1e-9 {
+                        differences.push(format!(
+                            "{dataset} row {index} column {column} is {left} stored against \
+                             {right} replayed"
+                        ));
+                    }
+                }
+                _ => differences.push(format!(
+                    "{dataset} row {index} column {column} is {left:?} stored against \
+                     {right:?} replayed"
+                )),
+            }
+        }
+    }
+    differences
+}

--- a/examples/integration/tests/persistence.rs
+++ b/examples/integration/tests/persistence.rs
@@ -25,13 +25,21 @@ use examples_integration::{Response, ServiceClient, reference_request, report_cl
 /// Steps in the tapes compared below.
 const STEPS: usize = 4;
 
-/// How long to let the warehouse queue drain before comparing, in attempts of
-/// a fifth of a second.
+/// How long to wait for the warehouse to accept a row, in attempts of a fifth
+/// of a second.
 ///
 /// The write is detached from the request that produced it — that is what
 /// keeps a degraded warehouse from delaying a response — so a step served is
 /// not a row stored yet.
 const SETTLE_ATTEMPTS: usize = 25;
+
+/// The counter that says rows have actually been filed.
+///
+/// Without waiting on it, the comparison below can pass before a single row
+/// reaches the warehouse: the export replays whatever is missing, so both
+/// sides would be replays and the test would be green without exercising
+/// storage at all.
+const FILED_ROWS_METRIC: &str = "v2_snapshot_rows_filed_total";
 
 /// Whether this deployment persists its snapshots.
 ///
@@ -60,6 +68,40 @@ fn persistence_is_on(client: &ServiceClient) -> Option<bool> {
     Some(dependencies.iter().any(|dependency| {
         dependency.get("name").and_then(serde_json::Value::as_str) == Some("clickhouse")
     }))
+}
+
+/// The highest `v2_snapshot_rows_filed_total` any instance reports.
+///
+/// The maximum rather than a sum: `/metrics` serves whichever replica answers,
+/// so a sum across scrapes would double-count one instance and a single scrape
+/// may miss the one that filed. `None` when the deployment does not publish
+/// the counter, which is a deployment older than the metric.
+fn filed_rows(client: &ServiceClient) -> Option<u64> {
+    let mut highest = None;
+    for _ in 0..4 {
+        let response = match client.get("/metrics") {
+            Ok(response) => response,
+            Err(error) => panic!("{error}"),
+        };
+        assert_eq!(
+            response.status,
+            200,
+            "the metrics must serve: {}",
+            response.text()
+        );
+        for line in response.text().lines() {
+            let Some(rest) = line.strip_prefix(FILED_ROWS_METRIC) else {
+                continue;
+            };
+            let Some(value) = rest.split_whitespace().last() else {
+                continue;
+            };
+            if let Ok(value) = value.parse::<u64>() {
+                highest = Some(highest.map_or(value, |current: u64| current.max(value)));
+            }
+        }
+    }
+    highest
 }
 
 /// A simulation with a chosen seed that deletes itself.
@@ -202,9 +244,34 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
 
     // Only the first is walked. Its steps are what the warehouse has to file;
     // the second's tape exists only inside the export that asks for it.
+    let before = filed_rows(&client);
     served.walk();
 
-    let mut near_misses = 0_usize;
+    // Waiting for a ROW, not for a while. The export replays whatever storage
+    // does not have, so comparing before the writer has filed anything would
+    // compare two replays and pass without touching the warehouse, which is
+    // the false green this test exists to remove.
+    let mut filed = false;
+    for _ in 0..SETTLE_ATTEMPTS {
+        match (before, filed_rows(&client)) {
+            (Some(before), Some(now)) if now > before => {
+                filed = true;
+                break;
+            }
+            (None, _) | (_, None) => break,
+            _ => {}
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    if !filed {
+        println!(
+            "SKIP: no instance reported {FILED_ROWS_METRIC} rising after a walked tape, so \
+             nothing here would be served from storage and the comparison would be two replays"
+        );
+        return;
+    }
+
     for dataset in ["underlying", "option_chains"] {
         let query = format!("dataset={dataset}&format=csv");
         let expected = fresh.export(&query);
@@ -215,27 +282,15 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
             expected.text()
         );
 
-        // The write is detached from the advance that caused it, so the rows
-        // may still be in the queue. Retried rather than slept on once: rows
-        // that arrive make the two agree, and a disagreement that survives the
-        // budget is the finding.
-        let mut stored_body = Vec::new();
-        let mut differences = Vec::new();
-        for _ in 0..SETTLE_ATTEMPTS {
-            let stored = served.export(&query);
-            assert_eq!(
-                stored.status,
-                200,
-                "a stored {dataset} export must serve: {}",
-                stored.text()
-            );
-            stored_body = stored.body.clone();
-            differences = compare(dataset, &stored_body, &expected.body);
-            if differences.is_empty() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(200));
-        }
+        let stored = served.export(&query);
+        assert_eq!(
+            stored.status,
+            200,
+            "a stored {dataset} export must serve: {}",
+            stored.text()
+        );
+        let stored_body = stored.body.clone();
+        let differences = compare(dataset, &stored_body, &expected.body);
 
         assert!(
             differences.is_empty(),
@@ -250,7 +305,6 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
             // a float on the way in and back. It is not a corrupted row, and
             // it is not nothing either: a consumer that diffs two exports of
             // the same tape sees a change that is not there.
-            near_misses += 1;
             println!(
                 "INFO: the {dataset} export agrees value by value but not byte for byte, {} bytes \
                  stored against {} replayed, which is issue #152",
@@ -260,12 +314,9 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
         }
     }
 
-    if near_misses == 0 {
-        println!(
-            "INFO: a stored tape and a replayed one export the same bytes for every dataset \
-             compared"
-        );
-    }
+    println!(
+        "INFO: a stored tape and a replayed one agree on every value in every dataset compared"
+    );
 }
 
 /// Every cell of two CSV exports, compared as values.

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -37,13 +37,17 @@
 //! logs at `DEBUG`.
 //!
 //! Both sources go through one adapter ([`StepChains`]) that yields the same
-//! per-quote view, so a row is byte-identical whichever side produced it. The
+//! per-quote view, so a row carries the same values whichever side produced it,
+//! and the same bytes once issue #152 lands. The
 //! factor row still comes from the tape either way: the underlying and
 //! volatility datasets are built from it, and it is cheap next to a chain.
 //!
 //! # Determinism
 //!
-//! Two exports of the same simulation are byte-identical. Every value is a
+//! Two exports of the same simulation are byte-identical where the steps come
+//! from the same source. With persistence on, one taken after the rows were
+//! filed can differ in the last digit of a rendered number from one taken
+//! before (issue #152); the values agree either way. Every value is a
 //! function of the effective parameters and the cursor, timestamps render as
 //! whole-second RFC 3339, and numbers use Rust's shortest round-trip
 //! formatting — no locale, no thousands separators. That is what lets a

--- a/src/infrastructure/telemetry/collector.rs
+++ b/src/infrastructure/telemetry/collector.rs
@@ -35,6 +35,13 @@ pub struct MetricsCollector {
     v2_snapshot_cache_size: IntGauge,
     /// v2 simulations reaped by the retention sweep since startup.
     v2_simulations_expired: IntCounter,
+    /// Quote rows the warehouse has actually accepted.
+    ///
+    /// The write is detached from the advance that produced it, so "the step
+    /// was served" says nothing about "the row is stored". This is the only
+    /// signal from outside that it is, which is what lets a test wait for a
+    /// persisted row rather than assume one (issue #149).
+    v2_snapshot_rows_filed: IntCounter,
 
     // Resource metrics
     memory_usage: Gauge,
@@ -124,6 +131,11 @@ impl MetricsCollector {
             "Total number of v2 simulations reaped by the retention sweep",
         )?;
 
+        let v2_snapshot_rows_filed = IntCounter::new(
+            "v2_snapshot_rows_filed_total",
+            "Total number of quote rows the snapshot warehouse has accepted",
+        )?;
+
         // Create resource metrics
         let memory_usage = Gauge::new("memory_usage_bytes", "Current memory usage in bytes")?;
 
@@ -160,6 +172,7 @@ impl MetricsCollector {
         registry.register(Box::new(v2_tape_cache_size.clone()))?;
         registry.register(Box::new(v2_snapshot_cache_size.clone()))?;
         registry.register(Box::new(v2_simulations_expired.clone()))?;
+        registry.register(Box::new(v2_snapshot_rows_filed.clone()))?;
         registry.register(Box::new(memory_usage.clone()))?;
 
         // Register MongoDB metrics
@@ -183,6 +196,7 @@ impl MetricsCollector {
             v2_tape_cache_size,
             v2_snapshot_cache_size,
             v2_simulations_expired,
+            v2_snapshot_rows_filed,
             memory_usage,
             mongodb_insert_counter,
             mongodb_insert_duration,
@@ -279,6 +293,17 @@ impl MetricsCollector {
     /// tracks actual cache occupancy rather than a stale estimate.
     pub fn set_simulation_cache_size(&self, size: i64) {
         self.simulation_cache_size.set(size);
+    }
+
+    /// Records quote rows the warehouse accepted.
+    ///
+    /// Counted on the WRITE that succeeded, not on the advance that queued it:
+    /// a queue that never drains must not look like storage that is filling.
+    pub fn record_snapshot_rows_filed(&self, rows: usize) {
+        if rows == 0 {
+            return;
+        }
+        self.v2_snapshot_rows_filed.inc_by(rows as u64);
     }
 
     /// Records the current memory usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,12 @@
 //! CI runs it on a change to the probes, to what they probe, or to how the
 //! service is packaged.
 //!
+//! Whether a deployment persists its snapshots is visible in the readiness
+//! body: the warehouse probe exists only when the manager has a warehouse, so
+//! a `clickhouse` dependency there is persistence being on. The integration
+//! suite reads it and says which of the two export paths a run exercises,
+//! rather than testing one and reporting as though it had covered both.
+//!
 //! Both are unversioned, unauthenticated, and excluded from the request
 //! metrics: an orchestrator polling forever would otherwise add a constant to
 //! every series and a flood of 503s to the error series while a dependency is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,7 +619,16 @@
 //! walked-one-request-at-a-time simulation into something a backtester loads in
 //! one go. With persistence on it reads the steps the warehouse already holds,
 //! in windows, and replays the rest; with it off, or for a simulation nobody
-//! has walked, every step is replayed. Either source renders the same bytes.
+//! has walked, every step is replayed. Either source renders the same VALUES,
+//! row for row and column for column.
+//!
+//! It does not yet render the same BYTES. A value crosses the storage column's
+//! own scale on the way in and back, and the shortest rendering of the float
+//! that comes out can differ in the last digit from the one the replay
+//! produces, so an export taken after a tape's rows were filed can differ from
+//! the same export taken before (issue #152). Byte-identical repeats hold on a
+//! deployment with persistence off, which is the default; where it is on, treat
+//! the values as the contract until that issue lands.
 //!
 //! | Parameter | Values |
 //! |-----------|--------|

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(warehouse) => {
             warehouse.ensure_schema().await?;
             info!("v2 snapshot persistence is enabled");
-            simulation_manager = simulation_manager.with_warehouse(Arc::new(warehouse));
+            // The metrics BEFORE the warehouse: the writer the next call
+            // spawns is what reports the rows it files.
+            simulation_manager = simulation_manager
+                .with_snapshot_metrics(Arc::clone(&metrics_collector))
+                .with_warehouse(Arc::new(warehouse));
         }
         None => {
             info!("v2 snapshot persistence is disabled; snapshots are served from replay only");

--- a/src/session/manager_v2.rs
+++ b/src/session/manager_v2.rs
@@ -24,7 +24,9 @@
 
 use crate::domain::factors::FactorTape;
 use crate::domain::series::{SeriesBuilder, SeriesSnapshot, SnapshotCache};
-use crate::infrastructure::{SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord};
+use crate::infrastructure::{
+    MetricsCollector, SimulationSnapshotRepository, SimulationV2Config, SnapshotRecord,
+};
 use crate::session::model::SessionState;
 use crate::session::snapshot_record::{snapshot_quote_count, snapshot_record};
 use crate::session::store::{BuildClaim, SharedTapeCache, SimulationStore, tape_key};
@@ -255,6 +257,12 @@ pub struct SimulationManager {
     /// without waiting out the production value, which is deliberately as long
     /// as the slowest build.
     shared_build_wait: Duration,
+    /// Where the count of filed rows is reported, when the binary wired it.
+    ///
+    /// Set before [`Self::with_warehouse`], which is what the writer task
+    /// captures. `None` in a test or a library caller that has no collector,
+    /// and the writer then files without counting.
+    snapshot_metrics: Option<Arc<MetricsCollector>>,
     /// Where served snapshots are queued for filing, when the operator turned
     /// persistence on. `None` is the default and the whole feature is then
     /// absent from the serving path — no connection, no latency, no failure
@@ -321,6 +329,7 @@ impl SimulationManager {
             ))),
             shared_tapes: None,
             shared_build_wait: SHARED_BUILD_WAIT,
+            snapshot_metrics: None,
             warehouse: None,
         }
     }
@@ -348,6 +357,23 @@ impl SimulationManager {
         self
     }
 
+    /// Reports filed rows to `metrics`.
+    ///
+    /// Call it BEFORE [`Self::with_warehouse`]: that method spawns the writer,
+    /// and the writer captures whatever this left behind. Separate from it
+    /// rather than a parameter of it, because the warehouse is wired by
+    /// library callers that have no collector and the signature is public.
+    ///
+    /// What it buys is a signal that does not exist otherwise: the write is
+    /// detached from the advance that produced it, so "the step was served"
+    /// says nothing about "the row is stored", and `v2_snapshot_rows_filed_total`
+    /// is how anything outside the process can tell (issue #149).
+    #[must_use]
+    pub fn with_snapshot_metrics(mut self, metrics: Arc<MetricsCollector>) -> Self {
+        self.snapshot_metrics = Some(metrics);
+        self
+    }
+
     /// Files every served snapshot in `warehouse`.
     ///
     /// Opt-in, and deliberately a separate constructor rather than an argument
@@ -360,6 +386,7 @@ impl SimulationManager {
         let queued_contracts = Arc::new(AtomicUsize::new(0));
         let writer_contracts = Arc::clone(&queued_contracts);
         let warehouse = Arc::clone(&repository);
+        let writer_metrics = self.snapshot_metrics.clone();
 
         // One writer, not one task per advance: the queue bounds what a slow
         // warehouse can accumulate, and serialising the writes means two steps
@@ -372,6 +399,14 @@ impl SimulationManager {
 
                 let result = warehouse.persist(record).await;
                 writer_contracts.fetch_sub(contracts, Ordering::SeqCst);
+
+                // Counted on the write that SUCCEEDED: a queue that never
+                // drains must not look like storage that is filling.
+                if result.is_ok()
+                    && let Some(metrics) = writer_metrics.as_ref()
+                {
+                    metrics.record_snapshot_rows_filed(contracts);
+                }
 
                 if let Err(error) = result {
                     warn!(


### PR DESCRIPTION
## Summary

An export is served two ways: with snapshot persistence off the tape is replayed, and with it on the steps a client has already been served are read back from the warehouse instead of being walked again. The suite could not tell them apart, so every comparison it made had replay on both sides and a warehouse returning subtly different rows would have been invisible.

Running the new comparison found exactly that, which is why this PR does **not** turn persistence on by default: see the decision below.

## Changes

- `examples/integration/tests/persistence.rs`, new. `test_the_deployment_says_whether_it_persists_its_snapshots` reads the readiness body — a `clickhouse` dependency is persistence being on, since the warehouse probe exists only when the manager has a warehouse — and says which path the run exercises. `test_a_stored_tape_exports_what_a_replayed_one_does` walks one tape to the end so its steps are filed, leaves a second tape of the same seed unwalked, and requires the two exports to agree cell by cell, retrying while the detached write queue drains.
- The compose file documents `OCS_SNAPSHOT_PERSISTENCE_ENABLED`: what turning it on buys, what it costs today, and the two consequences an operator should know (the schema is created at boot, so an unreachable warehouse fails the boot; `/ready` gains a `clickhouse` dependency, so a replica whose warehouse is down reports itself unready).
- The crate docs say the readiness body is where the export path is visible.

## The decision this PR took, and why

The issue offers "enable the warehouse in the deployed stack". I wrote that change, ran the suite against it, and reverted the default to `false`.

With persistence on, a stored export renders a computed mid price a digit differently from a replayed one:

```
stored:   ...,0.54,0.55,0.5415620196854147,...
replayed: ...,0.54,0.55,0.5415620196854148,...
```

The values agree; the bytes do not. And it is not only across simulations: an export taken before the rows are filed differs from the same export seconds later, so `test_the_same_export_twice_is_byte_identical` and `test_an_export_is_byte_identical_across_instances` both fail against a warehouse-backed deployment. Flipping the default would trade a documented guarantee for the saving, which is an owner's call and not mine to make silently.

Filed as #152 with the reproduction, three options and the acceptance criteria. The default flips when it is fixed, and the comparison here goes back to bytes.

Meanwhile the comparison is value by value, with the byte-level near miss printed and named rather than hidden. A truncated decimal, a timestamp that lost its zone, a reordered column or a missing row is still a failure.

## Testing

- [x] Against a locally run 0.2.27 with `OCS_SNAPSHOT_PERSISTENCE_ENABLED=true` over ClickHouse: both new tests pass and report the near miss as #152
- [x] Against a deployment with persistence off: the comparison skips with its reason and the reporting test says which path is exercised
- [x] `make pre-push` clean, strict clippy clean; the hermetic suite is unaffected

## Stack

- Base branch: `stack/1-148-arrow-in-the-image`
- Stacked on: #151
- Blocks: #154
- Stack: #150 (merged) → #151 → **this** → #154
- The diff is cumulative until #151 merges, so read it against the base branch rather than against `main`.

Closes #149