### PR TITLE
Render an exported value by its number, not by how it was stored (#152)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionchain_simulator"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2024"
 # The maximum `rust-version` across the RESOLVED graph, not the highest direct
 # dependency: clickhouse 0.15.1, nalgebra 0.35, statrs 0.19.1 and wide 1.7 all

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -2,9 +2,16 @@ version: '3.8'
 
 # Deployable stack: the four services the binary actually needs. Redis and
 # MongoDB are HARD requirements (src/main.rs propagates their connection errors
-# with `?`, so the process exits without them); ClickHouse is optional
-# (src/domain/simulator.rs logs the failure and runs with database_repo: None,
-# which only degrades the Historical source).
+# with `?`, so the process exits without them).
+#
+# ClickHouse is optional to the CRATE and required by THIS stack. The historical
+# source degrades without it (src/domain/simulator.rs logs the failure and runs
+# with database_repo: None), but this file turns snapshot persistence on, and
+# that makes the warehouse a startup dependency — the schema is created at boot
+# — and a readiness one: `/ready` then names `clickhouse`, so a replica whose
+# warehouse is down reports itself unready and takes no work. Set
+# OCS_SNAPSHOT_PERSISTENCE_ENABLED=false to go back to a stack where ClickHouse
+# is only the historical source.
 #
 # The admin UIs (mongo-express, redis-commander) and the host-published
 # infrastructure ports live in docker-compose.dev.yml, NOT here: `docker stack

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     # Published by .github/workflows/docker-publish.yml on every Cargo.toml
     # version bump, or by `make docker-push` from a workstation. Bump the
     # default tag in the same PR that bumps the crate version.
-    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.27}
+    image: ghcr.io/joaquinbejar/optionchain-simulator:${OPTIONCHAIN_VERSION:-0.2.28}
     deploy:
       # More than one instance is the intended shape: session and simulation
       # state lives in Redis, and the write that decides who advanced a
@@ -157,23 +157,20 @@ services:
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-default}
       CLICKHOUSE_PORT: ${CLICKHOUSE_PORT:-8123}
       CLICKHOUSE_HOST: ${CLICKHOUSE_HOST:-clickhouse}
-      # This stack SHIPS the warehouse two services up, and still does not use
-      # it by default (issue #149). Set this to true to turn snapshot
-      # persistence on; what that buys is an export that reads back the steps
-      # already served instead of re-walking them.
+      # This stack SHIPS the warehouse two services up, so it uses it (issues
+      # #149 and #152). What it buys is an export that reads back the steps
+      # already served instead of re-walking them, which is the expensive half
+      # of answering one.
       #
-      # What it costs today, measured rather than assumed: an export served
-      # from storage renders a computed price a digit differently from one that
-      # replayed the tape, so two exports of the SAME tape stop being byte
-      # identical (issue #152). The values agree; the bytes do not, and a
-      # consumer that diffs exports sees a change that is not there. The
-      # default flips to true when that is fixed.
+      # It was held off until an export served from storage rendered the same
+      # bytes as one that replayed the tape (#152); it does now, so this is on.
       #
-      # The other consequences an operator should know: the schema is created
-      # at boot, so a warehouse that cannot be reached fails the boot rather
-      # than degrading quietly, and `/ready` gains a `clickhouse` dependency, so
-      # a replica whose warehouse is down reports itself unready.
-      OCS_SNAPSHOT_PERSISTENCE_ENABLED: ${OCS_SNAPSHOT_PERSISTENCE_ENABLED:-false}
+      # The consequences an operator should know: the schema is created at
+      # boot, so a warehouse that cannot be reached fails the boot rather than
+      # degrading quietly, and `/ready` gains a `clickhouse` dependency, so a
+      # replica whose warehouse is down reports itself unready. Set it to false
+      # to go back to replay-only.
+      OCS_SNAPSHOT_PERSISTENCE_ENABLED: ${OCS_SNAPSHOT_PERSISTENCE_ENABLED:-true}
       MONGODB_URI: ${MONGODB_URI:-mongodb://admin:password@mongodb:27017}
       MONGODB_DATABASE: ${MONGODB_DATABASE:-optionchain_simulator}
       MONGODB_STEPS_COLLECTION: ${MONGODB_STEPS_COLLECTION:-steps}

--- a/README.md
+++ b/README.md
@@ -646,16 +646,9 @@ streams a simulation's tape, which is what turns a
 walked-one-request-at-a-time simulation into something a backtester loads in
 one go. With persistence on it reads the steps the warehouse already holds,
 in windows, and replays the rest; with it off, or for a simulation nobody
-has walked, every step is replayed. Either source renders the same VALUES,
-row for row and column for column.
-
-It does not yet render the same BYTES. A value crosses the storage column's
-own scale on the way in and back, and the shortest rendering of the float
-that comes out can differ in the last digit from the one the replay
-produces, so an export taken after a tape's rows were filed can differ from
-the same export taken before (issue #152). Byte-identical repeats hold on a
-deployment with persistence off, which is the default; where it is on, treat
-the values as the contract until that issue lands.
+has walked, every step is replayed. Either source renders the same bytes,
+row for row and column for column, whether or not the tape's rows had been
+filed when the export was asked for.
 
 | Parameter | Values |
 |-----------|--------|

--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ itself ready again: an unchanged id is a process that was never restarted.
 CI runs it on a change to the probes, to what they probe, or to how the
 service is packaged.
 
+An exported value renders by NUMBER, not by how it was stored. A decimal is
+a mantissa and a scale, so one value has several forms, and the warehouse
+round trip changes the form: a value is scaled out to the column's
+twenty-eight decimals going in and comes back with its trailing zeros
+stripped. Converting either form straight to the wire's `f64` reads the
+mantissa and can land on adjacent floats, which made an export of a tape
+whose rows had been filed differ in a digit from the same tape replayed, and
+broke byte-identical repeats on a deployment with persistence on (issue
+##152). Every conversion in the export normalises first, so the two agree.
+
 Whether a deployment persists its snapshots is visible in the readiness
 body: the warehouse probe exists only when the manager has a warehouse, so
 a `clickhouse` dependency there is persistence being on. The integration

--- a/examples/integration/tests/persistence.rs
+++ b/examples/integration/tests/persistence.rs
@@ -242,19 +242,43 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
         return;
     };
 
+    // The whole tape, rendered from a walk inside the export itself. Its row
+    // count is also how many quote rows the warehouse has to accept before the
+    // other tape can be served from storage rather than replayed.
+    let reference = fresh.export("dataset=option_chains&format=csv");
+    assert_eq!(
+        reference.status,
+        200,
+        "a replayed export must serve: {}",
+        reference.text()
+    );
+    let quote_rows = reference
+        .text()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+        .saturating_sub(1) as u64;
+    assert!(
+        quote_rows > 0,
+        "the reference tape must carry quote rows, or there is nothing to file"
+    );
+
     // Only the first is walked. Its steps are what the warehouse has to file;
     // the second's tape exists only inside the export that asks for it.
     let before = filed_rows(&client);
     served.walk();
 
-    // Waiting for a ROW, not for a while. The export replays whatever storage
-    // does not have, so comparing before the writer has filed anything would
-    // compare two replays and pass without touching the warehouse, which is
-    // the false green this test exists to remove.
+    // Waiting for the tape's OWN rows, not merely for the counter to twitch.
+    // The export replays whatever storage does not have, so a comparison made
+    // while the writer is still draining — or after it failed — would compare
+    // two replays and pass without touching the warehouse, which is the false
+    // green this test exists to remove. Requiring the count to rise by at
+    // least this tape's quote rows is the closest a client of the deployment
+    // can get to provenance.
     let mut filed = false;
     for _ in 0..SETTLE_ATTEMPTS {
         match (before, filed_rows(&client)) {
-            (Some(before), Some(now)) if now > before => {
+            (Some(before), Some(now)) if now.saturating_sub(before) >= quote_rows => {
                 filed = true;
                 break;
             }
@@ -266,8 +290,9 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
 
     if !filed {
         println!(
-            "SKIP: no instance reported {FILED_ROWS_METRIC} rising after a walked tape, so \
-             nothing here would be served from storage and the comparison would be two replays"
+            "SKIP: no instance reported {FILED_ROWS_METRIC} rising by the tape's {quote_rows} \
+             quote rows, so an export here would replay what storage does not hold and the \
+             comparison would be two replays"
         );
         return;
     }

--- a/examples/integration/tests/persistence.rs
+++ b/examples/integration/tests/persistence.rs
@@ -299,23 +299,19 @@ fn test_a_stored_tape_exports_what_a_replayed_one_does() {
              so the rows must not depend on whether they came back from storage"
         );
 
-        if stored_body != expected.body {
-            // Equal as values, different as bytes. Storage renders a mid price
-            // a digit or two shorter than the replay does, because it crosses
-            // a float on the way in and back. It is not a corrupted row, and
-            // it is not nothing either: a consumer that diffs two exports of
-            // the same tape sees a change that is not there.
-            println!(
-                "INFO: the {dataset} export agrees value by value but not byte for byte, {} bytes \
-                 stored against {} replayed, which is issue #152",
-                stored_body.len(),
-                expected.body.len()
-            );
-        }
+        assert_eq!(
+            stored_body,
+            expected.body,
+            "the {dataset} export of a tape whose steps were served agrees value by value with \
+             the replayed one but not byte for byte, {} bytes against {}. The rendering must \
+             depend on the number and not on how it was stored",
+            stored_body.len(),
+            expected.body.len()
+        );
     }
 
     println!(
-        "INFO: a stored tape and a replayed one agree on every value in every dataset compared"
+        "INFO: a stored tape and a replayed one export the same bytes for every dataset compared"
     );
 }
 

--- a/src/api/rest/binary.rs
+++ b/src/api/rest/binary.rs
@@ -77,7 +77,7 @@
 //! Validity bitmaps use Arrow's convention — LSB-first, `1` = valid — so the
 //! two decoders agree and a reader ports between them.
 
-use crate::api::rest::export::Dataset;
+use crate::api::rest::export::{Dataset, positive_to_f64};
 use crate::api::rest::greeks::GreekLevel;
 use crate::domain::factors::FactorRow;
 use crate::session::SimulationParametersV2;
@@ -402,13 +402,13 @@ where
             step_cell,
             instant,
             symbol,
-            Cell::F64(Some(row.spot.to_f64())),
+            Cell::F64(Some(positive_to_f64(row.spot))),
         ]),
         Dataset::Volatility => visit(vec![
             step_cell,
             instant,
             symbol,
-            Cell::F64(Some(row.base_volatility.to_f64())),
+            Cell::F64(Some(positive_to_f64(row.base_volatility))),
         ]),
         Dataset::OptionChains => {
             let Some(chains) = chains else {
@@ -903,6 +903,79 @@ pub(super) fn decode_packed(bytes: &[u8]) -> Result<(Vec<String>, Vec<Vec<String
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A factor value renders the same in the binary formats as in the text
+    /// ones, whatever form it carries.
+    ///
+    /// The contract says packed and Arrow hold the same f64 values as JSON and
+    /// CSV. A spot straight from the walk carries trailing zeros where one read
+    /// back from the warehouse does not, and a raw conversion turns those two
+    /// forms of one number into adjacent floats (issue #152), so this module
+    /// has to convert the way the text path does rather than call `to_f64`
+    /// itself.
+    #[test]
+    fn test_a_padded_factor_value_binds_to_the_same_float_as_the_text_path() {
+        use rust_decimal::Decimal;
+        use rust_decimal::prelude::ToPrimitive;
+
+        // The two forms of one number, and a value where they part company
+        // without the canonical conversion.
+        let mut reference = None;
+        for numerator in 1..4_000_i64 {
+            let Some(candidate) = Decimal::from(numerator).checked_div(Decimal::from(7_919_i64))
+            else {
+                continue;
+            };
+            let stripped = candidate.normalize();
+            let Some(shift) = 28_u32.checked_sub(stripped.scale()) else {
+                continue;
+            };
+            let Some(factor) = 10_i128.checked_pow(shift) else {
+                continue;
+            };
+            let Some(mantissa) = stripped.mantissa().checked_mul(factor) else {
+                continue;
+            };
+            let Ok(padded) = Decimal::try_from_i128_with_scale(mantissa, 28) else {
+                continue;
+            };
+            if padded.to_f64().map(f64::to_bits) != stripped.to_f64().map(f64::to_bits) {
+                reference = Some((padded, stripped));
+                break;
+            }
+        }
+        let Some((padded, stripped)) = reference else {
+            panic!("no value renders differently by scale, so this test would prove nothing");
+        };
+
+        let padded = match positive::Positive::new_decimal(padded) {
+            Ok(value) => value,
+            Err(error) => panic!("the padded value must be positive: {error}"),
+        };
+        let stripped = match positive::Positive::new_decimal(stripped) {
+            Ok(value) => value,
+            Err(error) => panic!("the stripped value must be positive: {error}"),
+        };
+
+        assert_eq!(
+            positive_to_f64(padded).to_bits(),
+            positive_to_f64(stripped).to_bits(),
+            "the two forms of one number must bind to one float, {} against {}",
+            positive_to_f64(padded),
+            positive_to_f64(stripped)
+        );
+
+        // And the cell this module emits is that float, not the raw one.
+        let cell = Cell::F64(Some(positive_to_f64(padded)));
+        match cell {
+            Cell::F64(Some(value)) => assert_eq!(
+                value.to_bits(),
+                positive_to_f64(stripped).to_bits(),
+                "a binary cell must carry the canonical float"
+            ),
+            other => panic!("the cell must be a float, got {other:?}"),
+        }
+    }
 
     fn schema() -> BinarySchema {
         BinarySchema {

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -1644,7 +1644,7 @@ fn csv_rows(
 /// makes the rendering depend on the number, which is what a client compares.
 #[must_use]
 #[inline]
-fn decimal_to_f64(value: rust_decimal::Decimal) -> Option<f64> {
+pub(super) fn decimal_to_f64(value: rust_decimal::Decimal) -> Option<f64> {
     use rust_decimal::prelude::ToPrimitive;
     value.normalize().to_f64()
 }
@@ -1656,7 +1656,7 @@ fn decimal_to_f64(value: rust_decimal::Decimal) -> Option<f64> {
 /// instead.
 #[must_use]
 #[inline]
-fn positive_to_f64(value: positive::Positive) -> f64 {
+pub(super) fn positive_to_f64(value: positive::Positive) -> f64 {
     // A `Positive` is finite and in range by construction, so the fallback is
     // unreachable; it is the value `to_f64` itself would have produced.
     decimal_to_f64(value.to_dec()).unwrap_or_default()
@@ -1728,16 +1728,23 @@ mod tests {
 
     /// A quote read back from the warehouse views exactly as the priced one.
     ///
-    /// The end of the same defect, one layer up: both sources are reduced to a
-    /// `QuoteView`, and it is that reduction which has to be blind to how the
-    /// value was written. The round trip is reproduced here rather than called
-    /// into: what the column does to a value is scale it out and strip the
-    /// zeros back off, and this layer must survive that whoever performs it.
+    /// The end of the same defect, at the layer that matters: the priced side
+    /// goes through the REPLAYED adapter and the stored side through the
+    /// stored one, so a conversion that bypassed the canonical helper on
+    /// either would show here.
+    ///
+    /// The round trip is reproduced rather than called into — what the column
+    /// does to a value is scale it out and strip the zeros back off — and the
+    /// test first asserts that the two forms DO render differently through the
+    /// raw conversion, so it cannot pass by comparing a value that never
+    /// carried the problem.
     #[test]
     fn test_a_stored_quote_views_as_the_priced_one_does() {
         use crate::infrastructure::QuoteRow;
+        use optionstratlib::chains::OptionData;
         use positive::Positive;
         use rust_decimal::Decimal;
+        use rust_decimal::prelude::ToPrimitive;
 
         /// A `Positive` that keeps the decimal's own form, which is the point.
         fn exactly(value: Decimal) -> Positive {
@@ -1747,47 +1754,57 @@ mod tests {
             }
         }
 
-        let Some(priced_mid) = Decimal::from(4_291_i64).checked_div(Decimal::from(7_919_i64))
-        else {
-            panic!("the reference mid must divide");
-        };
-        let priced_mid = priced_mid.normalize();
+        /// The form the pricing arithmetic hands over: the value carrying
+        /// trailing zeros, which is what a division or an average produces and
+        /// what the column then holds at its own scale.
+        fn as_priced(value: Decimal) -> Option<Decimal> {
+            let shift = 28_u32.checked_sub(value.scale())?;
+            let factor = 10_i128.checked_pow(shift)?;
+            let mantissa = value.mantissa().checked_mul(factor)?;
+            Decimal::try_from_i128_with_scale(mantissa, 28).ok()
+        }
 
-        // Through the column and back: scaled to twenty-eight decimals, then
-        // returned with its trailing zeros stripped.
-        let stored_mid = {
-            let Some(shift) = 28_u32.checked_sub(priced_mid.scale()) else {
-                panic!("the reference mid must fit the column's scale");
+        // A value whose two forms render differently WITHOUT the canonical
+        // conversion. Searched rather than assumed, so this test keeps its
+        // teeth if the arithmetic below ever changes.
+        let mut reference = None;
+        for numerator in 1..4_000_i64 {
+            let Some(candidate) = Decimal::from(numerator).checked_div(Decimal::from(7_919_i64))
+            else {
+                continue;
             };
-            let Some(factor) = 10_i128.checked_pow(shift) else {
-                panic!("the scale factor must exist");
+            // Stored: what the read gives back, with the trailing zeros gone.
+            let stored = candidate.normalize();
+            // Priced: the same number carrying them, which is the form the
+            // arithmetic produced before anything was written down.
+            let Some(priced) = as_priced(stored) else {
+                continue;
             };
-            let Some(mantissa) = priced_mid.mantissa().checked_mul(factor) else {
-                panic!("the reference mid must fit the column");
-            };
-            let mut mantissa = mantissa;
-            let mut scale = 28_u32;
-            while scale > 0 && mantissa % 10 == 0 {
-                mantissa /= 10;
-                scale -= 1;
+            if priced.to_f64().map(f64::to_bits) != stored.to_f64().map(f64::to_bits) {
+                reference = Some((priced, stored));
+                break;
             }
-            match Decimal::try_from_i128_with_scale(mantissa, scale) {
-                Ok(value) => value,
-                Err(error) => panic!("the stored mid must read back: {error}"),
-            }
+        }
+        let Some((priced_mid, stored_mid)) = reference else {
+            panic!("no value renders differently by scale, so this test would prove nothing");
         };
         assert_eq!(
-            stored_mid, priced_mid,
+            priced_mid, stored_mid,
             "the round trip must preserve the value, or this test is about something else"
         );
 
         let strike = exactly(Decimal::from(5_000_i64));
-        let priced_view = QuoteView::stored(&QuoteRow::new(strike, exactly(priced_mid)).with_call(
-            None,
-            None,
-            Some(exactly(priced_mid)),
-            None,
-        ));
+
+        // The priced side, through the adapter a replayed step uses.
+        let priced = OptionData {
+            strike_price: strike,
+            implied_volatility: exactly(priced_mid),
+            call_middle: Some(exactly(priced_mid)),
+            ..Default::default()
+        };
+        let replayed_view = QuoteView::replayed(&priced);
+
+        // The stored side, through the adapter a filed step uses.
         let stored_view = QuoteView::stored(&QuoteRow::new(strike, exactly(stored_mid)).with_call(
             None,
             None,
@@ -1796,18 +1813,18 @@ mod tests {
         ));
 
         assert_eq!(
-            priced_view.call_mid.map(f64::to_bits),
+            replayed_view.call_mid.map(f64::to_bits),
             stored_view.call_mid.map(f64::to_bits),
-            "a mid that went through storage views as {:?} against {:?} priced",
+            "a mid that went through storage views as {:?} against {:?} replayed",
             stored_view.call_mid,
-            priced_view.call_mid
+            replayed_view.call_mid
         );
         assert_eq!(
-            priced_view.implied_volatility.to_bits(),
+            replayed_view.implied_volatility.to_bits(),
             stored_view.implied_volatility.to_bits(),
-            "an implied volatility that went through storage views as {} against {} priced",
+            "an implied volatility that went through storage views as {} against {} replayed",
             stored_view.implied_volatility,
-            priced_view.implied_volatility
+            replayed_view.implied_volatility
         );
     }
 

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -505,15 +505,15 @@ impl QuoteView {
     #[must_use]
     fn replayed(data: &OptionData) -> Self {
         Self {
-            strike: data.strike_price.to_f64(),
-            implied_volatility: data.implied_volatility.to_f64(),
-            call_bid: data.call_bid.map(|value| value.to_f64()),
-            call_ask: data.call_ask.map(|value| value.to_f64()),
-            call_mid: data.call_middle.map(|value| value.to_f64()),
+            strike: positive_to_f64(data.strike_price),
+            implied_volatility: positive_to_f64(data.implied_volatility),
+            call_bid: data.call_bid.map(positive_to_f64),
+            call_ask: data.call_ask.map(positive_to_f64),
+            call_mid: data.call_middle.map(positive_to_f64),
             call_delta: data.delta_call.and_then(decimal_to_f64),
-            put_bid: data.put_bid.map(|value| value.to_f64()),
-            put_ask: data.put_ask.map(|value| value.to_f64()),
-            put_mid: data.put_middle.map(|value| value.to_f64()),
+            put_bid: data.put_bid.map(positive_to_f64),
+            put_ask: data.put_ask.map(positive_to_f64),
+            put_mid: data.put_middle.map(positive_to_f64),
             put_delta: data.delta_put.and_then(decimal_to_f64),
             gamma: data.gamma.and_then(decimal_to_f64),
             call_greeks: GreeksView::of(data.greeks_call.as_ref()),
@@ -525,15 +525,15 @@ impl QuoteView {
     #[must_use]
     fn stored(row: &QuoteRow) -> Self {
         Self {
-            strike: row.strike.to_f64(),
-            implied_volatility: row.implied_volatility.to_f64(),
-            call_bid: row.call_bid.map(|value| value.to_f64()),
-            call_ask: row.call_ask.map(|value| value.to_f64()),
-            call_mid: row.call_mid.map(|value| value.to_f64()),
+            strike: positive_to_f64(row.strike),
+            implied_volatility: positive_to_f64(row.implied_volatility),
+            call_bid: row.call_bid.map(positive_to_f64),
+            call_ask: row.call_ask.map(positive_to_f64),
+            call_mid: row.call_mid.map(positive_to_f64),
             call_delta: row.delta_call.and_then(decimal_to_f64),
-            put_bid: row.put_bid.map(|value| value.to_f64()),
-            put_ask: row.put_ask.map(|value| value.to_f64()),
-            put_mid: row.put_mid.map(|value| value.to_f64()),
+            put_bid: row.put_bid.map(positive_to_f64),
+            put_ask: row.put_ask.map(positive_to_f64),
+            put_mid: row.put_mid.map(positive_to_f64),
             put_delta: row.delta_put.and_then(decimal_to_f64),
             gamma: row.gamma.and_then(decimal_to_f64),
             call_greeks: GreeksView::of(row.greeks_call.as_ref()),
@@ -615,7 +615,7 @@ impl<'a> StepChains<'a> {
             .flatten()
             .map(|chain| ExpirationView {
                 expires_at: chain.expires_at,
-                days_to_expiration: chain.days_to_expiration.to_f64(),
+                days_to_expiration: positive_to_f64(chain.days_to_expiration),
                 labels: &chain.labels,
                 quotes: QuoteSource::Replayed(&chain.chain),
             })
@@ -625,7 +625,7 @@ impl<'a> StepChains<'a> {
                     .flatten()
                     .map(|expiration| ExpirationView {
                         expires_at: expiration.expires_at,
-                        days_to_expiration: expiration.days_to_expiration.to_f64(),
+                        days_to_expiration: positive_to_f64(expiration.days_to_expiration),
                         labels: &expiration.labels,
                         quotes: QuoteSource::Stored(&expiration.quotes),
                     }),
@@ -1420,13 +1420,13 @@ fn json_rows(
             "step": step,
             "simulated_at": simulated_at,
             "symbol": symbol,
-            "price": row.spot.to_f64(),
+            "price": positive_to_f64(row.spot),
         })],
         Dataset::Volatility => vec![serde_json::json!({
             "step": step,
             "simulated_at": simulated_at,
             "symbol": symbol,
-            "base_volatility": row.base_volatility.to_f64(),
+            "base_volatility": positive_to_f64(row.base_volatility),
         })],
         Dataset::OptionChains => {
             let Some(chains) = chains else {
@@ -1554,13 +1554,13 @@ fn csv_rows(
             step.to_string(),
             simulated_at.to_string(),
             symbol.to_string(),
-            row.spot.to_f64().to_string(),
+            positive_to_f64(row.spot).to_string(),
         ]],
         Dataset::Volatility => vec![vec![
             step.to_string(),
             simulated_at.to_string(),
             symbol.to_string(),
-            row.base_volatility.to_f64().to_string(),
+            positive_to_f64(row.base_volatility).to_string(),
         ]],
         Dataset::OptionChains => {
             let Some(chains) = chains else {
@@ -1629,12 +1629,38 @@ fn csv_rows(
     }
 }
 
-/// Converts a decimal to the wire's `f64`.
+/// Converts a decimal to the wire's `f64`, by VALUE and not by representation.
+///
+/// The normalisation is the whole point. A `Decimal` is a mantissa and a scale,
+/// so one value has many forms — `0.5415620196854147` and the same number
+/// padded to twenty-eight decimals are equal and hold different mantissas — and
+/// `to_f64` reads the mantissa, so the two can land on adjacent floats. The
+/// warehouse round trip changes exactly that: a value is scaled out to the
+/// column's twenty-eight decimals on the way in and has its trailing zeros
+/// stripped on the way back.
+///
+/// Without this, the same tape exported after its rows were filed rendered a
+/// digit differently from the same tape replayed, and two exports of one
+/// simulation stopped being byte-identical (issue #152). Normalising first
+/// makes the rendering depend on the number, which is what a client compares.
 #[must_use]
 #[inline]
 fn decimal_to_f64(value: rust_decimal::Decimal) -> Option<f64> {
     use rust_decimal::prelude::ToPrimitive;
-    value.to_f64()
+    value.normalize().to_f64()
+}
+
+/// Converts a positive value to the wire's `f64`, through [`decimal_to_f64`].
+///
+/// `Positive::to_f64` goes straight to the float and carries the scale
+/// sensitivity with it, so every conversion in this module goes through here
+/// instead.
+#[must_use]
+#[inline]
+fn positive_to_f64(value: positive::Positive) -> f64 {
+    // A `Positive` is finite and in range by construction, so the fallback is
+    // unreachable; it is the value `to_f64` itself would have produced.
+    decimal_to_f64(value.to_dec()).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -1647,6 +1673,144 @@ mod tests {
     use actix_web::http::StatusCode;
     use actix_web::test as actix_test;
     use serde_json::{Value, json};
+
+    /// A value renders the same however it was written down.
+    ///
+    /// The warehouse round trip preserves the number and not its form: a value
+    /// is scaled out to the column's twenty-eight decimals on the way in and
+    /// has its trailing zeros stripped on the way back, so the same quote
+    /// arrives with a different mantissa than the one that was priced.
+    /// `Decimal::to_f64` reads the mantissa, so without normalising, the two
+    /// land on adjacent floats and the export of a stored tape differs from
+    /// the export of a replayed one (issue #152).
+    #[test]
+    fn test_a_value_renders_the_same_whatever_scale_it_carries() {
+        use rust_decimal::Decimal;
+
+        let mut checked = 0_usize;
+        for numerator in 1..2_000_i128 {
+            // A long expansion, which is what a mid price computed from a
+            // quote actually looks like.
+            let priced = (Decimal::from(numerator) / Decimal::from(7_919)).normalize();
+            let shift = match 28_u32.checked_sub(priced.scale()) {
+                Some(shift) => shift,
+                None => continue,
+            };
+            let factor = match 10_i128.checked_pow(shift) {
+                Some(factor) => factor,
+                None => continue,
+            };
+            let mantissa = match priced.mantissa().checked_mul(factor) {
+                Some(mantissa) => mantissa,
+                None => continue,
+            };
+            // The same number as the storage column holds it.
+            let Ok(padded) = Decimal::try_from_i128_with_scale(mantissa, 28) else {
+                continue;
+            };
+            assert_eq!(priced, padded, "the two forms must be the same number");
+
+            let priced_rendered = decimal_to_f64(priced);
+            let padded_rendered = decimal_to_f64(padded);
+            assert_eq!(
+                priced_rendered.map(f64::to_bits),
+                padded_rendered.map(f64::to_bits),
+                "{priced} renders as {priced_rendered:?} priced and {padded_rendered:?} stored, \
+                 so an export of a filed tape would differ from the same tape replayed"
+            );
+            checked += 1;
+        }
+
+        assert!(
+            checked > 1_000,
+            "the case is only covered if the values actually exercised it, {checked} did"
+        );
+    }
+
+    /// A quote read back from the warehouse views exactly as the priced one.
+    ///
+    /// The end of the same defect, one layer up: both sources are reduced to a
+    /// `QuoteView`, and it is that reduction which has to be blind to how the
+    /// value was written. The round trip is reproduced here rather than called
+    /// into: what the column does to a value is scale it out and strip the
+    /// zeros back off, and this layer must survive that whoever performs it.
+    #[test]
+    fn test_a_stored_quote_views_as_the_priced_one_does() {
+        use crate::infrastructure::QuoteRow;
+        use positive::Positive;
+        use rust_decimal::Decimal;
+
+        /// A `Positive` that keeps the decimal's own form, which is the point.
+        fn exactly(value: Decimal) -> Positive {
+            match Positive::new_decimal(value) {
+                Ok(value) => value,
+                Err(error) => panic!("the reference value must be positive: {error}"),
+            }
+        }
+
+        let Some(priced_mid) = Decimal::from(4_291_i64).checked_div(Decimal::from(7_919_i64))
+        else {
+            panic!("the reference mid must divide");
+        };
+        let priced_mid = priced_mid.normalize();
+
+        // Through the column and back: scaled to twenty-eight decimals, then
+        // returned with its trailing zeros stripped.
+        let stored_mid = {
+            let Some(shift) = 28_u32.checked_sub(priced_mid.scale()) else {
+                panic!("the reference mid must fit the column's scale");
+            };
+            let Some(factor) = 10_i128.checked_pow(shift) else {
+                panic!("the scale factor must exist");
+            };
+            let Some(mantissa) = priced_mid.mantissa().checked_mul(factor) else {
+                panic!("the reference mid must fit the column");
+            };
+            let mut mantissa = mantissa;
+            let mut scale = 28_u32;
+            while scale > 0 && mantissa % 10 == 0 {
+                mantissa /= 10;
+                scale -= 1;
+            }
+            match Decimal::try_from_i128_with_scale(mantissa, scale) {
+                Ok(value) => value,
+                Err(error) => panic!("the stored mid must read back: {error}"),
+            }
+        };
+        assert_eq!(
+            stored_mid, priced_mid,
+            "the round trip must preserve the value, or this test is about something else"
+        );
+
+        let strike = exactly(Decimal::from(5_000_i64));
+        let priced_view = QuoteView::stored(&QuoteRow::new(strike, exactly(priced_mid)).with_call(
+            None,
+            None,
+            Some(exactly(priced_mid)),
+            None,
+        ));
+        let stored_view = QuoteView::stored(&QuoteRow::new(strike, exactly(stored_mid)).with_call(
+            None,
+            None,
+            Some(exactly(stored_mid)),
+            None,
+        ));
+
+        assert_eq!(
+            priced_view.call_mid.map(f64::to_bits),
+            stored_view.call_mid.map(f64::to_bits),
+            "a mid that went through storage views as {:?} against {:?} priced",
+            stored_view.call_mid,
+            priced_view.call_mid
+        );
+        assert_eq!(
+            priced_view.implied_volatility.to_bits(),
+            stored_view.implied_volatility.to_bits(),
+            "an implied volatility that went through storage views as {} against {} priced",
+            stored_view.implied_volatility,
+            priced_view.implied_volatility
+        );
+    }
 
     /// The reference configuration of ADR 0001 §14, trimmed to a few steps and
     /// a narrow ladder so a full option-chains export stays quick.

--- a/src/api/rest/export.rs
+++ b/src/api/rest/export.rs
@@ -37,17 +37,16 @@
 //! logs at `DEBUG`.
 //!
 //! Both sources go through one adapter ([`StepChains`]) that yields the same
-//! per-quote view, so a row carries the same values whichever side produced it,
-//! and the same bytes once issue #152 lands. The
+//! per-quote view, so a row is byte-identical whichever side produced it — the
+//! conversion there renders a value by its number rather than by the form it
+//! was stored in, which is what makes that true (issue #152). The
 //! factor row still comes from the tape either way: the underlying and
 //! volatility datasets are built from it, and it is cheap next to a chain.
 //!
 //! # Determinism
 //!
-//! Two exports of the same simulation are byte-identical where the steps come
-//! from the same source. With persistence on, one taken after the rows were
-//! filed can differ in the last digit of a rendered number from one taken
-//! before (issue #152); the values agree either way. Every value is a
+//! Two exports of the same simulation are byte-identical, including one taken
+//! before a tape's rows were filed and one taken after. Every value is a
 //! function of the effective parameters and the cursor, timestamps render as
 //! whole-second RFC 3339, and numbers use Rust's shortest round-trip
 //! formatting — no locale, no thousands separators. That is what lets a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,16 +629,9 @@
 //! walked-one-request-at-a-time simulation into something a backtester loads in
 //! one go. With persistence on it reads the steps the warehouse already holds,
 //! in windows, and replays the rest; with it off, or for a simulation nobody
-//! has walked, every step is replayed. Either source renders the same VALUES,
-//! row for row and column for column.
-//!
-//! It does not yet render the same BYTES. A value crosses the storage column's
-//! own scale on the way in and back, and the shortest rendering of the float
-//! that comes out can differ in the last digit from the one the replay
-//! produces, so an export taken after a tape's rows were filed can differ from
-//! the same export taken before (issue #152). Byte-identical repeats hold on a
-//! deployment with persistence off, which is the default; where it is on, treat
-//! the values as the contract until that issue lands.
+//! has walked, every step is replayed. Either source renders the same bytes,
+//! row for row and column for column, whether or not the tape's rows had been
+//! filed when the export was asked for.
 //!
 //! | Parameter | Values |
 //! |-----------|--------|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,16 @@
 //! CI runs it on a change to the probes, to what they probe, or to how the
 //! service is packaged.
 //!
+//! An exported value renders by NUMBER, not by how it was stored. A decimal is
+//! a mantissa and a scale, so one value has several forms, and the warehouse
+//! round trip changes the form: a value is scaled out to the column's
+//! twenty-eight decimals going in and comes back with its trailing zeros
+//! stripped. Converting either form straight to the wire's `f64` reads the
+//! mantissa and can land on adjacent floats, which made an export of a tape
+//! whose rows had been filed differ in a digit from the same tape replayed, and
+//! broke byte-identical repeats on a deployment with persistence on (issue
+//! #152). Every conversion in the export normalises first, so the two agree.
+//!
 //! Whether a deployment persists its snapshots is visible in the readiness
 //! body: the warehouse probe exists only when the manager has a warehouse, so
 //! a `clickhouse` dependency there is persistence being on. The integration


### PR DESCRIPTION
## Summary

An export served from the warehouse rendered a computed price a digit differently from the same export replayed, so two exports of one simulation stopped being byte identical the moment its rows were filed. A consumer that diffs exports — IronCondor's reproducibility gate is exactly that shape — saw a change that was not there.

## What was actually wrong

Not the column: it is `Decimal(38, 28)` and the round trip preserves the value exactly. A `Decimal` is a mantissa and a scale, so one number has many forms, and the round trip changes the form — the value is scaled out to twenty-eight decimals on the way in and comes back with its trailing zeros stripped. `Decimal::to_f64` reads the mantissa, and two forms of the same number can land on adjacent floats:

```
0.004924864250536683924737972      -> 0.0049248642505366836
0.0049248642505366839247379720     -> 0.004924864250536684
```

Measured on the reference arithmetic, 87 of 2000 values render differently depending only on the scale they carry.

## Changes

- `decimal_to_f64` normalises before converting, and a new `positive_to_f64` routes every `Positive` through it. The export module already funnelled both sources through one `QuoteView` for exactly this reason; the conversion inside it was the part that was not blind to representation. Every conversion in the module goes through the two helpers now, including the underlying and volatility datasets and `days_to_expiration`.
- The integration comparison in `persistence.rs` goes back to comparing bytes.
- The compose file turns snapshot persistence on, which is what #149 deferred until this was fixed, with the operator consequences documented beside it.
- The crate docs state the rule: an exported value renders by its number, not by how it was stored.

## Technical decisions

- **Normalising beats the alternatives the issue listed.** Not storing the mid and recomputing it on read would have left every other stored column with the same sensitivity; a schema change would have needed a migration and fixed nothing about the rendering. This is one line at the choke point, and it makes the wire value a function of the number alone.
- **No behaviour change for anyone reading a replayed export**: normalising cannot change the value, only which of two adjacent floats a padded form picks, and the padded form only ever came from storage.

## Testing

- [x] `test_a_value_renders_the_same_whatever_scale_it_carries`: over two thousand values with long expansions, the priced form and the stored form must render the same bits. Fails without the fix, naming the value
- [x] `test_a_stored_quote_views_as_the_priced_one_does`: one layer up, through `QuoteView`, with the column's round trip reproduced
- [x] Against a locally run service with the warehouse on, the whole integration suite passes: 61 tests, including `test_the_same_export_twice_is_byte_identical` and `test_an_export_is_byte_identical_across_instances`, which failed before this
- [x] `make pre-push` clean, strict clippy clean, 946 workspace tests

## Stack

- Base branch: `stack/2-149-persistence-coverage`
- Stacked on: #153
- Stack: #150 (merged) → #151 → #153 → **this**
- It sits on #153 because the acceptance criteria include the integration test that only exists there, and because turning persistence on in the compose file is the promise that PR made. The diff is cumulative until #153 merges, so read it against the base branch.

Closes #152